### PR TITLE
PHPUnit8以降でcompatible error出るためエラーが出ないよう対応

### DIFF
--- a/tests/class/Common_TestCase.php
+++ b/tests/class/Common_TestCase.php
@@ -41,13 +41,13 @@ class Common_TestCase extends PHPUnit_Framework_TestCase
     /** 実際の値 */
     protected $actual;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objQuery = SC_Query_Ex::getSingletonInstance('', true);
         $this->objQuery->begin();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->objQuery->rollback();
         $this->objQuery = null;

--- a/tests/class/SC_CartSession/SC_CartSessionTest.php
+++ b/tests/class/SC_CartSession/SC_CartSessionTest.php
@@ -7,13 +7,13 @@ class SC_CartSessionTest extends Common_TestCase
      */
     protected $objCartSession;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objCartSession = new SC_CartSession_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $objDb = new SC_Helper_DB_Ex();

--- a/tests/class/SC_CartSession/SC_CartSession_TestBase.php
+++ b/tests/class/SC_CartSession/SC_CartSession_TestBase.php
@@ -7,12 +7,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
  */
 class SC_CartSession_TestBase extends Common_TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_CartSession/SC_CartSession_getAllCartListTest.php
+++ b/tests/class/SC_CartSession/SC_CartSession_getAllCartListTest.php
@@ -15,13 +15,13 @@ require_once($HOME . "/tests/class/SC_CartSession/SC_CartSession_TestBase.php");
 class SC_CartSession_getAllCartListTest extends SC_CartSession_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objCartSession = new SC_CartSession_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_CartSession/SC_CartSession_getCartListTest.php
+++ b/tests/class/SC_CartSession/SC_CartSession_getCartListTest.php
@@ -15,13 +15,13 @@ require_once($HOME . "/tests/class/SC_CartSession/SC_CartSession_TestBase.php");
 class SC_CartSession_getCartListTest extends SC_CartSession_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objCartSession = new SC_CartSession_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_CheckError/SC_CheckError_ALL_EXIST_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_ALL_EXIST_CHECKTest.php
@@ -9,7 +9,7 @@ class SC_CheckError_ALL_EXIST_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var string */
     const FORM_NAME3 = 'day';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'ALL_EXIST_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_ALNUM_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_ALNUM_CHECKTest.php
@@ -2,7 +2,7 @@
 
 class SC_CheckError_ALNUM_CHECKTest extends SC_CheckError_AbstractTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'ALNUM_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_ALPHA_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_ALPHA_CHECKTest.php
@@ -2,7 +2,7 @@
 
 class SC_CheckError_ALPHA_CHECKTest extends SC_CheckError_AbstractTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'ALPHA_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_CHECK_BIRTHDAYTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_CHECK_BIRTHDAYTest.php
@@ -20,7 +20,7 @@ class SC_CheckError_CHECK_BIRTHDAYTest extends SC_CheckError_AbstractTestCase
     /** @var \DateTime */
     protected $targetDateTime;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Faker\Generator $faker */
         $faker = Faker\Factory::create('ja_JP');

--- a/tests/class/SC_CheckError/SC_CheckError_CHECK_DATE2Test.php
+++ b/tests/class/SC_CheckError/SC_CheckError_CHECK_DATE2Test.php
@@ -29,7 +29,7 @@ class SC_CheckError_CHECK_DATE2Test extends SC_CheckError_AbstractTestCase
     /** @var \DateTime */
     protected $targetDateTime;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Faker\Generator $faker */
         $faker = Faker\Factory::create('ja_JP');

--- a/tests/class/SC_CheckError/SC_CheckError_CHECK_DATE3Test.php
+++ b/tests/class/SC_CheckError/SC_CheckError_CHECK_DATE3Test.php
@@ -13,7 +13,7 @@ class SC_CheckError_CHECK_DATE3Test extends SC_CheckError_AbstractTestCase
     /** @var \DateTime */
     protected $targetDateTime;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Faker\Generator $faker */
         $faker = Faker\Factory::create('ja_JP');

--- a/tests/class/SC_CheckError/SC_CheckError_CHECK_DATETest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_CHECK_DATETest.php
@@ -17,7 +17,7 @@ class SC_CheckError_CHECK_DATETest extends SC_CheckError_AbstractTestCase
     /** @var \DateTime */
     protected $targetDateTime;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Faker\Generator $faker */
         $faker = Faker\Factory::create('ja_JP');

--- a/tests/class/SC_CheckError/SC_CheckError_CHECK_REGIST_CUSTOMER_EMAILTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_CHECK_REGIST_CUSTOMER_EMAILTest.php
@@ -9,7 +9,7 @@ class SC_CheckError_CHECK_REGIST_CUSTOMER_EMAILTest extends SC_CheckError_Abstra
     /** @var int */
     protected $customer_id;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'CHECK_REGIST_CUSTOMER_EMAIL';
@@ -25,7 +25,7 @@ class SC_CheckError_CHECK_REGIST_CUSTOMER_EMAILTest extends SC_CheckError_Abstra
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $objQuery = SC_Query_Ex::getSingletonInstance();
         $objQuery->delete('dtb_customer', 'customer_id = ?', [$this->customer_id]);

--- a/tests/class/SC_CheckError/SC_CheckError_CHECK_SET_TERM2Test.php
+++ b/tests/class/SC_CheckError/SC_CheckError_CHECK_SET_TERM2Test.php
@@ -60,7 +60,7 @@ class SC_CheckError_CHECK_SET_TERM2Test extends SC_CheckError_AbstractTestCase
     /** @var \DateTime */
     protected $targetDateTime;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Faker\Generator $faker */
         $faker = Faker\Factory::create('ja_JP');

--- a/tests/class/SC_CheckError/SC_CheckError_CHECK_SET_TERM3Test.php
+++ b/tests/class/SC_CheckError/SC_CheckError_CHECK_SET_TERM3Test.php
@@ -26,7 +26,7 @@ class SC_CheckError_CHECK_SET_TERM3Test extends SC_CheckError_AbstractTestCase
     /** @var \DateTime */
     protected $targetDateTime;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Faker\Generator $faker */
         $faker = Faker\Factory::create('ja_JP');

--- a/tests/class/SC_CheckError/SC_CheckError_CHECK_SET_TERMTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_CHECK_SET_TERMTest.php
@@ -34,7 +34,7 @@ class SC_CheckError_CHECK_SET_TERMTest extends SC_CheckError_AbstractTestCase
     /** @var \DateTime */
     protected $targetDateTime;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Faker\Generator $faker */
         $faker = Faker\Factory::create('ja_JP');

--- a/tests/class/SC_CheckError/SC_CheckError_DIFFERENT_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_DIFFERENT_CHECKTest.php
@@ -4,7 +4,7 @@ class SC_CheckError_DIFFERENT_CHECKTest extends SC_CheckError_AbstractTestCase
 {
     const FORM_NAME_REPEAT = 'form_repeat';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'DIFFERENT_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_DIR_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_DIR_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_DIR_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var string */
     protected $dirName;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'DIR_CHECK';
@@ -13,7 +13,7 @@ class SC_CheckError_DIR_CHECKTest extends SC_CheckError_AbstractTestCase
         mkdir($this->dirName);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (is_dir($this->dirName)) {
             rmdir($this->dirName);

--- a/tests/class/SC_CheckError/SC_CheckError_DOMAIN_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_DOMAIN_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_DOMAIN_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var Faker\Generator */
     protected $faker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'DOMAIN_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_EMAIL_CHAR_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_EMAIL_CHAR_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_EMAIL_CHAR_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var Faker\Generator */
     protected $faker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'EMAIL_CHAR_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_EMAIL_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_EMAIL_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_EMAIL_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var Faker\Generator */
     protected $faker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'EMAIL_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_EQUAL_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_EQUAL_CHECKTest.php
@@ -4,7 +4,7 @@ class SC_CheckError_EQUAL_CHECKTest extends SC_CheckError_AbstractTestCase
 {
     const FORM_NAME_REPEAT = 'form_repeat';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'EQUAL_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_EVAL_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_EVAL_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_EVAL_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var string */
     protected $evaluation;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'EVAL_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_EXIST_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_EXIST_CHECKTest.php
@@ -24,7 +24,7 @@
 class SC_CheckError_EXIST_CHECKTest extends SC_CheckError_AbstractTestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'EXIST_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_EXIST_CHECK_REVERSETest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_EXIST_CHECK_REVERSETest.php
@@ -24,7 +24,7 @@
 class SC_CheckError_EXIST_CHECK_REVERSETest extends SC_CheckError_AbstractTestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'EXIST_CHECK_REVERSE';

--- a/tests/class/SC_CheckError/SC_CheckError_FILE_EXIST_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_FILE_EXIST_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_FILE_EXIST_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var int */
     protected $fileSize;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'FILE_EXIST_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_FILE_EXT_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_FILE_EXT_CHECKTest.php
@@ -9,7 +9,7 @@ class SC_CheckError_FILE_EXT_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var string|null */
     protected $fileName;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'FILE_EXT_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_FILE_NAME_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_FILE_NAME_CHECKTest.php
@@ -7,7 +7,7 @@ class SC_CheckError_FILE_NAME_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var string|null */
     protected $fileName;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'FILE_NAME_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_FILE_NAME_CHECK_BY_NOUPLOADTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_FILE_NAME_CHECK_BY_NOUPLOADTest.php
@@ -24,7 +24,7 @@
 class SC_CheckError_FILE_NAME_CHECK_BY_NOUPLOADTest extends SC_CheckError_AbstractTestCase
 {
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         set_error_handler(function($errno, $errstr, $errfile, $errline) {
             throw new RuntimeException($errstr . " on line " . $errline . " in file " . $errfile);
@@ -32,7 +32,7 @@ class SC_CheckError_FILE_NAME_CHECK_BY_NOUPLOADTest extends SC_CheckError_Abstra
         $this->target_func = 'FILE_NAME_CHECK_BY_NOUPLOAD';
     }
 
-    public function tearDown() {
+    public function tearDown(): void {
         restore_error_handler();
         parent::tearDown();
     }

--- a/tests/class/SC_CheckError/SC_CheckError_FILE_SIZE_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_FILE_SIZE_CHECKTest.php
@@ -7,7 +7,7 @@ class SC_CheckError_FILE_SIZE_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var int */
     protected $maxFileSize;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'FILE_SIZE_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_FIND_FILETest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_FIND_FILETest.php
@@ -9,7 +9,7 @@ class SC_CheckError_FIND_FILETest extends SC_CheckError_AbstractTestCase
     /** @var string */
     protected $targetDir;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'FIND_FILE';

--- a/tests/class/SC_CheckError/SC_CheckError_FULL_EXIST_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_FULL_EXIST_CHECKTest.php
@@ -9,7 +9,7 @@ class SC_CheckError_FULL_EXIST_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var string */
     const FORM_NAME3 = 'day';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'FULL_EXIST_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_GRAPH_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_GRAPH_CHECKTest.php
@@ -2,7 +2,7 @@
 
 class SC_CheckError_GRAPH_CHECKTest extends SC_CheckError_AbstractTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'GRAPH_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_GREATER_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_GREATER_CHECKTest.php
@@ -4,7 +4,7 @@ class SC_CheckError_GREATER_CHECKTest extends SC_CheckError_AbstractTestCase
 {
     const FORM_NAME_REPEAT = 'form_repeat';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'GREATER_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_HTML_TAG_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_HTML_TAG_CHECKTest.php
@@ -27,7 +27,7 @@ class SC_CheckError_HTML_TAG_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var array */
     protected $arrAllowedTag;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $masterData = new SC_DB_MasterData_Ex();

--- a/tests/class/SC_CheckError/SC_CheckError_IP_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_IP_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_IP_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var Faker\Generator */
     protected $faker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'IP_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_KANABLANK_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_KANABLANK_CHECKTest.php
@@ -2,7 +2,7 @@
 
 class SC_CheckError_KANABLANK_CHECKTest extends SC_CheckError_AbstractTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'KANABLANK_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_KANA_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_KANA_CHECKTest.php
@@ -2,7 +2,7 @@
 
 class SC_CheckError_KANA_CHECKTest extends SC_CheckError_AbstractTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'KANA_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_MAX_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_MAX_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_MAX_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var int */
     protected $max;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'MAX_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_MAX_LENGTH_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_MAX_LENGTH_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_MAX_LENGTH_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var int */
     protected $maxlength;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'MAX_LENGTH_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_MIN_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_MIN_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_MIN_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var int */
     protected $min;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'MIN_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_MIN_LENGTH_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_MIN_LENGTH_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_MIN_LENGTH_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var int */
     protected $minlength;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'MIN_LENGTH_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_MOBILE_EMAIL_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_MOBILE_EMAIL_CHECKTest.php
@@ -7,7 +7,7 @@ class SC_CheckError_MOBILE_EMAIL_CHECKTest extends SC_CheckError_AbstractTestCas
     /** @var string */
     protected $mobileEmail;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'MOBILE_EMAIL_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_NO_SPTABTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_NO_SPTABTest.php
@@ -24,13 +24,13 @@
 class SC_CheckError_NO_SPTABTest extends SC_CheckError_AbstractTestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'NO_SPTAB';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_CheckError/SC_CheckError_NUM_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_NUM_CHECKTest.php
@@ -2,7 +2,7 @@
 
 class SC_CheckError_NUM_CHECKTest extends SC_CheckError_AbstractTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'NUM_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_NUM_COUNT_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_NUM_COUNT_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_NUM_COUNT_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var int */
     protected $length;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'NUM_COUNT_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_NUM_POINT_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_NUM_POINT_CHECKTest.php
@@ -2,7 +2,7 @@
 
 class SC_CheckError_NUM_POINT_CHECKTest extends SC_CheckError_AbstractTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'NUM_POINT_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_NUM_RANGE_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_NUM_RANGE_CHECKTest.php
@@ -8,7 +8,7 @@ class SC_CheckError_NUM_RANGE_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var int */
     protected $maxlength;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'NUM_RANGE_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_ONE_EXIST_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_ONE_EXIST_CHECKTest.php
@@ -9,7 +9,7 @@ class SC_CheckError_ONE_EXIST_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var string */
     const FORM_NAME3 = 'day';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'ONE_EXIST_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_PASSWORD_CHAR_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_PASSWORD_CHAR_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_PASSWORD_CHAR_CHECKTest extends SC_CheckError_AbstractTestCa
     /** @var Faker\Generator */
     protected $faker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'PASSWORD_CHAR_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_PREF_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_PREF_CHECKTest.php
@@ -7,7 +7,7 @@ class SC_CheckError_PREF_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var int */
     protected $pref_id;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'PREF_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_PROHIBITED_STR_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_PROHIBITED_STR_CHECKTest.php
@@ -8,7 +8,7 @@ class SC_CheckError_PROHIBITED_STR_CHECKTest extends SC_CheckError_AbstractTestC
     /** @var array */
     protected $denyStrings;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'PROHIBITED_STR_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_SELECT_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_SELECT_CHECKTest.php
@@ -2,7 +2,7 @@
 
 class SC_CheckError_SELECT_CHECKTest extends SC_CheckError_AbstractTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'SELECT_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_SPTAB_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_SPTAB_CHECKTest.php
@@ -24,13 +24,13 @@
 class SC_CheckError_SPTAB_CHECKTest extends SC_CheckError_AbstractTestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'SPTAB_CHECK';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_CheckError/SC_CheckError_TEL_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_TEL_CHECKTest.php
@@ -14,7 +14,7 @@ class SC_CheckError_TEL_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var int */
     protected $tel_length = 12;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'TEL_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_TOP_EXIST_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_TOP_EXIST_CHECKTest.php
@@ -9,7 +9,7 @@ class SC_CheckError_TOP_EXIST_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var string */
     const FORM_NAME3 = 'day';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'TOP_EXIST_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_URL_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_URL_CHECKTest.php
@@ -5,7 +5,7 @@ class SC_CheckError_URL_CHECKTest extends SC_CheckError_AbstractTestCase
     /** @var Faker\Generator */
     protected $faker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'URL_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_ZERO_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_ZERO_CHECKTest.php
@@ -2,7 +2,7 @@
 
 class SC_CheckError_ZERO_CHECKTest extends SC_CheckError_AbstractTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'ZERO_CHECK';

--- a/tests/class/SC_CheckError/SC_CheckError_ZERO_STARTTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_ZERO_STARTTest.php
@@ -2,7 +2,7 @@
 
 class SC_CheckError_ZERO_STARTTest extends SC_CheckError_AbstractTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target_func = 'ZERO_START';

--- a/tests/class/SC_CheckError/SC_CheckError_createParamTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_createParamTest.php
@@ -26,7 +26,7 @@ class SC_CheckError_createParamTest extends SC_CheckError_AbstractTestCase
 {
     protected $old_reporting_level;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->old_reporting_level = error_reporting();
@@ -37,7 +37,7 @@ class SC_CheckError_createParamTest extends SC_CheckError_AbstractTestCase
 
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         error_reporting($this->old_reporting_level);

--- a/tests/class/SC_CustomerListTest.php
+++ b/tests/class/SC_CustomerListTest.php
@@ -14,7 +14,7 @@ class SC_CustomerListTest extends Common_TestCase
     /** @var array */
     protected $params = [];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->faker = Faker\Factory::create('ja_JP');

--- a/tests/class/SC_CustomerTest.php
+++ b/tests/class/SC_CustomerTest.php
@@ -20,7 +20,7 @@ class SC_CustomerTest extends Common_TestCase
     /** @var SC_Customer_Ex */
     protected $objCustomer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objGenerator = new FixtureGenerator($this->objQuery);

--- a/tests/class/SC_Date/SC_Date_AccessorTest.php
+++ b/tests/class/SC_Date/SC_Date_AccessorTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Date_AccessorTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDate = new SC_Date_Ex('2010','2014');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Date/SC_Date_getDayTest.php
+++ b/tests/class/SC_Date/SC_Date_getDayTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Date_getDayTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDate = new SC_Date_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Date/SC_Date_getHourTest.php
+++ b/tests/class/SC_Date/SC_Date_getHourTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Date_getHourTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDate = new SC_Date_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Date/SC_Date_getMinutesIntervalTest.php
+++ b/tests/class/SC_Date/SC_Date_getMinutesIntervalTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Date_getMinutesIntervalTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDate = new SC_Date_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Date/SC_Date_getMinutesTest.php
+++ b/tests/class/SC_Date/SC_Date_getMinutesTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Date_getMinutesTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDate = new SC_Date_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Date/SC_Date_getMonthTest.php
+++ b/tests/class/SC_Date/SC_Date_getMonthTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Date_getMonthTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDate = new SC_Date_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Date/SC_Date_getYearTest.php
+++ b/tests/class/SC_Date/SC_Date_getYearTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Date_getYearTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDate = new SC_Date_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Date/SC_Date_getZeroMonthTest.php
+++ b/tests/class/SC_Date/SC_Date_getZeroMonthTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Date_getZeroMonthTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDate = new SC_Date_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Date/SC_Date_getZeroYearTest.php
+++ b/tests/class/SC_Date/SC_Date_getZeroYearTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Date_getZeroYearTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDate = new SC_Date_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Date/SC_Date_isHolidayTest.php
+++ b/tests/class/SC_Date/SC_Date_isHolidayTest.php
@@ -27,7 +27,7 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Date_isHolidayTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDate = new SC_Date_Ex();
@@ -74,7 +74,7 @@ class SC_Date_isHolidayTest extends Common_TestCase
         $objDb->sfGetBasisData(true);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_DisplayTest.php
+++ b/tests/class/SC_DisplayTest.php
@@ -7,7 +7,7 @@ class SC_DisplayTest extends Common_TestCase
      */
     protected $objDisplay;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/class/SC_FormParamTest.php
+++ b/tests/class/SC_FormParamTest.php
@@ -7,7 +7,7 @@ class SC_FormParamTest extends Common_TestCase
      */
     protected $objFormParam;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objFormParam = new SC_FormParam_Ex();

--- a/tests/class/SC_Product/SC_Product_TestBase.php
+++ b/tests/class/SC_Product/SC_Product_TestBase.php
@@ -7,12 +7,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
  */
 class SC_Product_TestBase extends Common_TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_findProductCountTest.php
+++ b/tests/class/SC_Product/SC_Product_findProductCountTest.php
@@ -8,14 +8,14 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_findProductCountTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpProductClass();
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_findProductIdsOrderTest.php
+++ b/tests/class/SC_Product/SC_Product_findProductIdsOrderTest.php
@@ -8,14 +8,14 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_findProductsOrderTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpProductClass();
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_getBuyLimitTest.php
+++ b/tests/class/SC_Product/SC_Product_getBuyLimitTest.php
@@ -8,13 +8,13 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_getBuyLimitTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_getDetailAndProductsClassTest.php
+++ b/tests/class/SC_Product/SC_Product_getDetailAndProductsClassTest.php
@@ -8,14 +8,14 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_getDetailAndProductsClassTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpProductClass();
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_getDetailTest.php
+++ b/tests/class/SC_Product/SC_Product_getDetailTest.php
@@ -8,14 +8,14 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_getDetailTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpProductClass();
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_getListByProductIdsTest.php
+++ b/tests/class/SC_Product/SC_Product_getListByProductIdsTest.php
@@ -8,14 +8,14 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_getListsByProductIdsTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpProductClass();
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_getProductStatusTest.php
+++ b/tests/class/SC_Product/SC_Product_getProductStatusTest.php
@@ -8,7 +8,7 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_getProductStatusTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpProductClass();
@@ -16,7 +16,7 @@ class SC_Product_getProductStatusTest extends SC_Product_TestBase
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_getProductsClassByProductIdsTest.php
+++ b/tests/class/SC_Product/SC_Product_getProductsClassByProductIdsTest.php
@@ -8,14 +8,14 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_getProductsClassByProductIdsTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpProductClass();
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_getProductsClassByQueryTest.php
+++ b/tests/class/SC_Product/SC_Product_getProductsClassByQueryTest.php
@@ -8,14 +8,14 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_getProductsClassByQueryTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpProductClass();
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_getProductsClassTest.php
+++ b/tests/class/SC_Product/SC_Product_getProductsClassTest.php
@@ -8,14 +8,14 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_getProductsClassTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpProductClass();
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_listsTest.php
+++ b/tests/class/SC_Product/SC_Product_listsTest.php
@@ -8,14 +8,14 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_listsTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpProductClass();
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_reduceStockTest.php
+++ b/tests/class/SC_Product/SC_Product_reduceStockTest.php
@@ -8,14 +8,14 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_reduceStockTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpProductClass();
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_setProductStatusTest.php
+++ b/tests/class/SC_Product/SC_Product_setProductStatusTest.php
@@ -8,7 +8,7 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_setProductStatusTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpProductClass();
@@ -16,7 +16,7 @@ class SC_Product_setProductStatusTest extends SC_Product_TestBase
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Product/SC_Product_setProductsOrderTest.php
+++ b/tests/class/SC_Product/SC_Product_setProductsOrderTest.php
@@ -8,13 +8,13 @@ require_once($HOME . "/tests/class/SC_Product/SC_Product_TestBase.php");
 class SC_Product_setProductsOrderTest extends SC_Product_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objProducts = new SC_Product_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_Query_Test.php
+++ b/tests/class/SC_Query_Test.php
@@ -50,13 +50,13 @@ class SC_Query_Test extends PHPUnit_Framework_TestCase
     protected $expected;
     protected $actual;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objQuery = SC_Query_Ex::getSingletonInstance();
         $this->objQuery->begin();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         // MySQL では CREATE TABLE がロールバックされないので DROP TABLE を行う
         $this->dropTestTable();

--- a/tests/class/SC_SendMailTest.php
+++ b/tests/class/SC_SendMailTest.php
@@ -7,7 +7,7 @@ class SC_SendMailTest extends Common_TestCase
      */
     protected $objSendMail;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->checkMailCatcherStatus();

--- a/tests/class/SC_SessionTest.php
+++ b/tests/class/SC_SessionTest.php
@@ -8,7 +8,7 @@ class SC_SessionTest extends Common_TestCase
      */
     protected $objSession;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $_SESSION['cert'] = CERT_STRING;

--- a/tests/class/SC_SiteSession/SC_SiteSession_checkUniqIdTest.php
+++ b/tests/class/SC_SiteSession/SC_SiteSession_checkUniqIdTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Session_checkUniqIdTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objSiteSession = new SC_SiteSession_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_SiteSession/SC_SiteSession_getUniqIdTest.php
+++ b/tests/class/SC_SiteSession/SC_SiteSession_getUniqIdTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Session_getUniqIdTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objSiteSession = new SC_SiteSession_Mock();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_SiteSession/SC_SiteSession_getValueTest.php
+++ b/tests/class/SC_SiteSession/SC_SiteSession_getValueTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Session_getValueTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objSiteSession = new SC_SiteSession_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_SiteSession/SC_SiteSession_isPrepageTest.php
+++ b/tests/class/SC_SiteSession/SC_SiteSession_isPrepageTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Session_isPrepageTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objSiteSession = new SC_SiteSession_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_SiteSession/SC_SiteSession_setNowPageTest.php
+++ b/tests/class/SC_SiteSession/SC_SiteSession_setNowPageTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Session_setNowPageTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objSiteSession = new SC_SiteSession_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_SiteSession/SC_SiteSession_setRegistFlagTest.php
+++ b/tests/class/SC_SiteSession/SC_SiteSession_setRegistFlagTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Session_setRegistFlagTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objSiteSession = new SC_SiteSession_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_SiteSession/SC_SiteSession_setUniqIdTest.php
+++ b/tests/class/SC_SiteSession/SC_SiteSession_setUniqIdTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Session_setUniqIdTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objSiteSession = new SC_SiteSession_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_SiteSession/SC_SiteSession_unsetUniqIdTest.php
+++ b/tests/class/SC_SiteSession/SC_SiteSession_unsetUniqIdTest.php
@@ -27,13 +27,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Session_unsetUniqIdTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objSiteSession = new SC_SiteSession_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_SmartphoneUserAgent/SC_SmartphoneUserAgent_isSmartphoneTest.php
+++ b/tests/class/SC_SmartphoneUserAgent/SC_SmartphoneUserAgent_isSmartphoneTest.php
@@ -33,13 +33,13 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_SmartphoneUserAgent_isSmartphoneTest extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->su = new SC_SmartphoneUserAgent_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/SC_UploadFileTest.php
+++ b/tests/class/SC_UploadFileTest.php
@@ -9,7 +9,7 @@ class SC_UploadFileTest extends Common_TestCase
     /** @var string */
     protected $tempDir;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->saveDir = sys_get_temp_dir().'/'.uniqid();
@@ -29,7 +29,7 @@ class SC_UploadFileTest extends Common_TestCase
         ];
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach ([$this->saveDir, $this->tempDir] as $dir) {
             $files = new RecursiveIteratorIterator(

--- a/tests/class/helper/SC_Helper_Address/SC_Helper_Address_TestBase.php
+++ b/tests/class/helper/SC_Helper_Address/SC_Helper_Address_TestBase.php
@@ -7,12 +7,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
  */
 class SC_Helper_Address_TestBase extends Common_TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_Address/SC_Helper_Address_deleteAddressTest.php
+++ b/tests/class/helper/SC_Helper_Address/SC_Helper_Address_deleteAddressTest.php
@@ -8,7 +8,7 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Address/SC_Helper_Address_Te
 class SC_Helper_Address_deleteAddressTest extends SC_Helper_Address_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objAddress = new SC_Helper_Address_Ex();

--- a/tests/class/helper/SC_Helper_Address/SC_Helper_Address_getAddressTest.php
+++ b/tests/class/helper/SC_Helper_Address/SC_Helper_Address_getAddressTest.php
@@ -8,7 +8,7 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Address/SC_Helper_Address_Te
 class SC_Helper_Address_getAddressTest extends SC_Helper_Address_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objAddress = new SC_Helper_Address_Ex();

--- a/tests/class/helper/SC_Helper_Address/SC_Helper_Address_getListTest.php
+++ b/tests/class/helper/SC_Helper_Address/SC_Helper_Address_getListTest.php
@@ -8,7 +8,7 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Address/SC_Helper_Address_Te
 class SC_Helper_Address_getListTest extends SC_Helper_Address_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objAddress = new SC_Helper_Address_Ex();

--- a/tests/class/helper/SC_Helper_Address/SC_Helper_Address_registAddressTest.php
+++ b/tests/class/helper/SC_Helper_Address/SC_Helper_Address_registAddressTest.php
@@ -8,7 +8,7 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Address/SC_Helper_Address_Te
 class SC_Helper_Address_registAddressTest extends SC_Helper_Address_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objAddress = new SC_Helper_Address_Ex();

--- a/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_TestBase.php
+++ b/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_TestBase.php
@@ -33,12 +33,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Helper_BestProducts_TestBase extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_deleteBestProductsTest.php
+++ b/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_deleteBestProductsTest.php
@@ -31,13 +31,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestP
  */
 class SC_Helper_BestProducts_deleteBestProductsTest extends SC_Helper_BestProducts_TestBase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpBestProducts();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_deleteByProductIDsTest.php
+++ b/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_deleteByProductIDsTest.php
@@ -30,13 +30,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestP
  */
 class SC_Helper_BestProducts_deleteByProductIDsTest extends SC_Helper_BestProducts_TestBase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpBestProducts();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_getBestProductsTest.php
+++ b/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_getBestProductsTest.php
@@ -31,13 +31,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestP
  */
 class SC_Helper_BestProducts_getBestProductsTest extends SC_Helper_BestProducts_TestBase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpBestProducts();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_getByRankTest.php
+++ b/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_getByRankTest.php
@@ -31,13 +31,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestP
  */
 class SC_Helper_BestProducts_getByRankTest extends SC_Helper_BestProducts_TestBase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpBestProducts();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_getListTest.php
+++ b/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_getListTest.php
@@ -31,12 +31,12 @@ require_once($HOME . "/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestP
  */
 class SC_Helper_BestProducts_getListTest extends SC_Helper_BestProducts_TestBase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_rankDownTest.php
+++ b/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_rankDownTest.php
@@ -30,13 +30,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestP
  */
 class SC_Helper_BestProducts_rankDownTest extends SC_Helper_BestProducts_TestBase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpBestProducts();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_rankUpTest.php
+++ b/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_rankUpTest.php
@@ -30,13 +30,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestP
  */
 class SC_Helper_BestProducts_rankUpTest extends SC_Helper_BestProducts_TestBase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpBestProducts();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_saveBestProductsTest.php
+++ b/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestProducts_saveBestProductsTest.php
@@ -31,13 +31,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_BestProducts/SC_Helper_BestP
  */
 class SC_Helper_BestProducts_saveBestProductsTest extends SC_Helper_BestProducts_TestBase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpBestProducts();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_TestBase.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_TestBase.php
@@ -36,13 +36,13 @@ class SC_Helper_DB_TestBase extends Common_TestCase
   /** @var FixtureGenerator */
   protected $objGenerator;
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->objGenerator = new FixtureGenerator($this->objQuery);
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_registerBasisDataTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_registerBasisDataTest.php
@@ -10,7 +10,7 @@ class SC_Helper_DB_registerBasisDataTest extends SC_Helper_DB_TestBase
     /** @var Faker\Generator */
     protected $faker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->faker = Faker\Factory::create('ja_JP');

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfColumnAddTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfColumnAddTest.php
@@ -33,13 +33,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_DB/SC_Helper_DB_TestBase.php
 class SC_Helper_DB_sfColumnAdd extends SC_Helper_DB_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->helper = new SC_Helper_DB_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfColumnExistsTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfColumnExistsTest.php
@@ -33,13 +33,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_DB/SC_Helper_DB_TestBase.php
 class SC_Helper_DB_sfColumnExists extends SC_Helper_DB_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->helper = new SC_Helper_DB_sfColumnExistsMock();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfCountCategoryTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfCountCategoryTest.php
@@ -10,7 +10,7 @@ class SC_Helper_DB_sfCountCategoryTest extends SC_Helper_DB_TestBase
     /** @var int[] */
     protected $category_ids;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDb = new SC_Helper_DB_Ex();

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfCountMakerTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfCountMakerTest.php
@@ -12,7 +12,7 @@ class SC_Helper_DB_sfCountMakerTest extends SC_Helper_DB_TestBase
     /** @var Faker\Generator */
     protected $faker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDb = new SC_Helper_DB_Ex();

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfCreateBasisDataCacheTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfCreateBasisDataCacheTest.php
@@ -33,14 +33,14 @@ require_once($HOME . "/tests/class/helper/SC_Helper_DB/SC_Helper_DB_TestBase.php
 class SC_Helper_DB_sfCreateBasisDataCache extends SC_Helper_DB_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->helper = new SC_Helper_DB_sfCreateBasisDataCacheMock();
         $this->cashFilePath = MASTER_DATA_REALDIR . 'dtb_baseinfo.serial';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfDataExistsTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfDataExistsTest.php
@@ -33,13 +33,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_DB/SC_Helper_DB_TestBase.php
 class SC_Helper_DB_sfDataExists extends SC_Helper_DB_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->helper = new SC_Helper_DB_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetAddPointTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetAddPointTest.php
@@ -5,7 +5,7 @@ class SC_Helper_DB_sfGetAddPointTest extends SC_Helper_DB_TestBase
     /** @var int */
     const POINT_RATE = 4;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objQuery->update('dtb_baseinfo', ['point_rate' => self::POINT_RATE], 'id = 1');

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetBasisCountTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetBasisCountTest.php
@@ -33,13 +33,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_DB/SC_Helper_DB_TestBase.php
 class SC_Helper_DB_sfGetBasisCount extends SC_Helper_DB_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->helper = new SC_Helper_DB_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetBasisDataCacheTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetBasisDataCacheTest.php
@@ -33,13 +33,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_DB/SC_Helper_DB_TestBase.php
 class SC_Helper_DB_sfGetBasisDataCache extends SC_Helper_DB_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->cashFilePath = MASTER_DATA_REALDIR . 'dtb_baseinfo.serial';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetBasisDataTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetBasisDataTest.php
@@ -33,13 +33,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_DB/SC_Helper_DB_TestBase.php
 class SC_Helper_DB_sfGetBasisData extends SC_Helper_DB_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->helper = new SC_Helper_DB_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetBasisExistsTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetBasisExistsTest.php
@@ -33,13 +33,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_DB/SC_Helper_DB_TestBase.php
 class SC_Helper_DB_sfGetBasisExists extends SC_Helper_DB_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->helper = new SC_Helper_DB_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetCatTreeTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetCatTreeTest.php
@@ -5,7 +5,7 @@ class SC_Helper_DB_sfGetCatTreeTest extends SC_Helper_DB_TestBase
     /** @var int[] */
     protected $category_ids;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->category_ids = $this->objGenerator->createCategories();

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetCategoryIdTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetCategoryIdTest.php
@@ -10,7 +10,7 @@ class SC_Helper_DB_sfGetCategoryIdTest extends SC_Helper_DB_TestBase
     /** @var int */
     protected $category_id;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDb = new SC_Helper_DB_Ex();

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetCategoryListTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetCategoryListTest.php
@@ -5,7 +5,7 @@ class SC_Helper_DB_sfGetCategoryListTest extends SC_Helper_DB_TestBase
     /** @var SC_Helper_DB */
     protected $objDb;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDb = new SC_Helper_DB_Ex();

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetChildrenArrayTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetChildrenArrayTest.php
@@ -7,7 +7,7 @@ class SC_Helper_DB_sfGetChildrenArrayTest extends SC_Helper_DB_TestBase
     /** @var int[] */
     protected $category_ids;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDb = new SC_Helper_DB_Ex();

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetIDValueListTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetIDValueListTest.php
@@ -9,7 +9,7 @@ class SC_Helper_DB_sfGetIDValueListTest extends SC_Helper_DB_TestBase
     /** @var Faker\Generator */
     protected $faker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->faker = Faker\Factory::create('ja_JP');

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetLevelCatListTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetLevelCatListTest.php
@@ -2,7 +2,7 @@
 
 class SC_Helper_DB_sfGetLevelCatListTest extends SC_Helper_DB_TestBase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objQuery->delete('dtb_category');

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetMakerIdTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetMakerIdTest.php
@@ -11,7 +11,7 @@ class SC_Helper_DB_sfGetMakerIdTest extends SC_Helper_DB_TestBase
     /** @var Faker\Generator */
     protected $faker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDb = new SC_Helper_DB_Ex();

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetMultiCatTreeTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetMultiCatTreeTest.php
@@ -2,7 +2,7 @@
 
 class SC_Helper_DB_sfGetMultiCatTreeTest extends SC_Helper_DB_TestBase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetParentsArrayTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetParentsArrayTest.php
@@ -7,7 +7,7 @@ class SC_Helper_DB_sfGetParentsArrayTest extends SC_Helper_DB_TestBase
     /** @var int[] */
     protected $category_ids;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDb = new SC_Helper_DB_Ex();

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetRollbackPointTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfGetRollbackPointTest.php
@@ -15,7 +15,7 @@ class SC_Helper_DB_sfGetRollbackPointTest extends SC_Helper_DB_TestBase
     /** @var int */
     protected $rollback_point;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->customer_id = $this->objGenerator->createCustomer();

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfHasProductClassTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfHasProductClassTest.php
@@ -5,7 +5,7 @@ class SC_Helper_DB_sfHasProductClassTest extends SC_Helper_DB_TestBase
     /** @var SC_Helper_DB_Ex */
     protected $objDb;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDb = new SC_Helper_DB_Ex();

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfMoveRankTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_sfMoveRankTest.php
@@ -35,13 +35,13 @@ class SC_Helper_DB_sfMoveRank extends SC_Helper_DB_TestBase
     /** @var SC_Helper_DB_Ex */
     protected $helper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->helper = new SC_Helper_DB_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_DB/SC_Helper_DB_updateProductCategoriesTest.php
+++ b/tests/class/helper/SC_Helper_DB/SC_Helper_DB_updateProductCategoriesTest.php
@@ -10,7 +10,7 @@ class SC_Helper_DB_updateProductCategoriesTest extends SC_Helper_DB_TestBase
     /** @var int */
     protected $category_id;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objDb = new SC_Helper_DB_Ex();

--- a/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_TestBase.php
+++ b/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_TestBase.php
@@ -7,12 +7,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
  */
 class SC_Helper_Kiyaku_TestBase extends Common_TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_deleteKiyakuTest.php
+++ b/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_deleteKiyakuTest.php
@@ -8,7 +8,7 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_Test
 class SC_Helper_Kiyaku_deleteKiyakuTest extends SC_Helper_Kiyaku_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objKiyaku = new SC_Helper_Kiyaku_Ex();

--- a/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_getKiyakuTest.php
+++ b/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_getKiyakuTest.php
@@ -8,7 +8,7 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_Test
 class SC_Helper_Kiyaku_getKiyakuTest extends SC_Helper_Kiyaku_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objKiyaku = new SC_Helper_Kiyaku_Ex();

--- a/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_getListTest.php
+++ b/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_getListTest.php
@@ -8,7 +8,7 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_Test
 class SC_Helper_Kiyaku_getListTest extends SC_Helper_Kiyaku_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objKiyaku = new SC_Helper_Kiyaku_Ex();

--- a/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_isTitleExistTest.php
+++ b/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_isTitleExistTest.php
@@ -8,13 +8,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_Test
 class SC_Helper_Kiyaku_isTitleExistTest extends SC_Helper_Kiyaku_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objKiyaku = new SC_Helper_Kiyaku_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_rankDownTest.php
+++ b/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_rankDownTest.php
@@ -8,13 +8,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_Test
 class SC_Helper_Kiyaku_rankDownTest extends SC_Helper_Kiyaku_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objKiyaku = new SC_Helper_Kiyaku_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_rankUpTest.php
+++ b/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_rankUpTest.php
@@ -8,7 +8,7 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_Test
 class SC_Helper_Kiyaku_rankUpTest extends SC_Helper_Kiyaku_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objKiyaku = new SC_Helper_Kiyaku_Ex();

--- a/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_saveKiyakuTest.php
+++ b/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_saveKiyakuTest.php
@@ -8,13 +8,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Kiyaku/SC_Helper_Kiyaku_Test
 class SC_Helper_Kiyaku_saveKiyakuTest extends SC_Helper_Kiyaku_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objKiyaku = new SC_Helper_Kiyaku_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_Maker/SC_Helper_Maker_TestBase.php
+++ b/tests/class/helper/SC_Helper_Maker/SC_Helper_Maker_TestBase.php
@@ -33,12 +33,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Helper_Maker_TestBase extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_Maker/SC_Helper_Maker_getByNameTest.php
+++ b/tests/class/helper/SC_Helper_Maker/SC_Helper_Maker_getByNameTest.php
@@ -34,14 +34,14 @@ class SC_Helper_Maker_getByNameTest extends SC_Helper_Maker_TestBase
 
     var $objHelperMaker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpMaker();
         $this->objHelperMaker = new SC_Helper_Maker_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_Maker/SC_Helper_Maker_getListTest.php
+++ b/tests/class/helper/SC_Helper_Maker/SC_Helper_Maker_getListTest.php
@@ -34,14 +34,14 @@ class SC_Helper_Maker_getListTest extends SC_Helper_Maker_TestBase
 
     var $objHelperMaker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objHelperMaker = new SC_Helper_Maker_Ex();
         $this->setUpMaker();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_Maker/SC_Helper_Maker_getMakerTest.php
+++ b/tests/class/helper/SC_Helper_Maker/SC_Helper_Maker_getMakerTest.php
@@ -34,14 +34,14 @@ class SC_Helper_Maker_getMakerTest extends SC_Helper_Maker_TestBase
 
     var $objHelperMaker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setUpMaker();
         $this->objHelperMaker = new SC_Helper_Maker_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_Maker/SC_Helper_Maker_saveMakerTest.php
+++ b/tests/class/helper/SC_Helper_Maker/SC_Helper_Maker_saveMakerTest.php
@@ -32,7 +32,7 @@ class SC_Helper_Maker_saveMakerTest extends SC_Helper_Maker_TestBase
 {
     var $objHelperMaker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
 
         parent::setUp();
@@ -40,7 +40,7 @@ class SC_Helper_Maker_saveMakerTest extends SC_Helper_Maker_TestBase
         $this->objHelperMaker = new SC_Helper_Maker_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_News/SC_Helper_News_TestBase.php
+++ b/tests/class/helper/SC_Helper_News/SC_Helper_News_TestBase.php
@@ -33,12 +33,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Helper_News_TestBase extends Common_TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_News/SC_Helper_News_deleteNewsTest.php
+++ b/tests/class/helper/SC_Helper_News/SC_Helper_News_deleteNewsTest.php
@@ -8,13 +8,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_News/SC_Helper_News_TestBase
 class SC_Helper_News_deleteNewsTest extends SC_Helper_News_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objNews = new SC_Helper_News_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_News/SC_Helper_News_getCountTest.php
+++ b/tests/class/helper/SC_Helper_News/SC_Helper_News_getCountTest.php
@@ -8,13 +8,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_News/SC_Helper_News_TestBase
 class SC_Helper_News_getCount extends SC_Helper_News_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objNews = new SC_Helper_News_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_News/SC_Helper_News_getListTest.php
+++ b/tests/class/helper/SC_Helper_News/SC_Helper_News_getListTest.php
@@ -8,13 +8,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_News/SC_Helper_News_TestBase
 class SC_Helper_News_getListTest extends SC_Helper_News_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objNews = new SC_Helper_News_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_News/SC_Helper_News_getNewsTest.php
+++ b/tests/class/helper/SC_Helper_News/SC_Helper_News_getNewsTest.php
@@ -8,13 +8,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_News/SC_Helper_News_TestBase
 class SC_Helper_News_getNewsTest extends SC_Helper_News_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objNews = new SC_Helper_News_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_News/SC_Helper_News_moveRankTest.php
+++ b/tests/class/helper/SC_Helper_News/SC_Helper_News_moveRankTest.php
@@ -8,13 +8,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_News/SC_Helper_News_TestBase
 class SC_Helper_News_moveRankTest extends SC_Helper_News_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objNews = new SC_Helper_News_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_News/SC_Helper_News_rankDownTest.php
+++ b/tests/class/helper/SC_Helper_News/SC_Helper_News_rankDownTest.php
@@ -8,13 +8,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_News/SC_Helper_News_TestBase
 class SC_Helper_News_rankDownTest extends SC_Helper_News_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objNews = new SC_Helper_News_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_News/SC_Helper_News_rankUpTest.php
+++ b/tests/class/helper/SC_Helper_News/SC_Helper_News_rankUpTest.php
@@ -8,13 +8,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_News/SC_Helper_News_TestBase
 class SC_Helper_News_rankUpTest extends SC_Helper_News_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objNews = new SC_Helper_News_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_News/SC_Helper_News_saveNewsTest.php
+++ b/tests/class/helper/SC_Helper_News/SC_Helper_News_saveNewsTest.php
@@ -8,13 +8,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_News/SC_Helper_News_TestBase
 class SC_Helper_News_saveNewsTest extends SC_Helper_News_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objNews = new SC_Helper_News_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_TestBase.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_TestBase.php
@@ -35,13 +35,13 @@ class SC_Helper_Purchase_TestBase extends Common_TestCase
   /** @var FixtureGenerator */
   protected $objGenerator;
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->objGenerator = new FixtureGenerator($this->objQuery);
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_cancelOrderTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_cancelOrderTest.php
@@ -36,7 +36,7 @@ class SC_Helper_Purchase_cancelOrderTest extends SC_Helper_Purchase_TestBase
   private $arrProductsClasses;
   private $helper;
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $product_id = $this->objGenerator->createProduct(null, 2);
@@ -45,7 +45,7 @@ class SC_Helper_Purchase_cancelOrderTest extends SC_Helper_Purchase_TestBase
     $this->helper = new SC_Helper_Purchase_cancelOrderMock();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_cleanupSessionTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_cleanupSessionTest.php
@@ -37,7 +37,7 @@ class SC_Helper_Purchase_cleanupSessionTest extends SC_Helper_Purchase_TestBase
   private $product_class_id1;
     /** @var int */
   private $product_class_id2;
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $product_id1 = $this->objGenerator->createProduct(null, 3, PRODUCT_TYPE_NORMAL);
@@ -47,7 +47,7 @@ class SC_Helper_Purchase_cleanupSessionTest extends SC_Helper_Purchase_TestBase
 
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_clearShipmentItemTempTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_clearShipmentItemTempTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_
 class SC_Helper_Purchase_clearShipmentItemTempTest extends SC_Helper_Purchase_TestBase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_completeOrderTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_completeOrderTest.php
@@ -41,7 +41,7 @@ class SC_Helper_Purchase_completeOrderTest extends SC_Helper_Purchase_TestBase
   private $order_temp_ids = [];
   private $helper;
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->customer_ids = $this->setUpCustomer();
@@ -61,7 +61,7 @@ class SC_Helper_Purchase_completeOrderTest extends SC_Helper_Purchase_TestBase
     $this->helper = new SC_Helper_Purchase_completeOrderMock();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_copyFromCustomerTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_copyFromCustomerTest.php
@@ -37,7 +37,7 @@ class SC_Helper_Purchase_copyFromCustomerTest extends SC_Helper_Purchase_TestBas
   var $customer;
   var $customer_array;
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->customer = new SC_Customer_Ex();
@@ -65,7 +65,7 @@ class SC_Helper_Purchase_copyFromCustomerTest extends SC_Helper_Purchase_TestBas
     $this->customer_array = array('customer_id' => '1001', 'email' => 'test@example.com');
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_copyFromOrderTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_copyFromOrderTest.php
@@ -35,12 +35,12 @@ class SC_Helper_Purchase_copyFromOrderTest extends SC_Helper_Purchase_TestBase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_extractShippingTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_extractShippingTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_
 class SC_Helper_Purchase_extractShippingTest extends SC_Helper_Purchase_TestBase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getOrderDetailTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getOrderDetailTest.php
@@ -38,14 +38,14 @@ class SC_Helper_Purchase_getOrderDetailTest extends SC_Helper_Purchase_TestBase
   /** @var array */
   private $order_ids = [];
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->customer_ids = $this->setUpCustomer();
     $this->order_ids = $this->setUpOrder($this->customer_ids, [1, 2, 3, 4, 5]);
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getOrderTempTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getOrderTempTest.php
@@ -40,7 +40,7 @@ class SC_Helper_Purchase_getOrderTempTest extends SC_Helper_Purchase_TestBase
   /** @var array */
   private $order_temp_ids = [];
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->customer_ids = $this->setUpCustomer();
@@ -48,7 +48,7 @@ class SC_Helper_Purchase_getOrderTempTest extends SC_Helper_Purchase_TestBase
     $this->order_temp_ids = $this->setUpOrderTemp($this->order_ids);
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getOrderTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getOrderTest.php
@@ -38,14 +38,14 @@ class SC_Helper_Purchase_getOrderTest extends SC_Helper_Purchase_TestBase
   /** @var array */
   private $order_ids = [];
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->customer_ids = $this->setUpCustomer();
     $this->order_ids = $this->setUpOrder($this->customer_ids);
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getShipmentItemsTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getShipmentItemsTest.php
@@ -37,7 +37,7 @@ class SC_Helper_Purchase_getShipmentItemsTest extends SC_Helper_Purchase_TestBas
   private $customer_ids = [];
   /** @var array */
   private $order_ids = [];
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
 
@@ -45,7 +45,7 @@ class SC_Helper_Purchase_getShipmentItemsTest extends SC_Helper_Purchase_TestBas
     $this->order_ids = $this->setUpOrder($this->customer_ids, [1, 2]);
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getShippingPrefTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getShippingPrefTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_
 class SC_Helper_Purchase_getShippingPrefTest extends SC_Helper_Purchase_TestBase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getShippingTempTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getShippingTempTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_
 class SC_Helper_Purchase_getShippingTempTest extends SC_Helper_Purchase_TestBase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getShippingsTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_getShippingsTest.php
@@ -38,14 +38,14 @@ class SC_Helper_Purchase_getShippingsTest extends SC_Helper_Purchase_TestBase
   /** @var array */
   private $order_ids = [];
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->customer_ids = $this->setUpCustomer();
     $this->order_ids = $this->setUpOrder($this->customer_ids);
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_isAddPointTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_isAddPointTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_
 class SC_Helper_Purchase_isAddPointTest extends SC_Helper_Purchase_TestBase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_isUsePointTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_isUsePointTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_
 class SC_Helper_Purchase_isUsePointTest extends SC_Helper_Purchase_TestBase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_registerOrderCompleteTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_registerOrderCompleteTest.php
@@ -42,7 +42,7 @@ class SC_Helper_Purchase_registerOrderCompleteTest extends SC_Helper_Purchase_Te
   private $order_temp_ids = [];
   private $helper;
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->customer_ids = $this->setUpCustomer();
@@ -51,7 +51,7 @@ class SC_Helper_Purchase_registerOrderCompleteTest extends SC_Helper_Purchase_Te
     $this->helper = new SC_Helper_Purchase_registerOrderCompleteMock();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_registerOrderDetailTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_registerOrderDetailTest.php
@@ -36,14 +36,14 @@ class SC_Helper_Purchase_registerOrderDetailTest extends SC_Helper_Purchase_Test
   private $customer_ids = [];
   /** @var array */
   private $order_ids = [];
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->customer_ids = $this->setUpCustomer();
     $this->order_ids = $this->setUpOrder($this->customer_ids);
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_registerOrderTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_registerOrderTest.php
@@ -39,7 +39,7 @@ class SC_Helper_Purchase_registerOrderTest extends SC_Helper_Purchase_TestBase
     private $order_ids = [];
     private $helper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->customer_ids = $this->setUpCustomer();
@@ -47,7 +47,7 @@ class SC_Helper_Purchase_registerOrderTest extends SC_Helper_Purchase_TestBase
         $this->helper = new SC_Helper_Purchase_registerOrderMock();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_registerShipmentItemTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_registerShipmentItemTest.php
@@ -38,14 +38,14 @@ class SC_Helper_Purchase_registerShipmentItemTest extends SC_Helper_Purchase_Tes
   /** @var array */
   private $order_ids = [];
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->customer_ids = $this->setUpCustomer();
     $this->order_ids = $this->setUpOrder($this->customer_ids, [1, 2]);
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_registerShippingTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_registerShippingTest.php
@@ -34,13 +34,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_
 class SC_Helper_Purchase_registerShippingTest extends SC_Helper_Purchase_TestBase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->setUpShippingOnDb();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_rollbackOrderTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_rollbackOrderTest.php
@@ -35,14 +35,14 @@ class SC_Helper_Purchase_rollbackOrderTest extends SC_Helper_Purchase_TestBase
 
   private $helper;
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
 
     $this->helper = new SC_Helper_Purchase_rollbackOrderMock();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_saveOrderTempTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_saveOrderTempTest.php
@@ -41,7 +41,7 @@ class SC_Helper_Purchase_saveOrderTempTest extends SC_Helper_Purchase_TestBase
   private $order_temp_ids = [];
   private $helper;
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->objQuery->delete('dtb_order_temp');
@@ -51,7 +51,7 @@ class SC_Helper_Purchase_saveOrderTempTest extends SC_Helper_Purchase_TestBase
     $this->helper = new SC_Helper_Purchase_saveOrderTempMock();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_saveShippingTempTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_saveShippingTempTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_
 class SC_Helper_Purchase_saveShippingTempTest extends SC_Helper_Purchase_TestBase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_setDownloadableFlgToTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_setDownloadableFlgToTest.php
@@ -35,12 +35,12 @@ class SC_Helper_Purchase_setDownloadableFlgToTest extends SC_Helper_Purchase_Tes
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_setShipmentItemTempForSoleTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_setShipmentItemTempForSoleTest.php
@@ -35,12 +35,12 @@ class SC_Helper_Purchase_setShipmentItemTempForSoleTest extends SC_Helper_Purcha
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
     $_SESSION['testResult'] = null;

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_setShipmentItemTempTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_setShipmentItemTempTest.php
@@ -39,7 +39,7 @@ class SC_Helper_Purchase_setShipmentItemTempTest extends SC_Helper_Purchase_Test
   private $productsClass;
   private $helper;
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
 
@@ -53,7 +53,7 @@ class SC_Helper_Purchase_setShipmentItemTempTest extends SC_Helper_Purchase_Test
     $this->helper = new SC_Helper_Purchase_Ex();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_sfUpdateOrderNameColTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_sfUpdateOrderNameColTest.php
@@ -41,7 +41,7 @@ class SC_Helper_Purchase_sfUpdateOrderNameColTest extends SC_Helper_Purchase_Tes
   /** @var array */
   private $order_temp_ids = [];
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
 
@@ -52,7 +52,7 @@ class SC_Helper_Purchase_sfUpdateOrderNameColTest extends SC_Helper_Purchase_Tes
     $this->helper = new SC_Helper_Purchase_Ex();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_sfUpdateOrderStatusTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_sfUpdateOrderStatusTest.php
@@ -38,7 +38,7 @@ class SC_Helper_Purchase_sfUpdateOrderStatusTest extends SC_Helper_Purchase_Test
   /** @var array */
   private $order_ids = [];
   private $helper;
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->customer_ids = $this->setUpCustomer();
@@ -46,7 +46,7 @@ class SC_Helper_Purchase_sfUpdateOrderStatusTest extends SC_Helper_Purchase_Test
     $this->helper = new SC_Helper_Purchase_sfUpdateOrderStatusMock();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_unsetAllShippingTempTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_unsetAllShippingTempTest.php
@@ -34,7 +34,7 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_
 class SC_Helper_Purchase_unsetAllShippingTempTest extends SC_Helper_Purchase_TestBase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
 
@@ -43,7 +43,7 @@ class SC_Helper_Purchase_unsetAllShippingTempTest extends SC_Helper_Purchase_Tes
     $_SESSION['multiple_temp'] = 'temp02';
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_unsetOneShippingTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_unsetOneShippingTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_
 class SC_Helper_Purchase_unsetOneShippingTempTest extends SC_Helper_Purchase_TestBase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_unsetShippingTempTest.php
+++ b/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_unsetShippingTempTest.php
@@ -34,7 +34,7 @@ require_once($HOME . "/tests/class/helper/SC_Helper_Purchase/SC_Helper_Purchase_
 class SC_Helper_Purchase_unsetShippingTempTest extends SC_Helper_Purchase_TestBase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
 
@@ -43,7 +43,7 @@ class SC_Helper_Purchase_unsetShippingTempTest extends SC_Helper_Purchase_TestBa
     $_SESSION['multiple_temp'] = 'temp02';
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_TestBase.php
+++ b/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_TestBase.php
@@ -36,12 +36,12 @@ class SC_Helper_TaxRule_TestBase extends Common_TestCase
      */
     protected $objTaxRule;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxRuleTest.php
+++ b/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxRuleTest.php
@@ -8,14 +8,14 @@ require_once($HOME . "/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_Te
 class SC_Helper_TaxRule_getTaxRuleTest extends SC_Helper_TaxRule_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objTaxRule = new SC_Helper_TaxRule_Ex();
         $this->setUpTax();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxRule_OptionProductTaxRuleTest.php
+++ b/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxRule_OptionProductTaxRuleTest.php
@@ -9,14 +9,14 @@ class SC_Helper_TaxRule_getTaxRule_OptionProductTaxRuleTest extends SC_Helper_Ta
      */
     const OPTION_PRODUCT_TAX_RULE_ENABLE = 1;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objTaxRule = new SC_Helper_TaxRule_Ex();
         $this->setUpTax();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_setTaxRuleTest.php
+++ b/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_setTaxRuleTest.php
@@ -6,13 +6,13 @@ require_once($HOME . "/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_Te
 class SC_Helper_TaxRule_setTaxRuleTest extends SC_Helper_TaxRule_TestBase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->objTaxRule = new SC_Helper_TaxRule_Ex();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/class/module/Calendar/CalendarTest.php
+++ b/tests/class/module/Calendar/CalendarTest.php
@@ -16,11 +16,11 @@ class Calendar_Test extends Common_TestCase
     {
         $this->UnitTestCase('Test of Month Weekdays');
     }
-    public function setUp()
+    public function setUp(): void
     {
         $this->cal = new Calendar_Month_Weekdays(2003,10);
     }
-    public function tearDown()
+    public function tearDown(): void
     {
     }
     public function testPrevDay()

--- a/tests/class/pages/admin/products/LC_Page_Admin_Products_UploadCSVTest.php
+++ b/tests/class/pages/admin/products/LC_Page_Admin_Products_UploadCSVTest.php
@@ -7,7 +7,7 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
  */
 class LC_Page_Admin_Products_UploadCSVTest extends Common_TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if ('\\' !== DIRECTORY_SEPARATOR) {
@@ -15,7 +15,7 @@ class LC_Page_Admin_Products_UploadCSVTest extends Common_TestCase
         }
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         // ロケールを初期化する

--- a/tests/class/plugin/LoadClassFileChangeCustomDirTest.php
+++ b/tests/class/plugin/LoadClassFileChangeCustomDirTest.php
@@ -5,7 +5,7 @@
  */
 class LoadClassFileChangeCustomDirTest extends Common_TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $plugin_id = $this->objQuery->nextVal('dtb_plugin_plugin_id');

--- a/tests/class/plugin/LoadClassFileChangeTest.php
+++ b/tests/class/plugin/LoadClassFileChangeTest.php
@@ -5,13 +5,13 @@
  */
 class LoadClassFileChangeTest extends Common_TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->createPlugin();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $plugins = ['AutoloadingPlugin'];
         foreach ($plugins as $plugin) {

--- a/tests/class/util/SC_Utils/SC_Utils_arrayDefineIndexesTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_arrayDefineIndexesTest.php
@@ -35,12 +35,12 @@ class SC_Utils_arrayDefineIndexesTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_clearCompliedTemplateTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_clearCompliedTemplateTest.php
@@ -35,12 +35,12 @@ class SC_Utils_clearCompliedTemplateTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_copyDirectoryTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_copyDirectoryTest.php
@@ -36,7 +36,7 @@ class SC_Utils_copyDirectoryTest extends Common_TestCase
 
   static $TMP_DIR;
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
     self::$TMP_DIR = realpath(dirname(__FILE__)) . "/../../../tmp";
@@ -44,7 +44,7 @@ class SC_Utils_copyDirectoryTest extends Common_TestCase
     mkdir(self::$TMP_DIR, 0700, true);
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_encodeRFC3986Test.php
+++ b/tests/class/util/SC_Utils/SC_Utils_encodeRFC3986Test.php
@@ -35,12 +35,12 @@ class SC_Utils_encodeRFC3986Test extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_getHash2ArrayTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_getHash2ArrayTest.php
@@ -35,12 +35,12 @@ class SC_Utils_getHash2ArrayTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_getRealURLTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_getRealURLTest.php
@@ -35,12 +35,12 @@ class SC_Utils_getRealURLTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_getSaveImagePathTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_getSaveImagePathTest.php
@@ -35,12 +35,12 @@ class SC_Utils_getSaveImagePathTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_isAbsoluteRealPathTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_isAbsoluteRealPathTest.php
@@ -35,12 +35,12 @@ class SC_Utils_Test extends Common_TestCase
 {
 
 
-    protected function setUp()
+    protected function setUp(): void
     {
         // parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         // parent::tearDown();
     }

--- a/tests/class/util/SC_Utils/SC_Utils_isAppInnerUrlTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_isAppInnerUrlTest.php
@@ -38,12 +38,12 @@ class SC_Utils_isAppInnerUrlTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_isBlankTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_isBlankTest.php
@@ -35,12 +35,12 @@ class SC_Utils_isBlankTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_isInternalDomainTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_isInternalDomainTest.php
@@ -34,12 +34,12 @@ class SC_Utils_sfIsInternalDomainTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_jsonDecodeTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_jsonDecodeTest.php
@@ -35,12 +35,12 @@ class SC_Utils_jsonDecodeTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_jsonEncodeTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_jsonEncodeTest.php
@@ -35,12 +35,12 @@ class SC_Utils_jsonEncodeTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_recursiveMkDirTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_recursiveMkDirTest.php
@@ -36,7 +36,7 @@ class SC_Utils_recursiveMkdirTest extends Common_TestCase
 
     static $TMP_DIR;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::$TMP_DIR = realpath(dirname(__FILE__)) . "/../../../tmp";
         SC_Helper_FileManager::deleteFile(self::$TMP_DIR);
@@ -44,7 +44,7 @@ class SC_Utils_recursiveMkdirTest extends Common_TestCase
         // parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         // parent::tearDown();
     }

--- a/tests/class/util/SC_Utils/SC_Utils_repeatStrWithSeparatorTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_repeatStrWithSeparatorTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Utils_repeatStrWithSeparatorTest extends Common_TestCase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfArrCombineTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfArrCombineTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfArrCombineTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfArrKeyValueTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfArrKeyValueTest.php
@@ -38,7 +38,7 @@ class SC_Utils_sfArrKeyValueTest extends Common_TestCase
   var $keyname;
   var $valuename;
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
 
@@ -52,7 +52,7 @@ class SC_Utils_sfArrKeyValueTest extends Common_TestCase
     $this->valuename = 'testvalue';
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfArrayIntersectKeysTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfArrayIntersectKeysTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfArrayIntersectKeysTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfCalcIncTaxTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfCalcIncTaxTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Utils_sfCalcIncTaxTest extends Common_TestCase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfCopyDirtest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfCopyDirtest.php
@@ -36,7 +36,7 @@ class SC_Utils_sfCopyDirTest extends Common_TestCase
 
   static $TMP_DIR;
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
     self::$TMP_DIR = realpath(dirname(__FILE__)) . "/../../../tmp";
@@ -44,7 +44,7 @@ class SC_Utils_sfCopyDirTest extends Common_TestCase
     mkdir(self::$TMP_DIR, 0777, true);
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfCutStringTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfCutStringTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfCutStringTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfDBDateToTimeTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfDBDateToTimeTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfDBDatetoTimeTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfDispDBDateTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfDispDBDateTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfDispDBDateTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfEncodeFileTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfEncodeFileTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfEncodeFileTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfErrorHeaderTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfErrorHeaderTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfErrorHeaderTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfFlushTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfFlushTest.php
@@ -36,12 +36,12 @@ class SC_Utils_sfFlushTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetAddPointTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetAddPointTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfGetAddPointTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetAddressTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetAddressTest.php
@@ -35,13 +35,13 @@ class SC_Utils_sfGetAddressTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->setUpAddress();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetCSVListTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetCSVListTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfGetCSVListTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetCheckedTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetCheckedTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfGetCheckedTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetClassCatCountTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetClassCatCountTest.php
@@ -35,13 +35,13 @@ class SC_Utils_sfGetClassCatCountTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->setUpClassCat();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetCommaListTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetCommaListTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Utils_sfGetCommaListTest extends Common_TestCase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetEnabledTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetEnabledTest.php
@@ -37,12 +37,12 @@ class SC_Utils_sfGetEnabledTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetErrorColorTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetErrorColorTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfGetErrorColorTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetHashString_authTypeHmacTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetHashString_authTypeHmacTest.php
@@ -37,12 +37,12 @@ class SC_Utils_sfGetHashString_authTypeHmacTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetHashString_authTypePlainTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetHashString_authTypePlainTest.php
@@ -37,12 +37,12 @@ class SC_Utils_sfGetHashString_authTypePlainTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetProductClassIdTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetProductClassIdTest.php
@@ -35,13 +35,13 @@ class SC_Utils_sfGetProductClassIdTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
     $this->setUpProductsClass();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetRandomStringTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetRandomStringTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Utils_sfGetRandomStringTest extends Common_TestCase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetSearchPageMaxTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetSearchPageMaxTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfGetSearchPageMaxTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetTimestampTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetTimestampTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfGetTimestampTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetUnderChildrenArrayTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetUnderChildrenArrayTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfGetUnderChildrenArrayTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetUniqRandomIdTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetUniqRandomIdTest.php
@@ -36,12 +36,12 @@ class SC_Utils_sfGetUniqRandomIdTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfIsHTTPSTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfIsHTTPSTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfIsHTTPSTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfIsIntTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfIsIntTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Utils_sfIsIntTest extends Common_TestCase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfIsMatchHashPassword_authTypeHmacTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfIsMatchHashPassword_authTypeHmacTest.php
@@ -37,12 +37,12 @@ class SC_Utils_sfIsMatchHashPassword_authTypeHmacTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfIsMatchHashPassword_authTypePlainTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfIsMatchHashPassword_authTypePlainTest.php
@@ -37,12 +37,12 @@ class SC_Utils_sfIsMatchHashPassword_authTypePlainTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfIsSucceessTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfIsSucceessTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfIsSuccessTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfIsZeroFillingTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfIsZeroFillingTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Utils_sfIsZeroFillingTest extends Common_TestCase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfMakeHiddenArrayTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfMakeHiddenArrayTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfMakeHiddenArrayest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfMbConvertEncodingTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfMbConvertEncodingTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfMbConvertEncodingTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfMultiplyTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfMultiplyTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfMultiplyTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfNoImageMainListTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfNoImageMainListTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfNoImageMainListTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfNoImageMainTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfNoImageMainTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfNoImageMainTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfPassLenTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfPassLenTest.php
@@ -35,12 +35,12 @@ class SC_Utils_getSfPassLenTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfPrePointTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfPrePointTest.php
@@ -37,12 +37,12 @@ class SC_Utils_sfPrePointTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfPrintRTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfPrintRTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfPrintRTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfRmDupSlashTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfRmDupSlashTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfRmDupSlashTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfSetErrorStyleTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfSetErrorStyleTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfSetErrorStyleTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfSwapArrayTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfSwapArrayTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfSwapArrayTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfTaxTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfTaxTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Utils_sfTaxTest extends Common_TestCase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfTermMonthTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfTermMonthTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfTermMonthTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfTrimTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfTrimTest.php
@@ -34,12 +34,12 @@ require_once($HOME . "/tests/class/Common_TestCase.php");
 class SC_Utils_sfTrimTest extends Common_TestCase
 {
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfTrimURLTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfTrimURLTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfTrimURLTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     parent::tearDown();
   }

--- a/tests/class/util/SC_Utils/SC_Utils_sfUpDirNameTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfUpDirNameTest.php
@@ -35,12 +35,12 @@ class SC_Utils_sfUpDirNameTest extends Common_TestCase
 {
 
 
-  protected function setUp()
+  protected function setUp(): void
   {
     // parent::setUp();
   }
 
-  protected function tearDown()
+  protected function tearDown(): void
   {
     // parent::tearDown();
   }


### PR DESCRIPTION
Ubuntu 20.4、PHP 7.4、PHPUnit 8.5.2の環境でphpunitを動かした際、compatible errorが出るため、エラーが出ないよう対応しました。