### PR TITLE
`<svg.*on.*?>|<img.*on.*?>` はマッチする範囲が広すぎるため onload|onerror にサニタイズ対象を限定する

### DIFF
--- a/data/Smarty/templates/admin/home.tpl
+++ b/data/Smarty/templates/admin/home.tpl
@@ -29,8 +29,8 @@
         <!--{foreach item=info from=$arrInfo}-->
             <dl class="home-info-item">
                 <dt class="date"><!--{$info.disp_date|sfDispDBDate:false|h}--></dt>
-                <dt class="title"><!--{$info.title}--></dt>
-                <dd class="body"><!--{$info.body}--></dd>
+                <dt class="title"><!--{$info.title nofilter}--></dt>
+                <dd class="body"><!--{$info.body nofilter}--></dd>
             </dl>
         <!--{/foreach}-->
     </div>

--- a/data/smarty_extends/modifier.script_escape.php
+++ b/data/smarty_extends/modifier.script_escape.php
@@ -9,7 +9,7 @@ function smarty_modifier_script_escape($value)
 {
     if (is_array($value)) return $value;
 
-    $pattern = "/<script.*?>|<\/script>|javascript:|<svg.*on.*?>|<img.*on.*?>|<body.*onload.*?>|<iframe.*?>|<object.*?>|<embed.*?>|<.*onmouse.*?>/i";
+    $pattern = "/<script.*?>|<\/script>|javascript:|<svg.*(onload|onerror).*?>|<img.*(onload|onerror).*?>|<body.*onload.*?>|<iframe.*?>|<object.*?>|<embed.*?>|<.*onmouse.*?>/i";
     $convert = '#script tag escaped#';
 
     if (preg_match_all($pattern, $value, $matches)) {


### PR DESCRIPTION
- `<img src="Pater-Lieven-Blond.jpg">` などにもマッチしてしまうため、 `onload`,  `onerror` に対してサニタイズするよう修正
- #458