### PR TITLE
E_WARNING 回避

### DIFF
--- a/data/class/helper/SC_Helper_HandleError.php
+++ b/data/class/helper/SC_Helper_HandleError.php
@@ -180,7 +180,7 @@ class SC_Helper_HandleError
         }
 
         $error_type_name = GC_Utils_Ex::getErrorTypeName($arrError['type']);
-        $errstr = "Fatal error($error_type_name): {$arrError[message]} on [{$arrError[file]}({$arrError[line]})]";
+        $errstr = "Fatal error($error_type_name): {$arrError['message']} on [{$arrError['file']}({$arrError['line']})]";
 
         GC_Utils_Ex::gfPrintLog($errstr, ERROR_LOG_REALFILE, true);
 


### PR DESCRIPTION
以下を回避した
Warning(E_WARNING): Use of undefined constant message - assumed '*' (this will throw an Error in a future version of PHP)