### PR TITLE
SameSite cookie support

### DIFF
--- a/data/class/helper/SC_Helper_Session.php
+++ b/data/class/helper/SC_Helper_Session.php
@@ -68,6 +68,11 @@ class SC_Helper_Session
      */
     public function sfSessRead($id)
     {
+        if ($id !== $_COOKIE['legacy-ECSESSID']) {
+            // session_id と $_COOKIE['legacy-ECSESSID'] が異なる場合は ECSESSID の cookie が拒否されたと見なす
+            GC_Utils_Ex::gfPrintLog('replace session id: '.$id.'=>'.$_COOKIE['legacy-ECSESSID']);
+            $id = $_COOKIE['legacy-ECSESSID']; // $_COOKIE['legacy-ECSESSID'] からセッションデータを読み込む
+        }
         $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRet = $objQuery->select('sess_data', 'dtb_session', 'sess_id = ?', array($id));
         if (empty($arrRet)) {

--- a/data/class/helper/SC_Helper_Session.php
+++ b/data/class/helper/SC_Helper_Session.php
@@ -68,9 +68,10 @@ class SC_Helper_Session
      */
     public function sfSessRead($id)
     {
-        if (empty($_COOKIE['ECSESSID']) && $id !== $_COOKIE['legacy-ECSESSID']) {
+        // SameSite=None を未サポート UA 向け対応
+        if (empty($_COOKIE['ECSESSID']) && isset($_COOKIE['legacy-ECSESSID']) && $id !== $_COOKIE['legacy-ECSESSID']) {
             // session_id と $_COOKIE['legacy-ECSESSID'] が異なる場合は ECSESSID の cookie が拒否されたと見なす
-            GC_Utils_Ex::gfPrintLog('replace session id');
+            GC_Utils_Ex::gfPrintLog('replace session id: ECSESSID=>legacy-ECSESSID');
             $id = $_COOKIE['legacy-ECSESSID']; // $_COOKIE['legacy-ECSESSID'] からセッションデータを読み込む
         }
         $objQuery = SC_Query_Ex::getSingletonInstance();

--- a/data/class/helper/SC_Helper_Session.php
+++ b/data/class/helper/SC_Helper_Session.php
@@ -68,7 +68,7 @@ class SC_Helper_Session
      */
     public function sfSessRead($id)
     {
-        if ($id !== $_COOKIE['legacy-ECSESSID']) {
+        if (empty($_COOKIE['ECSESSID']) && $id !== $_COOKIE['legacy-ECSESSID']) {
             // session_id と $_COOKIE['legacy-ECSESSID'] が異なる場合は ECSESSID の cookie が拒否されたと見なす
             GC_Utils_Ex::gfPrintLog('replace session id: '.$id.'=>'.$_COOKIE['legacy-ECSESSID']);
             $id = $_COOKIE['legacy-ECSESSID']; // $_COOKIE['legacy-ECSESSID'] からセッションデータを読み込む

--- a/data/class/helper/SC_Helper_Session.php
+++ b/data/class/helper/SC_Helper_Session.php
@@ -73,6 +73,7 @@ class SC_Helper_Session
             // session_id と $_COOKIE['legacy-ECSESSID'] が異なる場合は ECSESSID の cookie が拒否されたと見なす
             GC_Utils_Ex::gfPrintLog('replace session id: ECSESSID=>legacy-ECSESSID');
             $id = $_COOKIE['legacy-ECSESSID']; // $_COOKIE['legacy-ECSESSID'] からセッションデータを読み込む
+            unset($_COOKIE['legacy-ECSESSID']);
         }
         $objQuery = SC_Query_Ex::getSingletonInstance();
         $arrRet = $objQuery->select('sess_data', 'dtb_session', 'sess_id = ?', array($id));

--- a/data/class/helper/SC_Helper_Session.php
+++ b/data/class/helper/SC_Helper_Session.php
@@ -72,7 +72,7 @@ class SC_Helper_Session
         if (empty($_COOKIE['ECSESSID']) && isset($_COOKIE['legacy-ECSESSID']) && $id !== $_COOKIE['legacy-ECSESSID']) {
             // session_id と $_COOKIE['legacy-ECSESSID'] が異なる場合は ECSESSID の cookie が拒否されたと見なす
             GC_Utils_Ex::gfPrintLog('replace session id: ECSESSID=>legacy-ECSESSID');
-            $id = $_COOKIE['legacy-ECSESSID']; // $_COOKIE['legacy-ECSESSID'] からセッションデータを読み込む
+            $id = $_COOKIE['legacy-ECSESSID']; // 互換用 cookie からセッションデータを読み込む
             unset($_COOKIE['legacy-ECSESSID']);
         }
         $objQuery = SC_Query_Ex::getSingletonInstance();

--- a/data/class/helper/SC_Helper_Session.php
+++ b/data/class/helper/SC_Helper_Session.php
@@ -70,7 +70,7 @@ class SC_Helper_Session
     {
         if (empty($_COOKIE['ECSESSID']) && $id !== $_COOKIE['legacy-ECSESSID']) {
             // session_id と $_COOKIE['legacy-ECSESSID'] が異なる場合は ECSESSID の cookie が拒否されたと見なす
-            GC_Utils_Ex::gfPrintLog('replace session id: '.$id.'=>'.$_COOKIE['legacy-ECSESSID']);
+            GC_Utils_Ex::gfPrintLog('replace session id');
             $id = $_COOKIE['legacy-ECSESSID']; // $_COOKIE['legacy-ECSESSID'] からセッションデータを読み込む
         }
         $objQuery = SC_Query_Ex::getSingletonInstance();

--- a/data/class/sessionfactory/SC_SessionFactory_UseCookie.php
+++ b/data/class/sessionfactory/SC_SessionFactory_UseCookie.php
@@ -71,7 +71,7 @@ class SC_SessionFactory_UseCookie extends SC_SessionFactory_Ex
         session_name('ECSESSID');
         session_start();
         if (session_id() !== '') {
-            // SameSite=None を未サポートの UA 向けに cookie を発行する. secure option 必須
+            // SameSite=None を未サポートの UA 向けに 互換用 cookie を発行する. secure option 必須
             setcookie('legacy-'.session_name(), session_id(), $params['lifetime'], $params['path'], $params['domain'], true, true);
         }
     }

--- a/data/class/sessionfactory/SC_SessionFactory_UseCookie.php
+++ b/data/class/sessionfactory/SC_SessionFactory_UseCookie.php
@@ -46,11 +46,17 @@ class SC_SessionFactory_UseCookie extends SC_SessionFactory_Ex
         ini_set('session.cache_limiter', 'none');
         // (session.auto_start などで)セッションが開始されていた場合に備えて閉じる。(FIXME: 保存する必要はない。破棄で良い。)
         session_write_close();
-        session_set_cookie_params(0, ROOT_URLPATH, DOMAIN_NAME, $this->getSecureOption(), true);
+        // FIXME PHP7.3 or higher
+        session_set_cookie_params(0, ROOT_URLPATH, DOMAIN_NAME.'; SameSite=None', $this->getSecureOption(), true);
+        $params = session_get_cookie_params();
         // セッション開始
         // FIXME EC-CUBE をネストしてインストールした場合を考慮して、一意とすべき
         session_name('ECSESSID');
         session_start();
+        if (session_id() !== '') {
+            // SameSite=None を未サポートの UA 向けに cookie を発行する
+            setcookie('legacy-'.session_name(), session_id(), $params['lifetime'], ROOT_URLPATH, $params['domain'], $params['secure'], true);
+        }
     }
 
     /**

--- a/data/class/sessionfactory/SC_SessionFactory_UseCookie.php
+++ b/data/class/sessionfactory/SC_SessionFactory_UseCookie.php
@@ -47,7 +47,7 @@ class SC_SessionFactory_UseCookie extends SC_SessionFactory_Ex
         // (session.auto_start などで)セッションが開始されていた場合に備えて閉じる。(FIXME: 保存する必要はない。破棄で良い。)
         session_write_close();
         // FIXME PHP7.3 or higher
-        session_set_cookie_params(0, ROOT_URLPATH, DOMAIN_NAME.'; SameSite=None', $this->getSecureOption(), true);
+        session_set_cookie_params(0, ROOT_URLPATH.'; SameSite=None', DOMAIN_NAME, $this->getSecureOption(), true);
         $params = session_get_cookie_params();
         // セッション開始
         // FIXME EC-CUBE をネストしてインストールした場合を考慮して、一意とすべき

--- a/data/class/sessionfactory/SC_SessionFactory_UseCookie.php
+++ b/data/class/sessionfactory/SC_SessionFactory_UseCookie.php
@@ -46,16 +46,33 @@ class SC_SessionFactory_UseCookie extends SC_SessionFactory_Ex
         ini_set('session.cache_limiter', 'none');
         // (session.auto_start などで)セッションが開始されていた場合に備えて閉じる。(FIXME: 保存する必要はない。破棄で良い。)
         session_write_close();
-        // FIXME PHP7.3 or higher
-        session_set_cookie_params(0, ROOT_URLPATH.'; SameSite=None', DOMAIN_NAME, $this->getSecureOption(), true);
-        $params = session_get_cookie_params();
+        $params = array(
+            'lifetime' => 0,
+            'path' => ROOT_URLPATH,
+            'domain' => DOMAIN_NAME,
+            'secure' => $this->getSecureOption(),
+            'httponly' => true,
+            'samesite' => ''
+        );
+        if ($this->getSecureOption()) {
+            $params['samesite'] = 'None'; // require secure option
+        }
+        if (PHP_VERSION_ID >= 70300) {
+            session_set_cookie_params($params);
+        } else {
+            $samesite = '';
+            if (!empty($params['samesite'])) {
+                $samesite = '; SameSite='.$params['samesite'];
+            }
+            session_set_cookie_params($params['lifetime'], $params['path'].$samesite, $params['domain'], $params['secure'], $params['httponly']);
+        }
         // セッション開始
         // FIXME EC-CUBE をネストしてインストールした場合を考慮して、一意とすべき
         session_name('ECSESSID');
         session_start();
         if (session_id() !== '') {
-            // SameSite=None を未サポートの UA 向けに cookie を発行する
-            setcookie('legacy-'.session_name(), session_id(), $params['lifetime'], ROOT_URLPATH, $params['domain'], $params['secure'], true);
+            // SameSite=None を未サポートの UA 向けに cookie を発行する. secure option 必須
+            setcookie('legacy-'.session_name(), session_id(), $params['lifetime'], $params['path'], $params['domain'], true, true);
         }
     }
 


### PR DESCRIPTION
- SameSite=None を未サポートの UA 向けに, SameSite 属性を削除した互換用 cookie を発行する
- UA の仕様により SameSite=None が SameSite=Strict と見なされて cookie が拒否された場合は, 互換用の cookie を読み込む
- ローカル環境等、非SSL環境では SameSite 属性を空にし、 secure 属性を付与しない

refs https://github.com/EC-CUBE/ec-cube/issues/4457

## 旧バージョンのサポート

### 2.4

[こちらのパッチを適用する](https://github.com/EC-CUBE/ec-cube2/commit/da66f5c701720a4256a2e59c5598fccbb09ae188)

### 2.11.x

- `data/class/helper/SC_Helper_Session.php` に [`sfSessRead()`](https://github.com/EC-CUBE/ec-cube2/blob/bf2bac19ed1d232e437043d0a2b0e3482ec306bd/data/class/helper/SC_Helper_Session.php#L71-L77) の修正を追加する
- [`data/class/sessionfactory/SC_SessionFactory_UseCookie.php`](https://raw.githubusercontent.com/EC-CUBE/ec-cube2/bf2bac19ed1d232e437043d0a2b0e3482ec306bd/data/class/sessionfactory/SC_SessionFactory_UseCookie.php) を `data/class/session/sessionfactory/SC_SessionFactory_UseCookie.php` に上書きする

### 2.12.x, 2.13.x

- [`data/class/helper/SC_Helper_Session.php`](https://raw.githubusercontent.com/EC-CUBE/ec-cube2/bf2bac19ed1d232e437043d0a2b0e3482ec306bd/data/class/helper/SC_Helper_Session.php) を上書きする
- [`data/class/sessionfactory/SC_SessionFactory_UseCookie.php`](https://raw.githubusercontent.com/EC-CUBE/ec-cube2/bf2bac19ed1d232e437043d0a2b0e3482ec306bd/data/class/sessionfactory/SC_SessionFactory_UseCookie.php) を上書きする

## テスト

- iOS12.0, iOS12.4, macOS 10.14 Safari 12.1.2, 過去バージョンのChromium(Chrome51 〜 66相当) で検証したが、 [SameSite=None が Strict と扱われる](https://docs.microsoft.com/ja-jp/aspnet/samesite/owin-samesite#sob) ような挙動は再現しなかった
- SameSite=None が Strict と扱われた際の動作をシミュレートするため、 [SameSite=Strict](https://github.com/EC-CUBE/ec-cube2/pull/374/files#diff-46e6989909c76a6d96cf6765dc418265R58) に修正し、外部サイトからの POST で互換用 Cookie を読み込み、正常にセッションが継続することを確認

## TODO

- [x] PHP7.3 or higher の対応
- [x] 互換用 cookie を読み込む際に secure 属性をチェックした方がいいかも
- [x] 互換用 cookie を読み込んだ後に削除した方がいいかも
- [x] ログ出力は削除予定