### PR TITLE
Smarty の script_escape でサニタイズされる対象の追加

### DIFF
--- a/data/smarty_extends/modifier.script_escape.php
+++ b/data/smarty_extends/modifier.script_escape.php
@@ -9,7 +9,7 @@ function smarty_modifier_script_escape($value)
 {
     if (is_array($value)) return $value;
 
-    $pattern = "/<script.*?>|<\/script>|javascript:|<svg.*(onload|onerror).*?>|<img.*(onload|onerror).*?>|<body.*onload.*?>|<iframe.*?>|<object.*?>|<embed.*?>|<.*onmouse.*?>/i";
+    $pattern = "/<script.*?>|<\/script>|javascript:|<svg.*(onload|onerror).*?>|<img.*(onload|onerror).*?>|<body.*onload.*?>|<iframe.*?>|<object.*?>|<embed.*?>|<.*onmouse.*?>|(\"|').*(onmouse|onerror|onload|onclick).*=.*(\"|').*/i";
     $convert = '#script tag escaped#';
 
     if (preg_match_all($pattern, $value, $matches)) {


### PR DESCRIPTION
- `" (onmouse|onload|onerror|onclick)***="***` のパターン追加
- 万が一、プラグインや独自カスタマイズでエスケープ漏れのあった場合の保険のため
- #458 