### PR TITLE
google-chrome-stable の GPG エラーを改善

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,6 @@ php:
   - 7.3
   - 7.4
 
-addons:
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - dpkg  # see https://github.com/travis-ci/travis-ci/issues/9361
-      - google-chrome-stable
-
 env:
     global:
         - DBNAME=myapp_test DBSERVER=127.0.0.1 HTTP_URL=http://localhost:8085/ HTTPS_URL=http://localhost:8085/
@@ -65,6 +57,9 @@ matrix:
     # Use for coverage report
     - php: 7.3
       env: DB=pgsql USER=postgres DBPASS=password DBUSER=postgres COVERAGE=true
+
+before_install:
+  - if [[ $DIST = 'trusty' ]]; then sudo apt-get -y install google-chrome-stable --allow-unauthenticated ; fi
 
 before_script:
   - if [[ $DB = 'mysql' ]]; then mysql -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION';" ; fi


### PR DESCRIPTION
Travis CI で以下のようなエラーになってしまう

```
WARNING: The following packages cannot be authenticated!
 google-chrome-stable
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
apt-get.diagnostics
apt-get install failed
The command "sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install dpkg debian-archive-keyring google-chrome-stable" failed and exited with 100 during
```

- xenial ではデフォルトの google-chrome-stable を使用する
- trusty では --allow-unauthenticated を付与してインストールする