### PR TITLE
fix #387 本質的には受注編集画面を直すべきだが、影響範囲が読めないので表示側で制御する

### DIFF
--- a/data/Smarty/templates/default/mypage/history.tpl
+++ b/data/Smarty/templates/default/mypage/history.tpl
@@ -82,6 +82,7 @@
                     <td class="alignC">
                     <!--{if $orderDetail.product_type_id == $smarty.const.PRODUCT_TYPE_DOWNLOAD}-->
                         <!--{if $orderDetail.is_downloadable}-->
+                            <!--{assign var="downloadable" value="1"}-->
                             <a target="_self" href="<!--{$smarty.const.ROOT_URLPATH}-->mypage/download.php?order_id=<!--{$tpl_arrOrderData.order_id}-->&product_class_id=<!--{$orderDetail.product_class_id}-->">ダウンロード</a>
                         <!--{else}-->
                             <!--{if $orderDetail.payment_date == "" && $orderDetail.effective == "0"}-->
@@ -153,6 +154,7 @@
         <!--{/if}-->
         <!-- 使用ポイントここまで -->
 
+        <!--{if $downloadable != 1}-->
         <!--{foreach item=shippingItem name=shippingItem from=$arrShipping}-->
             <h3>お届け先<!--{if $isMultiple}--><!--{$smarty.foreach.shippingItem.iteration}--><!--{/if}--></h3>
             <!--{if $isMultiple}-->
@@ -249,6 +251,7 @@
                 </tbody>
             </table>
         <!--{/foreach}-->
+        <!--{/if}-->
 
         <br />
 


### PR DESCRIPTION
ダウンロード販売商品の場合は、お届け先が表示されないようにする