### PR TITLE
latin1 で INSERT される場合があるのを修正

### DIFF
--- a/eccube_install.sh
+++ b/eccube_install.sh
@@ -269,7 +269,9 @@ case "${DBTYPE}" in
         cat - ${SQL_DIR}/create_table_mysqli.sql |
         ${MYSQL} -h ${DBSERVER} -u ${DBUSER} -h ${DBSERVER} -P ${DBPORT} ${PASSOPT} ${DBNAME}
     echo "insert data..."
-    ${MYSQL} -u ${DBUSER} -h ${DBSERVER} -P ${DBPORT} ${PASSOPT} ${DBNAME} < ${SQL_DIR}/insert_data.sql
+    echo "SET CHARACTER SET 'utf8';" |
+        cat - ${SQL_DIR}/insert_data.sql |
+        ${MYSQL} -u ${DBUSER} -h ${DBSERVER} -P ${DBPORT} ${PASSOPT} ${DBNAME}
     echo "create sequence table..."
     create_sequence_tables
     echo "execute optional SQL..."


### PR DESCRIPTION
以下のように docker-compose 経由でインストールした場合、 latin1 で INSERT されてしまい、文字化けしてしまう場合がある。

```shell
docker-compose -f docker-compose.yml -f docker-compose.mysql.yml up -d
```

明示的に CHARACTER SET を指定することで文字化けを防止する