### PR TITLE
売上集計の対象外ステータスに決済処理中も追加

### DIFF
--- a/ctests/acceptance/_bootstrap.php
+++ b/ctests/acceptance/_bootstrap.php
@@ -66,7 +66,10 @@ if ($num < $config['fixture_order_num']) {
         $discount = $faker->numberBetween(0, $charge);
         $order_count_per_customer = $objQuery->count('dtb_order', 'customer_id = ?', [$customer_id]);
         for ($i = $order_count_per_customer; $i < $config['fixture_order_num'] / count($customer_ids); $i++) {
-            $objGenerator->createOrder($customer_id, $target_product_class_ids, 1, $charge, $discount, $faker->numberBetween(1, 7));
+            // キャンセルと決済処理中は除外して注文を生成する
+            $target_statuses = [ORDER_NEW, ORDER_PAY_WAIT, ORDER_PRE_END, ORDER_BACK_ORDER, ORDER_DELIV];
+            $order_status_id = $target_statuses[$faker->numberBetween(0, count($target_statuses) - 1)];
+            $objGenerator->createOrder($customer_id, $target_product_class_ids, 1, $charge, $discount, $order_status_id);
             echo '.';
         }
     }

--- a/data/class/pages/admin/total/LC_Page_Admin_Total.php
+++ b/data/class/pages/admin/total/LC_Page_Admin_Total.php
@@ -31,6 +31,21 @@ require_once CLASS_EX_REALDIR . 'page_extends/admin/LC_Page_Admin_Ex.php';
  */
 class LC_Page_Admin_Total extends LC_Page_Admin_Ex
 {
+    /** @var bool */
+    public $install_GD;
+    /** @var string */
+    public $tpl_graphsubtitle;
+    /** @var string */
+    public $tpl_titleimage;
+    /** @var array */
+    public $arrSearchForm1;
+    /** @var array */
+    public $arrSearchForm2;
+    /** @var string */
+    public $tpl_page_type;
+    /** @var array */
+    public $excludeOrderStatuses;
+
     /**
      * Page を初期化する.
      *
@@ -80,6 +95,9 @@ class LC_Page_Admin_Total extends LC_Page_Admin_Ex
             'search_endmonth',
             'search_endday',
         );
+
+        // 集計から除外する受注ステータスの配列
+        $this->excludeOrderStatuses = array(ORDER_CANCEL, ORDER_PENDING);
     }
 
     /**
@@ -535,8 +553,8 @@ class LC_Page_Admin_Total extends LC_Page_Admin_Ex
         $objQuery = SC_Query_Ex::getSingletonInstance();
 
         list($where, $arrWhereVal) = $this->lfGetWhereMember('create_date', $sdate, $edate, $type);
-        $where .= ' AND del_flg = 0 AND status <> ?';
-        $arrWhereVal[] = ORDER_CANCEL;
+        $where .= ' AND del_flg = 0 AND status NOT IN ('.SC_Utils_Ex::repeatStrWithSeparator('?', count($this->excludeOrderStatuses)).')';
+        $arrWhereVal += $this->excludeOrderStatuses;
 
         // 会員集計の取得
         $col = <<< __EOS__
@@ -579,8 +597,8 @@ __EOS__;
 
         list($where, $arrWhereVal) = $this->lfGetWhereMember('create_date', $sdate, $edate, $type);
 
-        $where .= ' AND dtb_order.del_flg = 0 AND dtb_order.status <> ?';
-        $arrWhereVal[] = ORDER_CANCEL;
+        $where .= ' AND dtb_order.del_flg = 0 AND dtb_order.status NOT IN ('.SC_Utils_Ex::repeatStrWithSeparator('?', count($this->excludeOrderStatuses)).')';
+        $arrWhereVal += $this->excludeOrderStatuses;
 
         $col = <<< __EOS__
                 product_id,
@@ -619,8 +637,8 @@ __EOS__;
 
         $from   = 'dtb_order JOIN dtb_customer ON dtb_order.customer_id = dtb_customer.customer_id';
 
-        $where .= ' AND dtb_order.del_flg = 0 AND dtb_order.status <> ?';
-        $arrWhereVal[] = ORDER_CANCEL;
+        $where .= ' AND dtb_order.del_flg = 0 AND dtb_order.status NOT IN ('.SC_Utils_Ex::repeatStrWithSeparator('?', count($this->excludeOrderStatuses)).')';
+        $arrWhereVal += $this->excludeOrderStatuses;
 
         $objQuery->setGroupBy('job');
         $objQuery->setOrder('total DESC');
@@ -657,8 +675,8 @@ __EOS__;
 
         $from   = 'dtb_order';
 
-        $where .= ' AND del_flg = 0 AND status <> ?';
-        $arrWhereVal[] = ORDER_CANCEL;
+        $where .= ' AND del_flg = 0 AND status NOT IN ('.SC_Utils_Ex::repeatStrWithSeparator('?', count($this->excludeOrderStatuses)).')';
+        $arrWhereVal += $this->excludeOrderStatuses;  $objQuery->setGroupBy('age');
 
         $objQuery->setGroupBy('age');
         $objQuery->setOrder('age DESC');
@@ -687,9 +705,9 @@ __EOS__;
         $objQuery   = SC_Query_Ex::getSingletonInstance();
 
         list($where, $arrWhereVal) = $this->lfGetWhereMember('create_date', $sdate, $edate, null, null);
-        $where .= ' AND del_flg = 0 AND status <> ?';
-        $arrWhereVal[] = ORDER_CANCEL;
-
+        $where .= ' AND del_flg = 0 AND status NOT IN ('.SC_Utils_Ex::repeatStrWithSeparator('?', count($this->excludeOrderStatuses)).')';
+        $arrWhereVal += $this->excludeOrderStatuses;
+        $xincline = false;
         switch ($type) {
             case 'month':
                 $xtitle = '(月別)';


### PR DESCRIPTION
- 売上集計の対象外ステータスに決済処理中も追加
- `$this->excludeOrderStatuses` で一括して指定できるよう修正
- #440
- その他メンバ変数の定義を追加(PHP8向けの修正)