### PR TITLE
売上集計のE2Eテストでグラフの表示されないケースに対応

### DIFF
--- a/ctests/acceptance/admin/total/AdminTotalCept.php
+++ b/ctests/acceptance/admin/total/AdminTotalCept.php
@@ -31,54 +31,91 @@ $I->amGoingTo('売上集計>期間別集計>月度集計');
 $I->click('月度で集計する');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-term']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
+
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-term']);
+}
 
 $I->amGoingTo('売上集計>期間別集計>期間集計');
 $I->selectOption('select[name=search_startyear]', date('Y', strtotime('-1 year')));
 $I->click('期間で集計する');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-term']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
+
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-term']);
+}
 
 $I->amGoingTo('売上集計>期間別集計>期間集計>月別');
 $I->click('月別');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-term']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
+
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-term']);
+}
 
 $I->amGoingTo('売上集計>期間別集計>期間集計>年別');
 $I->click('年別');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-term']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
+
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-term']);
+}
+
 
 $I->amGoingTo('売上集計>期間別集計>期間集計>曜日別');
 $I->click('曜日別');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-term']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
+
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-term']);
+}
 
 $I->amGoingTo('売上集計>期間別集計>期間集計>時間別');
 $I->click('時間別');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-term']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
 
-$I->click('CSVダウンロード');
-$file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
-$I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-term']);
+
+    $I->click('CSVダウンロード');
+    $file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
+    $I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+}
 
 $I->amGoingTo('売上集計＞商品別集計');
 $I->amOnPage('/admin/total/?page=products');
@@ -99,38 +136,62 @@ $I->amGoingTo('売上集計>商品別集計>月度集計');
 $I->click('月度で集計する');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-products']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
+
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-products']);
+}
 
 $I->amGoingTo('売上集計>商品集計>期間集計');
 $I->selectOption('select[name=search_startyear]', date('Y', strtotime('-1 year')));
 $I->click('期間で集計する');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-products']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
+
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-products']);
+}
 
 $I->amGoingTo('売上集計>商品集計>期間集計>会員');
 $I->click('会員');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-products']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
+
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-products']);
+}
 
 $I->amGoingTo('売上集計>商品集計>期間集計>非会員');
 $I->click('非会員');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-products']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
 
-$I->click('CSVダウンロード');
-$file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
-$I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-products']);
+
+    $I->click('CSVダウンロード');
+    $file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
+    $I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+}
 
 $I->amGoingTo('売上集計＞年代別集計');
 $I->amOnPage('/admin/total/?page=age');
@@ -151,38 +212,62 @@ $I->amGoingTo('売上集計>年代別集計>月度集計');
 $I->click('月度で集計する');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-age']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
+
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-age']);
+}
 
 $I->amGoingTo('売上集計>年代別集計>期間集計');
 $I->selectOption('select[name=search_startyear]', date('Y', strtotime('-1 year')));
 $I->click('期間で集計する');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-age']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
+
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-age']);
+}
 
 $I->amGoingTo('売上集計>年代別集計>期間集計>会員');
 $I->click('会員');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-age']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
+
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-age']);
+}
 
 $I->amGoingTo('売上集計>年代別集計>期間集計>非会員');
 $I->click('非会員');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-age']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
 
-$I->click('CSVダウンロード');
-$file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
-$I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-age']);
+
+    $I->click('CSVダウンロード');
+    $file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
+    $I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+}
 
 $I->amGoingTo('売上集計＞職業別集計');
 $I->amOnPage('/admin/total/?page=job');
@@ -203,22 +288,34 @@ $I->amGoingTo('売上集計>職業別集計>月度集計');
 $I->click('月度で集計する');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-job']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
+
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-job']);
+}
 
 $I->amGoingTo('売上集計>職業別集計>期間集計');
 $I->selectOption('select[name=search_startyear]', date('Y', strtotime('-1 year')));
 $I->click('期間で集計する');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-job']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
 
-$I->click('CSVダウンロード');
-$file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
-$I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-job']);
+
+    $I->click('CSVダウンロード');
+    $file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
+    $I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+}
 
 $I->amGoingTo('売上集計＞会員別集計');
 $I->amOnPage('/admin/total/?page=member');
@@ -239,19 +336,31 @@ $I->amGoingTo('売上集計>会員別集計>月度集計');
 $I->click('月度で集計する');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-member']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
+
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-member']);
+}
 
 $I->amGoingTo('売上集計会員別集計>期間集計');
 $I->selectOption('select[name=search_startyear]', date('Y', strtotime('-1 year')));
 $I->click('期間で集計する');
 
 $I->expect('グラフの表示を確認する');
-$I->waitForElement(['css' => '#graph-image > img']);
-$I->expect('表の表示を確認する');
-$I->waitForElement(['id' => 'total-member']);
+$message = $I->grabPageSource();
+if (strpos('該当するデータはありません。', $message) !== false) {
+    $I->see('該当するデータはありません。', ['css' => '.message']);
+} else {
+    $I->waitForElement(['css' => '#graph-image > img']);
 
-$I->click('CSVダウンロード');
-$file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
-$I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+    $I->expect('表の表示を確認する');
+    $I->waitForElement(['id' => 'total-member']);
+
+    $I->click('CSVダウンロード');
+    $file = $I->getLastDownloadFile('/^total\d{12}\.csv$/');
+    $I->assertTrue(count(file($file)) >= 2, '2行以上のファイルがダウンロードされている');
+}


### PR DESCRIPTION
- 売上集計のE2Eテストで、グラフが表示されない場合はエラーになっていたのを修正
- グラフが表示されない場合は、**該当するデータはありません** というメッセージを表示する