### PR TITLE
プラグインを任意のディレクトリに配置できるように修正

### DIFF
--- a/data/app_initial.php
+++ b/data/app_initial.php
@@ -47,11 +47,15 @@ require_once(CLASS_EX_REALDIR . 'helper_extends/SC_Helper_Plugin_Ex.php');
 
 // クラスのオートローディングを定義する
 require_once(CLASS_EX_REALDIR . 'SC_ClassAutoloader_Ex.php');
-spl_autoload_register(array('SC_ClassAutoloader_Ex', 'autoload'), true, true);
+spl_autoload_register(
+    function ($class) {
+        SC_ClassAutoloader_Ex::autoload($class, __DIR__.'/downloads/plugin/');
+    },
+    true, true
+);
 
 SC_Helper_HandleError_Ex::load();
 
 // アプリケーション初期化処理
 $objInit = new SC_Initial_Ex();
 $objInit->init();
-

--- a/data/class/SC_ClassAutoloader.php
+++ b/data/class/SC_ClassAutoloader.php
@@ -36,7 +36,7 @@ class SC_ClassAutoloader
      * LC_* には対応していない。
      * @return void
      */
-    public static function autoload($class)
+    public static function autoload($class, $plugin_upload_realdir = PLUGIN_UPLOAD_REALDIR)
     {
         $arrClassNamePart = explode('_', $class);
         $is_ex = end($arrClassNamePart) === 'Ex';
@@ -66,7 +66,7 @@ class SC_ClassAutoloader
         // プラグイン向けフックポイント
         // MEMO: プラグインのローダーがDB接続を必要とするため、SC_Queryがロードされた後のみ呼び出される。
         //       プラグイン情報のキャッシュ化が行われれば、全部にフックさせることを可能に？
-        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance(true);
+        $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance(true, $plugin_upload_realdir);
         if (is_object($objPlugin)) {
             // 元の設定を一時保存
             $plugin_class = $class;

--- a/data/class/helper/SC_Helper_Plugin.php
+++ b/data/class/helper/SC_Helper_Plugin.php
@@ -45,7 +45,7 @@ class SC_Helper_Plugin
      * @param bool $plugin_activate_flg プラグインを有効化する場合 true
      * @return void
      */
-    public function load($plugin_activate_flg = true)
+    public function load($plugin_activate_flg = true, $plugin_upload_realdir = PLUGIN_UPLOAD_REALDIR)
     {
         if (!defined('CONFIG_REALFILE') || !file_exists(CONFIG_REALFILE)) return; // インストール前
         if (GC_Utils_Ex::isInstallFunction()) return; // インストール中
@@ -53,11 +53,11 @@ class SC_Helper_Plugin
         // 有効なプラグインを取得
         $arrPluginDataList = SC_Plugin_Util_Ex::getEnablePlugin();
         // pluginディレクトリを取得
-        $arrPluginDirectory = SC_Plugin_Util_Ex::getPluginDirectory();
+        $arrPluginDirectory = SC_Plugin_Util_Ex::getPluginDirectory($plugin_upload_realdir);
         foreach ($arrPluginDataList as $arrPluginData) {
             // プラグイン本体ファイル名が取得したプラグインディレクトリ一覧にある事を確認
             if (array_search($arrPluginData['plugin_code'], $arrPluginDirectory) !== false) {
-                $plugin_file_path = PLUGIN_UPLOAD_REALDIR . $arrPluginData['plugin_code'] . '/' . $arrPluginData['class_name'] . '.php';
+                $plugin_file_path = $plugin_upload_realdir . $arrPluginData['plugin_code'] . '/' . $arrPluginData['class_name'] . '.php';
                 // プラグイン本体ファイルが存在しない場合
                 if (!file_exists($plugin_file_path)) {
                     // エラー出力
@@ -90,7 +90,7 @@ class SC_Helper_Plugin
      * @param bool $plugin_activate_flg プラグインを有効化する場合 true
      * @return SC_Helper_Plugin SC_Helper_Pluginオブジェクト
      */
-    public static function getSingletonInstance($plugin_activate_flg = PLUGIN_ACTIVATE_FLAG)
+    public static function getSingletonInstance($plugin_activate_flg = PLUGIN_ACTIVATE_FLAG, $plugin_upload_realdir = PLUGIN_UPLOAD_REALDIR)
     {
         if (!isset($GLOBALS['_SC_Helper_Plugin_instance'])) {
             // プラグインのローダーがDB接続を必要とするため、
@@ -101,7 +101,7 @@ class SC_Helper_Plugin
             }
 
             $GLOBALS['_SC_Helper_Plugin_instance'] = new SC_Helper_Plugin_Ex();
-            $GLOBALS['_SC_Helper_Plugin_instance']->load($plugin_activate_flg);
+            $GLOBALS['_SC_Helper_Plugin_instance']->load($plugin_activate_flg, $plugin_upload_realdir);
         }
 
         return $GLOBALS['_SC_Helper_Plugin_instance'];

--- a/data/class/plugin/SC_Plugin_Util.php
+++ b/data/class/plugin/SC_Plugin_Util.php
@@ -124,11 +124,11 @@ class SC_Plugin_Util
      *
      * @return array $arrPluginDirectory
      */
-    public function getPluginDirectory()
+    public function getPluginDirectory($plugin_upload_realdir = PLUGIN_UPLOAD_REALDIR)
     {
         $arrPluginDirectory = array();
-        if (is_dir(PLUGIN_UPLOAD_REALDIR)) {
-            if ($dh = opendir(PLUGIN_UPLOAD_REALDIR)) {
+        if (is_dir($plugin_upload_realdir)) {
+            if ($dh = opendir($plugin_upload_realdir)) {
                 while (($pluginDirectory = readdir($dh)) !== false) {
                     $arrPluginDirectory[] = $pluginDirectory;
                 }

--- a/tests/class/fixtures/plugin/FixturePlugin/FixturePlugin.php
+++ b/tests/class/fixtures/plugin/FixturePlugin/FixturePlugin.php
@@ -3,8 +3,6 @@
 class FixturePlugin extends SC_Plugin_Base
 {
     public function loadClassFileChange(&$classname, &$classpath) {
-        var_dump($classpath);
-
         if ($classname === "SC_Customer_Ex") {
             $classpath = "FixturePlugin/Fixture_SC_Customer.php";
             $classname = "Fixture_SC_Customer";

--- a/tests/class/fixtures/plugin/FixturePlugin/FixturePlugin.php
+++ b/tests/class/fixtures/plugin/FixturePlugin/FixturePlugin.php
@@ -1,0 +1,13 @@
+<?php
+
+class FixturePlugin extends SC_Plugin_Base
+{
+    public function loadClassFileChange(&$classname, &$classpath) {
+        var_dump($classpath);
+
+        if ($classname === "SC_Customer_Ex") {
+            $classpath = "FixturePlugin/Fixture_SC_Customer.php";
+            $classname = "Fixture_SC_Customer";
+        }
+    }
+}

--- a/tests/class/fixtures/plugin/FixturePlugin/Fixture_SC_Customer.php
+++ b/tests/class/fixtures/plugin/FixturePlugin/Fixture_SC_Customer.php
@@ -1,0 +1,9 @@
+<?php
+
+class Fixture_SC_Customer extends SC_Customer
+{
+    public function getValue($key)
+    {
+        return $key;
+    }
+}

--- a/tests/class/plugin/LoadClassFileChangeCustomDirTest.php
+++ b/tests/class/plugin/LoadClassFileChangeCustomDirTest.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group classloader
+ */
 class LoadClassFileChangeCustomDirTest extends Common_TestCase
 {
     protected function setUp()
@@ -30,6 +33,10 @@ class LoadClassFileChangeCustomDirTest extends Common_TestCase
         $this->objQuery->insert('dtb_plugin_hookpoint', $hookpointValues);
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testLOading()
     {
         //  __DIR__.'/../fixtures/plugin/ に配置したプラグインをオートロード対象にする

--- a/tests/class/plugin/LoadClassFileChangeCustomDirTest.php
+++ b/tests/class/plugin/LoadClassFileChangeCustomDirTest.php
@@ -1,0 +1,44 @@
+<?php
+
+class LoadClassFileChangeCustomDirTest extends Common_TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $plugin_id = $this->objQuery->nextVal('dtb_plugin_plugin_id');
+        $pluginValues = [
+            'plugin_id' => $plugin_id,
+            'plugin_name' => 'FixturePlugin',
+            'plugin_code' => 'FixturePlugin',
+            'class_name' => 'FixturePlugin',
+            'plugin_version' => '0.0.0',
+            'compliant_version' => '2.17',
+            'enable' => 1,
+            'create_date' => 'CURRENT_TIMESTAMP',
+            'update_date' => 'CURRENT_TIMESTAMP'
+        ];
+        $this->objQuery->insert('dtb_plugin', $pluginValues);
+
+        $plugin_hookpoint_id = $this->objQuery->nextVal('dtb_plugin_hookpoint_plugin_hookpoint_id');
+        $hookpointValues = [
+            'plugin_hookpoint_id' => $plugin_hookpoint_id,
+            'plugin_id' => $plugin_id,
+            'hook_point' => 'loadClassFileChange',
+            'callback' => 'loadClassFileChange',
+            'update_date' => 'CURRENT_TIMESTAMP'
+        ];
+        $this->objQuery->insert('dtb_plugin_hookpoint', $hookpointValues);
+    }
+
+    public function testLOading()
+    {
+        //  __DIR__.'/../fixtures/plugin/ に配置したプラグインをオートロード対象にする
+        spl_autoload_register(function ($class){
+            SC_ClassAutoloader_Ex::autoload($class, __DIR__.'/../fixtures/plugin/');
+        }, true, true);
+
+        $objCustomer = new SC_Customer_Ex();
+        $this->assertInstanceOf('Fixture_SC_Customer', $objCustomer);
+        $this->assertEquals('loading', $objCustomer->getValue('loading'), __DIR__.'/../fixtures/plugin/Fixture_SC_Customer がロードされる');
+    }
+}

--- a/tests/class/plugin/LoadClassFileChangeTest.php
+++ b/tests/class/plugin/LoadClassFileChangeTest.php
@@ -32,6 +32,8 @@ class LoadClassFileChangeTest extends Common_TestCase
 
     /**
      * loadClassFileChange で拡張したクラスのテストケース.
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testLoadExtendedClass()
     {


### PR DESCRIPTION
従来、プラグインは  `data/downloads/plugin` 以下に配置する必要があったが、この修正で任意のディレクトリに配置可能となる。

以下のようなケースで有用
- テストケースの中で loadClassFileChange を利用したい場合
- プラグインを Composer で管理したい場合

`data/app_initial.php` では、`PLUGIN_UPLOAD_REALDIR` がまだ定義されていないため、定数を使用せずにデフォルトのプラグインディレクトリを設定している