### PR TITLE
スマホのマイページの購入履歴詳細画面の「今回加算ポイント」の表示を修正

### DIFF
--- a/data/Smarty/templates/sphone/mypage/history.tpl
+++ b/data/Smarty/templates/sphone/mypage/history.tpl
@@ -146,7 +146,9 @@
                 <div><span class="mini">送料：</span><!--{$tpl_arrOrderData.deliv_fee|n2s}-->円</div>
                 <div><span class="mini">手数料：</span><!--{$tpl_arrOrderData.charge|n2s}-->円</div>
                 <div><span class="mini">合計：</span><span class="price fb"><!--{$tpl_arrOrderData.payment_total|n2s}-->円</span></div>
-                <div><span class="mini">今回加算ポイント：</span><!--{$tpl_arrOrderData.add_point|n2s|default:0}-->Pt</div>
+                <!--{if $smarty.const.USE_POINT !== false}-->
+                    <div><span class="mini">今回加算ポイント：</span><!--{$tpl_arrOrderData.add_point|n2s|default:0}-->Pt</div>
+                <!--{/if}-->
             </div>
         </div><!-- /.formBox -->
 


### PR DESCRIPTION
ポイント機能が無効(USE_POINT:false)の場合でも「今回加算ポイント」の項目が表示されてしまっているのを修正。