### PR TITLE
正常に HTTPS 判定されるよう修正

### DIFF
--- a/data/app_initial.php
+++ b/data/app_initial.php
@@ -21,6 +21,12 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+// スクリプトが HTTPS プロトコルを通じて実行されている場合に 空でない値が設定される.
+// Webサーバーによっては 'On' が設定されるため正規化する
+// see https://www.php.net/manual/ja/reserved.variables.server.php
+if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') { // ISAPI/IIS の場合は off になる
+    $_SERVER['HTTPS'] = 'on';
+}
 // Flexible SSLへの対応
 if( isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && 'https' == $_SERVER['HTTP_X_FORWARDED_PROTO'] ){
     $_SERVER['HTTPS'] = 'on';
@@ -54,4 +60,3 @@ SC_Helper_HandleError_Ex::load();
 // アプリケーション初期化処理
 $objInit = new SC_Initial_Ex();
 $objInit->init();
-


### PR DESCRIPTION
- PEAR::Net_URL が正常に HTTPS 判定できないのを修正
- Symfony Local Web Server 対応
  - see https://symfony.com/doc/current/setup/symfony_server.html
  - TLS 有効にした場合, $_SERVER['HTTPS'] = 'On' に設定されるため
- ISAPI/IIS の環境にも対応
  - https://www.php.net/manual/ja/reserved.variables.server.php