### PR TITLE
非推奨のメソッド(SC_Helper_DB_Ex::sfCalcIncTax())を使用しないよう修正

### DIFF
--- a/data/class/SC_Fpdf.php
+++ b/data/class/SC_Fpdf.php
@@ -209,7 +209,7 @@ class SC_Fpdf extends SC_Helper_FPDI
             $data[0] = $this->arrDisp['quantity'][$i];
 
             // 税込金額（単価）
-            $data[1] = SC_Helper_DB_Ex::sfCalcIncTax($this->arrDisp['price'][$i], $this->arrDisp['tax_rate'][$i], $this->arrDisp['tax_rule'][$i]);
+            $data[1] = $this->arrDisp['price'][$i] + SC_Helper_TaxRule_Ex::calcTax($this->arrDisp['price'][$i], $this->arrDisp['tax_rate'][$i], $this->arrDisp['tax_rule'][$i]);
 
             // 小計（商品毎）
             $data[2] = $data[0] * $data[1];

--- a/data/class/helper/SC_Helper_DB.php
+++ b/data/class/helper/SC_Helper_DB.php
@@ -1547,7 +1547,7 @@ __EOS__;
      * @param  int $tax
      * @param  int $tax_rule
      * @return double 税金付与した金額
-     * @deprecated SC_Helper_TaxRule::sfCalcIncTax() を使用してください
+     * @deprecated SC_Helper_TaxRule::calcTax() を使用してください
      */
     public static function sfCalcIncTax($price, $tax = null, $tax_rule = null)
     {

--- a/data/class/pages/rss/LC_Page_Rss_Products.php
+++ b/data/class/pages/rss/LC_Page_Rss_Products.php
@@ -134,8 +134,6 @@ class LC_Page_Rss_Products extends LC_Page_Ex
         }
         // 値の整形
         foreach (array_keys($arrProduct) as $key) {
-            //販売価格を税込みに編集
-            $arrProduct[$key]['price02'] = SC_Helper_DB_Ex::sfCalcIncTax($arrProduct[$key]['price02']);
             // 画像ファイルのURLセット
             if (file_exists(IMAGE_SAVE_REALDIR . $arrProduct[$key]['main_list_image'])) {
                 $dir = IMAGE_SAVE_RSS_URL;


### PR DESCRIPTION
- `@deprecated` コメントを適切なメソッドに修正
- SC_Helper_DB_Ex::sfCalcIncTax() を使用しないよう修正