### PR TITLE
モジュール一覧上のインストール有無状態は、オーナーズストアからの情報ではなくホスト上の状態から判定する。

### DIFF
--- a/data/class/pages/upgrade/LC_Page_Upgrade_ProductsList.php
+++ b/data/class/pages/upgrade/LC_Page_Upgrade_ProductsList.php
@@ -186,6 +186,7 @@ class LC_Page_Upgrade_ProductsList extends LC_Page_Upgrade_Base
 
                 foreach ($objRet->data as $product) {
                     $tmp = get_object_vars($product);
+                    $this->detectInstalledFlagByHostState($tmp);
                     if (!isset($arrProducts[$tmp['product_id']])) {
                         if ($tmp['download_flg'] == 1) {
                             $tmp['status'] = "2.13系のモジュールは十分に動作確認できてない場合があります" ;
@@ -219,5 +220,21 @@ class LC_Page_Upgrade_ProductsList extends LC_Page_Upgrade_Base
 
             return;
         }
+    }
+
+    /**
+     * ホストの dtb_module に基づいた本当のインストール有無状態を取得し、
+     * オーナーズストアからの installed_flg を上書きする。
+     * @param array $productData
+     * @return void
+     */
+    private function detectInstalledFlagByHostState(&$productData)
+    {
+        $productId = $productData['product_id'];
+        $objQuery = \SC_Query_Ex::getSingletonInstance();
+
+        $isInstalled = $objQuery->exists('dtb_module', 'module_id = ?', array($productId));
+
+        $productData['installed_flg'] = $isInstalled;
     }
 }

--- a/data/class/pages/upgrade/LC_Page_Upgrade_ProductsList.php
+++ b/data/class/pages/upgrade/LC_Page_Upgrade_ProductsList.php
@@ -233,7 +233,7 @@ class LC_Page_Upgrade_ProductsList extends LC_Page_Upgrade_Base
         $productId = $productData['product_id'];
         $objQuery = \SC_Query_Ex::getSingletonInstance();
 
-        $isInstalled = $objQuery->exists('dtb_module', 'module_id = ?', array($productId));
+        $isInstalled = $objQuery->exists('dtb_module', 'module_id = ? AND del_flg = 0', array($productId));
 
         $productData['installed_flg'] = $isInstalled;
     }


### PR DESCRIPTION
## 問題

インストールされている(dtb_module にエントリがある)モジュールであるにも関わらず、
オーナーズストア上で「インストールされていない」と認識されていると、
モジュール一覧画面で未インストール状態として表示される。
そのため、そのようなモジュールの設定画面を開くことができない。

## 修正

あくまでホストの dtb_module の情報を元にインストール有無を判定し、 installed_flg を上書きする。
