### PR TITLE
管理画面→メンバー管理→削除で、 mode=delete を必須とする

### DIFF
--- a/data/class/pages/admin/system/LC_Page_Admin_System_Delete.php
+++ b/data/class/pages/admin/system/LC_Page_Admin_System_Delete.php
@@ -60,6 +60,10 @@ class LC_Page_Admin_System_Delete extends LC_Page_Admin_Ex
      */
     public function action()
     {
+        if ($this->getMode() !== 'delete') {
+            SC_Utils_Ex::sfDispError(INVALID_MOVE_ERRORR);
+            SC_Response_Ex::actionExit();
+        }
         $objFormParam = new SC_FormParam_Ex;
 
         // パラメーターの初期化

--- a/html/user_data/packages/admin/js/eccube.admin.js
+++ b/html/user_data/packages/admin/js/eccube.admin.js
@@ -31,9 +31,10 @@
 
     //指定されたidの削除を行うページを実行する。
     eccube.deleteMember = function(id, pageno, lastAdminFlag) {
-        var url = "./delete.php?id=" + id + "&pageno=" + pageno;
-        var message = lastAdminFlag ? 
-        '警告: 管理者がいなくなってしまいますと、システム設定などの操作が行えなくりますが宜しいでしょうか' 
+        var transactionid = $('input[name=transactionid]').val();
+        var url = "./delete.php?id=" + id + "&pageno=" + pageno + "&mode=delete&transactionid=" + transactionid;
+        var message = lastAdminFlag ?
+        '警告: 管理者がいなくなってしまいますと、システム設定などの操作が行えなくりますが宜しいでしょうか'
         : '登録内容を削除しても宜しいでしょうか';
         if(window.confirm(message)){
             location.href = url;


### PR DESCRIPTION
- `mode=delete` を指定するよう修正
- E2Eテストは別途作成します(#486)