### PR TITLE
refs #111 SC_FormParam::setHtmlDispNameArray() の判定が不適切

### DIFF
--- a/data/class/SC_FormParam.php
+++ b/data/class/SC_FormParam.php
@@ -138,7 +138,7 @@ class SC_FormParam
             } else {
                 $this->html_disp_name[$index] = $this->disp_name[$index];
             }
-            if ($this->arrDefault[$key] != '') {
+            if (strlen($this->arrDefault[$key]) >= 1) {
                 $this->html_disp_name[$index] .= ' [省略時初期値: ' . $this->arrDefault[$key] . ']';
             }
             if ($this->input_db[$index] == false) {


### PR DESCRIPTION
値のセット側 (例: `$arrCSVFrame[$key]['default'] = '0';`) は、必ずしも誤りでないので変更を見送った。