### PR TITLE
スマートフォンの商品一覧にて「もっと見る」をクリックした際のソート順が正しくなかったのを修正

### DIFF
--- a/data/Smarty/templates/sphone/products/list.tpl
+++ b/data/Smarty/templates/sphone/products/list.tpl
@@ -153,9 +153,9 @@
             },
             success: function(result){
                 var productStatus = result.productStatus;
-                for (var product_id in result) {
-                    if (isNaN(product_id)) continue;
-                    var product = result[product_id];
+                for (var key in result) {
+                    if (isNaN(key)) continue;
+                    var product = result[key];
                     var productHtml = "";
                     var maxCnt = $(".list_area").length - 1;
                     var productEl = $(".list_area").get(maxCnt);

--- a/data/class/pages/products/LC_Page_Products_List.php
+++ b/data/class/pages/products/LC_Page_Products_List.php
@@ -489,12 +489,20 @@ class LC_Page_Products_List extends LC_Page_Ex
         $this->arrProducts = $this->setStatusDataTo($this->arrProducts, $this->arrSTATUS, $this->arrSTATUS_IMAGE);
         SC_Product_Ex::setPriceTaxTo($this->arrProducts);
 
-        // 一覧メイン画像の指定が無い商品のための処理
-        foreach ($this->arrProducts as $key=>$val) {
-            $this->arrProducts[$key]['main_list_image'] = SC_Utils_Ex::sfNoImageMainList($val['main_list_image']);
+        $arrJson = array();
+        foreach ($this->arrProducts as $key => &$val) {
+            if ($key == "productStatus") {
+                $arrJson[$key] = $val;
+            } else {
+                // 一覧メイン画像の指定が無い商品のための処理
+                $val['main_list_image'] = SC_Utils_Ex::sfNoImageMainList($val['main_list_image']);
+
+                // JSON用に並び順を維持するために配列に入れ直す
+                $arrJson[] = $val;
+            }
         }
 
-        echo SC_Utils_Ex::jsonEncode($this->arrProducts);
+        echo SC_Utils_Ex::jsonEncode($arrJson);
         SC_Response_Ex::actionExit();
     }
 


### PR DESCRIPTION
#106 の修正。
配列キーが商品IDだと、JSONデータをJSが評価した際に商品IDでソートされてしまうようなので、並び順を維持するように配列に入れ直して渡すように修正した。