### PR TITLE
E2Eテストのカバレッジを取得する

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -146,7 +146,7 @@ jobs:
         mv html/admin html/${ADMIN_DIR}
         php data/vendor/bin/codecept build
         symfony serve -d --no-tls --port=8085 --document-root=html
-        php data/vendor/bin/codecept run --env chrome,http --skip-group installer --steps --coverage --coverage-xml
+        php data/vendor/bin/codecept run --env chrome,http --skip-group installer --skip-group excludeCoverage --steps --coverage --coverage-xml
         mv ./ctests/_output/acceptance\ \(chrome,\ http\).remote.coverage.xml ctests/_output/acceptance.remote.coverage.xml
 
     - name: Upload coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -70,7 +70,14 @@ jobs:
         php-version: ${{ matrix.php }}
 
     - name: Install to Composer
-      run: composer install --no-interaction -o
+      run: |
+        composer install --no-interaction -o
+        composer remove php5friends/codeception-phpunit48-wrapper --ignore-platform-reqs --dev
+        composer remove php5friends/phpunit48 --ignore-platform-reqs --dev
+    - name: Create ADMIN_DIR
+      run: |
+        sudo apt-fast install -y sharutils
+        echo "ADMIN_DIR=$(head -c 10 < /dev/random | uuencode -m - | tail -n 2 |head -n 1 |  sed 's,[/+],_,g' | head -c10)/" >> $GITHUB_ENV
 
     - name: Setup to EC-CUBE
       env:
@@ -80,8 +87,8 @@ jobs:
         DBPASS: ${{ matrix.dbpass }}
         DBNAME: ${{ matrix.dbname }}
         DBPORT: ${{ matrix.dbport }}
-        HTTP_URL: http://localhost:8085/
-        HTTPS_URL: http://localhost:8085/
+        HTTP_URL: http://127.0.0.1:8085/
+        HTTPS_URL: http://127.0.0.1:8085/
       run: |
         sudo apt-fast install -y mysql-client postgresql-client
         ./eccube_install.sh ${DB}
@@ -97,11 +104,62 @@ jobs:
       run: |
         sed 's|http://|https://|g' -i.bak data/config/config.php
         phpdbg -qrr data/vendor/bin/phpunit tests/class/SC_SessionFactoryTest.php --coverage-clover=coverage3.xml
+        mv data/config/config.php.bak data/config/config.php
+
+    - name: Install symfony/cli
+      # server:ca:install でエラーは出るが利用可能
+      continue-on-error: true
+      run: |
+        sudo apt-fast -y install libnss3-tools
+        wget https://get.symfony.com/cli/installer -O - | bash
+        sudo mv ~/.symfony/bin/symfony /usr/local/bin/symfony
+        symfony local:php:list
+
+    - name: setup-chromedriver
+      uses: nanasess/setup-chromedriver@master
+    - name: Run chromedriver
+      run: |
+        export DISPLAY=:99
+        chromedriver --url-base=/wd/hub &
+        echo ">>> Started chrome-driver"
+        sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+        echo ">>> Started xvfb"
+    - name: Setup C3
+      run: |
+        wget https://raw.github.com/Codeception/c3/2.0/c3.php
+        sed -i 's,/vendor/autoload.php,/data/vendor/autoload.php,g' c3.php
+        echo "include __DIR__.'/../c3.php';" >> html/define.php
+    - name: Run to Codeception
+      continue-on-error: true
+      env:
+        DB: ${{ matrix.db }}
+        USER: ${{ matrix.dbuser }}
+        DBUSER: ${{ matrix.dbuser }}
+        DBPASS: ${{ matrix.dbpass }}
+        DBNAME: ${{ matrix.dbname }}
+        DBPORT: ${{ matrix.dbport }}
+        DBSERVER: 127.0.0.1
+        HTTP_URL: http://127.0.0.1:8085/
+        HTTPS_URL: http://127.0.0.1:8085/
+        XDEBUG_MODE: coverage
+      run: |
+        sudo phpenmod -s cli xdebug
+        sudo phpenmod -s fpm xdebug
+        mv html/admin html/${ADMIN_DIR}
+        php data/vendor/bin/codecept build
+        symfony serve -d --no-tls --port=8085 --document-root=html
+        php data/vendor/bin/codecept run --env chrome --skip-group installer --steps --coverage --coverage-xml
+
     - name: Upload coverage
       uses: codecov/codecov-action@v1
       with:
-        files: ./coverage1.xml,./coverage2.xml,./coverage3.xml
+        files: ./coverage1.xml,./coverage2.xml,./coverage3.xml,ctests/_output/acceptance (chrome).remote.coverage.xml
         # token: ${{ secrets.CODECOV_TOKEN }}
         flags: tests
         # yml: ./codecov.yml
         fail_ci_if_error: true
+    - name: Upload evidence
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-evidence
+        path: ctests/_output/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -107,10 +107,8 @@ jobs:
         mv data/config/config.php.bak data/config/config.php
 
     - name: Install symfony/cli
-      # server:ca:install でエラーは出るが利用可能
       continue-on-error: true
       run: |
-        sudo apt-fast -y install libnss3-tools
         wget https://get.symfony.com/cli/installer -O - | bash
         sudo mv ~/.symfony/bin/symfony /usr/local/bin/symfony
         symfony local:php:list
@@ -148,12 +146,13 @@ jobs:
         mv html/admin html/${ADMIN_DIR}
         php data/vendor/bin/codecept build
         symfony serve -d --no-tls --port=8085 --document-root=html
-        php data/vendor/bin/codecept run --env chrome --skip-group installer --steps --coverage --coverage-xml
+        php data/vendor/bin/codecept run --env chrome,http --skip-group installer --steps --coverage --coverage-xml
+        mv ./ctests/_output/acceptance\ \(chrome,\ http\).remote.coverage.xml ctests/_output/acceptance.remote.coverage.xml
 
     - name: Upload coverage
       uses: codecov/codecov-action@v1
       with:
-        files: ./coverage1.xml,./coverage2.xml,./coverage3.xml,ctests/_output/acceptance (chrome).remote.coverage.xml
+        files: ./coverage1.xml,./coverage2.xml,./coverage3.xml,./ctests/_output/acceptance.remote.coverage.xml
         # token: ${{ secrets.CODECOV_TOKEN }}
         flags: tests
         # yml: ./codecov.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,8 +111,8 @@ jobs:
         DBPASS: ${{ matrix.dbpass }}
         DBNAME: ${{ matrix.dbname }}
         DBPORT: ${{ matrix.dbport }}
-        HTTP_URL: https://localhost:8085/
-        HTTPS_URL: https://localhost:8085/
+        HTTP_URL: https://127.0.0.1:8085/
+        HTTPS_URL: https://127.0.0.1:8085/
       run: |
         sudo apt-fast install -y mysql-client postgresql-client
         ./eccube_install.sh ${DB}
@@ -144,8 +144,8 @@ jobs:
         DBNAME: ${{ matrix.dbname }}
         DBPORT: ${{ matrix.dbport }}
         DBSERVER: 127.0.0.1
-        HTTP_URL: https://localhost:8085/
-        HTTPS_URL: https://localhost:8085/
+        HTTP_URL: https://127.0.0.1:8085/
+        HTTPS_URL: https://127.0.0.1:8085/
       run: |
         mv html/admin html/${ADMIN_DIR}
         php data/vendor/bin/codecept build
@@ -217,8 +217,8 @@ jobs:
         DBNAME: eccube_db
         DBPORT: 3306
         DBSERVER: 127.0.0.1
-        HTTP_URL: http://localhost:8085/
-        HTTPS_URL: http://localhost:8085/
+        HTTP_URL: http://127.0.0.1:8085/
+        HTTPS_URL: http://127.0.0.1:8085/
       run: bash eccube_install.sh mysql
       shell: bash
     - run: sleep 1
@@ -369,8 +369,8 @@ jobs:
         DBNAME: ${{ matrix.dbname }}
         DBPORT: ${{ matrix.dbport }}
         DBSERVER: 127.0.0.1
-        HTTP_URL: https://localhost:8085/
-        HTTPS_URL: https://localhost:8085/
+        HTTP_URL: https://127.0.0.1:8085/
+        HTTPS_URL: https://127.0.0.1:8085/
       run: |
         php data/vendor/bin/codecept build
         symfony serve -d --allow-http --port=8085 --document-root=html

--- a/codeception.yml
+++ b/codeception.yml
@@ -8,6 +8,7 @@ settings:
     bootstrap: _bootstrap.php
     colors: true
     memory_limit: 1024M
+    log: true
 modules:
     config:
         Db:
@@ -17,3 +18,12 @@ modules:
             dump: ctests/_data/dump.sql
 params:
     - env
+coverage:
+    enabled: true
+    whitelist:
+        include:
+            - ./data/class/*
+        exclude:
+            - data/class/graph/*
+            - data/class/batch/*
+            - data/class/db/dbfactory/*

--- a/codeception.yml
+++ b/codeception.yml
@@ -22,7 +22,7 @@ coverage:
     enabled: true
     whitelist:
         include:
-            - ./data/class/*
+            - data/class/*
         exclude:
             - data/class/graph/*
             - data/class/batch/*

--- a/ctests/acceptance.suite.yml
+++ b/ctests/acceptance.suite.yml
@@ -19,8 +19,8 @@ modules:
             url: 'http://127.0.0.1:8085/'
         WebDriver:
             browser: chrome
-            url: 'http://127.0.0.1:8085/'
-            host: 'localhost'
+            url: 'https://127.0.0.1:8085/'
+            host: '127.0.0.1'
             port: 9515
             window_size: 1680x3000
             wait: 10
@@ -38,11 +38,6 @@ modules:
             password: %DBPASS%
 
 env:
-    travis:
-        modules:
-            config:
-                PhpBrowser:
-                    url: 'http://localhost:8085/'
     chrome:
         modules:
             config:
@@ -52,3 +47,8 @@ env:
                         chromeOptions:
                             prefs:
                                 download.default_directory: '/tmp'
+    http:
+        modules:
+            config:
+                WebDriver:
+                    url: 'http://127.0.0.1:8085/'

--- a/ctests/acceptance.suite.yml
+++ b/ctests/acceptance.suite.yml
@@ -5,6 +5,8 @@
 # If you need both WebDriver and PHPBrowser tests - create a separate suite.
 
 class_name: AcceptanceTester
+coverage:
+    remote: true
 modules:
     enabled:
         - AcceptanceHelper
@@ -14,10 +16,10 @@ modules:
         - Db
     config:
         PhpBrowser:
-            url: 'http://localhost:8085/'
+            url: 'http://127.0.0.1:8085/'
         WebDriver:
             browser: chrome
-            url: 'https://localhost:8085/'
+            url: 'http://127.0.0.1:8085/'
             host: 'localhost'
             port: 9515
             window_size: 1680x3000

--- a/ctests/acceptance/admin/contents/AdminContentsRecommendSearchCept.php
+++ b/ctests/acceptance/admin/contents/AdminContentsRecommendSearchCept.php
@@ -1,5 +1,7 @@
 <?php
-
+/**
+ * @group excludeCoverage
+ */
 $I = new AcceptanceTester($scenario);
 $I->wantTo('おすすめ商品管理を確認する');
 $I->amOnPage('/'.ADMIN_DIR.'/'.DIR_INDEX_FILE);

--- a/ctests/acceptance/admin/contents/AdminContentsRecommendSearchCept.php
+++ b/ctests/acceptance/admin/contents/AdminContentsRecommendSearchCept.php
@@ -1,5 +1,7 @@
 <?php
-
+/**
+ * @group installer
+ */
 $I = new AcceptanceTester($scenario);
 $I->wantTo('おすすめ商品管理を確認する');
 $I->amOnPage('/'.ADMIN_DIR.'/'.DIR_INDEX_FILE);

--- a/ctests/acceptance/admin/contents/AdminContentsRecommendSearchCept.php
+++ b/ctests/acceptance/admin/contents/AdminContentsRecommendSearchCept.php
@@ -1,7 +1,5 @@
 <?php
-/**
- * @group installer
- */
+
 $I = new AcceptanceTester($scenario);
 $I->wantTo('おすすめ商品管理を確認する');
 $I->amOnPage('/'.ADMIN_DIR.'/'.DIR_INDEX_FILE);

--- a/ctests/acceptance/admin/ownersstore/AdminOwnersstorePluginInstallCept.php
+++ b/ctests/acceptance/admin/ownersstore/AdminOwnersstorePluginInstallCept.php
@@ -1,7 +1,5 @@
 <?php
-/**
- * @group installer
- */
+
 $I = new AcceptanceTester($scenario);
 $I->wantTo('プラグインの prefilterTransform が正常に動作するかを確認する');
 $I->amOnPage('/'.ADMIN_DIR.'/'.DIR_INDEX_FILE);

--- a/ctests/acceptance/admin/ownersstore/AdminOwnersstorePluginInstallCept.php
+++ b/ctests/acceptance/admin/ownersstore/AdminOwnersstorePluginInstallCept.php
@@ -1,5 +1,7 @@
 <?php
-
+/**
+ * @group excludeCoverage
+ */
 $I = new AcceptanceTester($scenario);
 $I->wantTo('プラグインの prefilterTransform が正常に動作するかを確認する');
 $I->amOnPage('/'.ADMIN_DIR.'/'.DIR_INDEX_FILE);

--- a/ctests/acceptance/admin/ownersstore/AdminOwnersstorePluginInstallCept.php
+++ b/ctests/acceptance/admin/ownersstore/AdminOwnersstorePluginInstallCept.php
@@ -1,5 +1,7 @@
 <?php
-
+/**
+ * @group installer
+ */
 $I = new AcceptanceTester($scenario);
 $I->wantTo('プラグインの prefilterTransform が正常に動作するかを確認する');
 $I->amOnPage('/'.ADMIN_DIR.'/'.DIR_INDEX_FILE);


### PR DESCRIPTION
- codeception のリモートカバレッジを取得する
- codecov でPHPUnit のカバレッジ結果と結合する
- codeception や PHPUnit が古いと動作しないため、 `--ignore-platform-reqs` を付与して PHP7.4 向けにインストールし直す
- https:// を使用すると c3.php がエラーになるため、 http:// でテストする
- ポップアップ系のテストは動作しないためカバレッジから除外