### PR TITLE
納品書PDF出力のメディアボックスがサイズ0になる問題を修正

### DIFF
--- a/data/class/SC_Fpdf.php
+++ b/data/class/SC_Fpdf.php
@@ -57,6 +57,8 @@ class SC_Fpdf extends SC_Helper_FPDI
     public $pageno;
     public function __construct($download, $title, $tpl_pdf = 'nouhinsyo1.pdf')
     {
+        parent::__construct();
+
         // デフォルトの設定
         $this->tpl_pdf = PDF_TEMPLATE_REALDIR . $tpl_pdf;  // テンプレートファイル
         $this->pdf_download = $download;      // PDFのダウンロード形式（0:表示、1:ダウンロード）

--- a/tests/class/SC_FpdfTest.php
+++ b/tests/class/SC_FpdfTest.php
@@ -1,0 +1,45 @@
+<?php
+
+class SC_FpdfTest extends Common_TestCase
+{
+    /** @var FixtureGenerator */
+    protected $objGenerator;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->objGenerator = new FixtureGenerator();
+    }
+
+    public function test_正しいMediaBox情報が出力される()
+    {
+        $order_id = $this->objGenerator->createOrder(0, []);
+        $objFormParam = new SC_FormParam_Ex();
+
+        $fpdf = new \SC_Fpdf(true, "");
+        $objFormParam->setParam(
+            [
+                'order_id' => $order_id,
+                'year'  >= date('Y'),
+                'month' => date('n'),
+                'day'  => date('j'),
+
+                'msg1' => 'このたびはお買上げいただきありがとうございます。',
+                'msg2' => '下記の内容にて納品させていただきます。',
+                'msg3' => 'ご確認くださいますよう、お願いいたします。',
+            ]
+        );
+
+        ob_start();
+        $fpdf->createPdf($objFormParam);
+        $pdfContent = ob_get_clean();
+
+        preg_match("|/MediaBox.+|", $pdfContent, $matches);
+        $mediaBoxLine = $matches[0];
+
+        // 不正な出力。
+        $this->assertNotEquals('/MediaBox [0 0 0.00 0.00]', $mediaBoxLine);
+        // 前行のテストをすり抜けた場合のダブルチェック。（本来の出力）
+        $this->assertEquals('/MediaBox [0 0 595.28 841.89]', $mediaBoxLine);        
+    }
+}


### PR DESCRIPTION
## 問題

こちらのテストの通り、FPDFのコンストラクタが呼ばれていないため、FPDFでゼロ除算が発生。
結果として、不正なPDF（/MediaBoxがサイズゼロ）が出力される。

## 修正

FPDFのコンストラクタを呼ぶようにしました。

## 補足

PHPUnitに慣れていないため、もしテストのより適切な書き方があればご変更・ご指示ください。

