### PR TITLE
Smarty の script_escape でサニタイズされる対象の追加

### DIFF
--- a/ctests/acceptance/ZZ_ScriptEscapeCept.php
+++ b/ctests/acceptance/ZZ_ScriptEscapeCept.php
@@ -1,0 +1,39 @@
+<?php
+$I = new AcceptanceTester($scenario);
+$I->wantTo('script_escapeを確認する。');
+copy(__DIR__.'/../../data/Smarty/templates/default/index.tpl', __DIR__.'/../../data/Smarty/templates/default/index.tpl.bak');
+
+$example = file_get_contents('https://raw.githubusercontent.com/zaproxy/zap-extensions/master/addOns/ascanrulesAlpha/src/main/zapHomeFiles/txt/example-ascan-file.txt');
+$patterns = explode("\n", $example);
+
+foreach ($patterns as $pattern) {
+    if (preg_match_all('/CONTENT="0/i', $pattern)) {
+        $I->comment('meta content=0 はチェックできないためスキップします');
+        continue;
+    }
+    $pattern = str_replace('\\', '\\\\', $pattern);
+    $pattern = str_replace('"', '\"', $pattern);
+    $pattern = str_replace('ha.ckers.org', '127.0.0.1', $pattern);
+    $I->expect($pattern.' が無効化されて alert の出ないことを確認します');
+
+    file_put_contents(__DIR__.'/../../data/Smarty/templates/default/index.tpl', '<!--{"'.trim($pattern).'"}-->');
+    $I->amOnPage('/'.DIR_INDEX_FILE);
+
+    $I->see('EC-CUBE発!世界中を旅して見つけた立方体グルメを立方隊長が直送！');
+    $I->seeElement('#site_description');
+    $I->expect('body の class 名が出力されている');
+    $I->seeElement(['css' => 'body'], ['class' => 'LC_Page_Index']);
+
+    $I->expect('システムエラーが出ていない');
+    $I->dontSeeElement('.error');
+
+    array_map('unlink', glob(__DIR__.'/../../data/Smarty/templates_c/default/*.tpl.php'));
+}
+
+$I->expect("nofilter で alert の出ることを確認します");
+file_put_contents(__DIR__.'/../../data/Smarty/templates/default/index.tpl', '<!--{"<script>alert(1)</script>" nofilter}-->');
+$I->amOnPage('/'.DIR_INDEX_FILE);
+$I->acceptPopup();
+$I->see('EC-CUBE発!世界中を旅して見つけた立方体グルメを立方隊長が直送！');
+
+copy(__DIR__.'/../../data/Smarty/templates/default/index.tpl.bak', __DIR__.'/../../data/Smarty/templates/default/index.tpl');

--- a/data/smarty_extends/modifier.script_escape.php
+++ b/data/smarty_extends/modifier.script_escape.php
@@ -9,7 +9,7 @@ function smarty_modifier_script_escape($value)
 {
     if (is_array($value)) return $value;
 
-    $pattern = "/<script.*?>|<\/script>|javascript:/i";
+    $pattern = "/<script.*?>|<\/script>|javascript:|<svg.*on.*?>|<img.*on.*?>|<body.*onload.*?>|<iframe.*?>|<object.*?>|<embed.*?>|<.*onmouse.*?>/i";
     $convert = '#script tag escaped#';
 
     if (preg_match_all($pattern, $value, $matches)) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -30,9 +30,9 @@ parameters:
     -
       message: "#^Call to static method dayOfWeek\\(\\) on an unknown class Date_Calc\\.#"
       path: data/module/Calendar/Util/Textual.php
-    # -
-    #   message: "#^Constant SMARTY_PLUGINS_DIR not found\\.$#"
-    #   path: data/smarty_extends/*
+    -
+      message: "#^Constant SMARTY_PLUGINS_DIR not found\\.$#"
+      path: data/smarty_extends/*
     -
       message: "#^Function smarty_function_escape_special_chars not found\\.$#"
       path: data/smarty_extends/*


### PR DESCRIPTION
- 万が一、プラグインや独自カスタマイズでエスケープ漏れのあった場合の保険のため、開くだけもしくはマウス操作だけで JavaScript の起動が可能なタグを追加
  - [許可タグ](https://github.com/EC-CUBE/ec-cube2/blob/c122ec94923d02eea289f2ba2ec1f4f5f3bc88b5/html/install/sql/insert_data.sql#L731-L764)には存在せず、 `onmouse*` 属性の使用頻度も低いため、既存コンテンツへの影響は低いと思われる
- [OWASP ZAP のスキャンルールで使用されるリスト](https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesAlpha/src/main/zapHomeFiles/txt/example-ascan-file.txt) で alert が起動しないことを確認する E2Eテストを追加
   - 一部、 alert 以外のものもあるが、起動しないことを手動で確認済み
- refs https://github.com/EC-CUBE/ec-cube/pull/5033