### PR TITLE
商品レビュー管理→おすすめレベルのデフォルト値に無効な値が指定されていたのを修正

### DIFF
--- a/data/Smarty/templates/admin/products/review.tpl
+++ b/data/Smarty/templates/admin/products/review.tpl
@@ -51,7 +51,7 @@
                     <!--{assign var=key value=search_recommend_level}-->
                     <select name="<!--{$key}-->">
                         <option value="" selected="selected">選択してください</option>
-                        <!--{html_options options=$arrRECOMMEND selected=$arrForm[$key].value}-->
+                        <!--{html_options options=$arrRECOMMEND selected=$arrForm[$key]}-->
                     </select>
                 </td>
             </tr>


### PR DESCRIPTION
 - PHP7 以下では検索時に選択値が保持されないのを修正
 - PHP8 ではシステムエラーとなるのを修正
    - `Uncaught TypeError: Cannot access offset of type string on string` となる
