### PR TITLE
インストールと税率の評価が同一秒で実行されテストに失敗するのを修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
       uses: nanasess/setup-chromedriver@master
       with:
         chromedriver-version: 2.43
-
+    - run: sleep 1
     - name: Run to PHPUnit
       run: data/vendor/bin/phpunit --exclude-group classloader
     - name: Run to PHPUnit classloader
@@ -200,7 +200,8 @@ jobs:
         HTTPS_URL: http://localhost:8085/
       run: bash eccube_install.sh mysql
       shell: bash
-
+    - run: sleep 1
+      shell: bash
     - name: Run to PHPUnit
       run: data/vendor/bin/phpunit --exclude-group classloader
     - name: Run to PHPUnit classloader


### PR DESCRIPTION
- sleep 1 を追加
- `dtb_tax_rule.apply_date < CURRENT_TIMESTAMP` で消費税率を取得しているため、セットアップと同一秒でテストが実行されると税率が取得できずエラーになってしまう
   - セットアップ時の `dtb_tax_rule.apply_date` は `CURRENT_TIMESTAMP` を INSERT している
- [失敗したテスト](https://github.com/nanasess/ec-cube2/runs/1924880412?check_suite_focus=true#step:10:9)
![スクリーンショット 2021-02-26 12 30 45](https://user-images.githubusercontent.com/815715/109251698-44eb4f00-782f-11eb-8103-38e5954e1beb.png)
- 税率の情報は static 変数にキャッシュされるため、後続のテストも失敗してしまう
