### PR TITLE
不適切な strlen の使用を修正

### DIFF
--- a/data/class/helper/SC_Helper_Address.php
+++ b/data/class/helper/SC_Helper_Address.php
@@ -47,7 +47,7 @@ class SC_Helper_Address
         $other_deliv_id = $sqlval['other_deliv_id'];
 
         // 追加
-        if (strlen($other_deliv_id == 0)) {
+        if (intval($other_deliv_id) === 0) {
             // 別のお届け先最大登録数に達している場合、エラー
             $from   = 'dtb_other_deliv';
             $where  = 'customer_id = ?';


### PR DESCRIPTION
- $other_deliv_id が空文字の場合は 1, 1以上の数値の場合は 0 を返すため、一応正常に動いていた
- PHP8 では動かない