### PR TITLE
常時 https の場合は Cookie の secure オプションを true に設定

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,8 @@ jobs:
       run: |
         data/vendor/bin/phpunit --exclude-group classloader
         data/vendor/bin/phpunit --group classloader
+        sed 's|http://|https://|g' -i.bak data/config/config.php
+        data/vendor/bin/phpunit tests/class/SC_SessionFactoryTest.php
 
     - name: Run chromedriver
       run: |
@@ -183,6 +185,8 @@ jobs:
       run: |
         data/vendor/bin/phpunit --exclude-group classloader
         data/vendor/bin/phpunit --group classloader
+        sed 's|http://|https://|g' -i.bak data/config/config.php
+        data/vendor/bin/phpunit tests/class/SC_SessionFactoryTest.php
 
   install-to-linux:
     name: Install to Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,8 @@ script:
   - if [ ! $COVERAGE ] ; then php data/vendor/bin/phpunit -c phpunit.xml.dist --group classloader ; fi
   - if [ $COVERAGE ] ; then phpdbg -qrr data/vendor/bin/phpunit -c phpunit.xml.dist --exclude-group classloader ; fi
   - if [ ! $COVERAGE ] ; then php data/vendor/bin/codecept run --env chrome --skip-group installer --steps ; fi
+  - sed -e 's|http://|https://|g' -i.bak data/config/config.php
+  - if [ ! $COVERAGE ] ; then php data/vendor/bin/phpunit -c phpunit.xml.dist tests/class/SC_SessionFactoryTest.php ; fi
 
 after_script:
   - if [ $COVERAGE ] ; then php data/vendor/bin/coveralls -v ; fi

--- a/data/class/sessionfactory/SC_SessionFactory_UseCookie.php
+++ b/data/class/sessionfactory/SC_SessionFactory_UseCookie.php
@@ -46,7 +46,7 @@ class SC_SessionFactory_UseCookie extends SC_SessionFactory_Ex
         ini_set('session.cache_limiter', 'none');
         // (session.auto_start などで)セッションが開始されていた場合に備えて閉じる。(FIXME: 保存する必要はない。破棄で良い。)
         session_write_close();
-        session_set_cookie_params(0, ROOT_URLPATH, DOMAIN_NAME, false, true);
+        session_set_cookie_params(0, ROOT_URLPATH, DOMAIN_NAME, $this->getSecureOption(), true);
         // セッション開始
         // FIXME EC-CUBE をネストしてインストールした場合を考慮して、一意とすべき
         session_name('ECSESSID');
@@ -61,6 +61,17 @@ class SC_SessionFactory_UseCookie extends SC_SessionFactory_Ex
     public function useCookie()
     {
         return true;
+    }
+
+    /**
+     * secure オプションの値を返す.
+     *
+     * この値をもとに secure オプションを設定する.
+     * @return bool HTTP_URL 及び HTTPS_URL が https の場合は true
+     */
+    protected function getSecureOption()
+    {
+        return (strpos(HTTP_URL, 'https') !== false && strpos(HTTPS_URL, 'https') !== false);
     }
 }
 /*

--- a/data/class/sessionfactory/SC_SessionFactory_UseRequest.php
+++ b/data/class/sessionfactory/SC_SessionFactory_UseRequest.php
@@ -238,7 +238,7 @@ class SC_SessionFactory_UseRequest extends SC_SessionFactory_Ex
 }
 /**
  * セッションデータ管理クラスの基底クラス
- *
+ * @deprecated
  */
 class LC_UseRequest_State
 {
@@ -429,7 +429,7 @@ class LC_UseRequest_State
 
 /**
  * PCサイト用のセッションデータ管理クラス
- *
+ * @deprecated
  */
 class LC_UseRequest_State_PC extends LC_UseRequest_State
 {
@@ -493,7 +493,7 @@ class LC_UseRequest_State_PC extends LC_UseRequest_State
 
 /**
  * モバイルサイト用のセッションデータ管理クラス
- *
+ * @deprecated
  */
 class LC_UseRequest_State_Mobile extends LC_UseRequest_State
 {

--- a/tests/class/SC_SessionFactoryTest.php
+++ b/tests/class/SC_SessionFactoryTest.php
@@ -1,0 +1,22 @@
+<?php
+
+class SC_SessionFactoryTest extends Common_TestCase
+{
+    public function testGetInstance()
+    {
+        $sessionFactory = SC_SessionFactory_Ex::getInstance();
+        $sessionFactory->initSession();
+
+        $this->assertInstanceOf('SC_SessionFactory_UseCookie', $sessionFactory);
+        $this->assertTrue($sessionFactory->useCookie());
+
+        $refClass = new ReflectionClass($sessionFactory);
+        $refMethod = $refClass->getMethod('getSecureOption');
+        $refMethod->setAccessible(true);
+        if (strpos(HTTP_URL, 'https') !== false) {
+            $this->assertTrue($refMethod->invoke($sessionFactory));
+        } else {
+            $this->markTestIncomplete();
+        }
+    }
+}


### PR DESCRIPTION
`HTTP_URL` 及び `HTTPS_URL` が https の場合は、 Cookie の secure オプションを true に設定するよう修正

SC_SessionFactory_UseRequest のサブクラスに `@deprecated` を追加