### PR TITLE
GitHub Actions の Windows インスタンスがエラーになるのを改善

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,9 +155,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Composer install
-      uses: nanasess/composer-installer-action@master
-
     - name: Setup PHP
       uses: nanasess/setup-php@master
       with:


### PR DESCRIPTION
Windows インスタンスに composer が含まれるようになり、エラーになるため削除