### PR TITLE
GitHub Actions のイベントを限定

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,17 @@
 name: CI/CD for EC-CUBE
 on:
   push:
+    branches:
+      - master
+    tags:
+      - '*'
+    paths:
+      - '**'
+      - '!*.md'
   pull_request:
+    paths:
+      - '**'
+      - '!*.md'
   release:
     types: [ published ]
 


### PR DESCRIPTION
- Pull Request を master にマージした場合にワークフローが2つ走らないよう修正
- `*.md` ファイルのみの修正はワークフローを実行しないよう修正