### PR TITLE
帳票作成のデフォルト日付が1月になってしまうのを修正

### DIFF
--- a/data/class/pages/admin/order/LC_Page_Admin_Order_Pdf.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order_Pdf.php
@@ -121,8 +121,8 @@ class LC_Page_Admin_Order_Pdf extends LC_Page_Admin_Ex
 
         // 今日の日付をセット
         $arrForm['year']  = date('Y');
-        $arrForm['month'] = date('m');
-        $arrForm['day']   = date('d');
+        $arrForm['month'] = date('n');
+        $arrForm['day']   = date('j');
 
         // メッセージ
         $arrForm['msg1'] = 'このたびはお買上げいただきありがとうございます。';


### PR DESCRIPTION
開発コミュニティより
https://xoops.ec-cube.net/modules/newbb/viewtopic.php?topic_id=24325&forum=15&post_id=99076#forumpost99076

Smarty3 の日付フォームでは、ゼロ埋めしないようにする必要がある