### PR TITLE
Weekly build のリリースノート自動生成

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,10 @@ jobs:
     name: Deploy
     runs-on: ubuntu-18.04
     steps:
+      - name: PREVIOUS_TAG_NAME
+        run: |
+          echo "PREVIOUS_TAG_NAME=$(curl -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)" >> $GITHUB_ENV
+
       - name: TAG_NAME for schedule
         if: github.event_name == 'schedule'
         run: echo "TAG_NAME=eccube2-weekly-$(date +%Y%m%d)" >> $GITHUB_ENV
@@ -42,6 +46,27 @@ jobs:
 
           draft: false
           prerelease: true
+      - name: RELEASE_BODY
+        if: github.event_name == 'schedule'
+        env:
+          TAG_NAME: ${{ env.TAG_NAME }}
+        run: |
+          echo 'RELEASE_BODY<<EOF' >> $GITHUB_ENV
+          echo $(curl -H 'Accept: application/vnd.github.v3+json'  https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ env.TAG_NAME }} | jq -r .body | sed 's,",\\",g' | sed "s,',,g") >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - name: RELEASE_ID
+        if: github.event_name == 'schedule'
+        env:
+          TAG_NAME: ${{ env.TAG_NAME }}
+        run: |
+          echo "RELEASE_ID=$(curl -H 'Accept: application/vnd.github.v3+json'  https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ env.TAG_NAME }} | jq -r .id)" >> $GITHUB_ENV
+      - name: GENERATED_NOTES
+        if: github.event_name == 'schedule'
+        run: |
+          echo 'GENERATED_NOTES<<EOF' >> $GITHUB_ENV
+          echo $(curl -X POST -H 'Accept: application/vnd.github.v3+json' -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'  https://api.github.com/repos/${{ github.repository }}/releases/generate-notes -d '{"tag_name":"${{ env.TAG_NAME }}", "previous_tag_name":"${{ env.PREVIOUS_TAG_NAME }}"}' | jq .body | sed 's,",,g' | sed "s,',,g") >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
       - name: Checkout code
         if: github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'prereleased' )
         uses: actions/checkout@v2
@@ -208,3 +233,13 @@ jobs:
           asset_name: ${{ env.TAG_NAME }}.zip.checksum.sha256
           tag: ${{ env.TAG_NAME }}
           overwrite: true
+
+      - name: Update Release notes
+        if: github.event_name == 'schedule'
+        run: |
+          curl \
+          -X PATCH \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }} \
+          -d '{"draft":false, "body":"${{ env.RELEASE_BODY }}\n${{ env.GENERATED_NOTES }}"}'


### PR DESCRIPTION
- 前回の(Pre release 以外の)リリースタグからの変更を自動生成する
- [Generate release notes content for a release API](https://docs.github.com/en/rest/reference/repos#generate-release-notes-content-for-a-release) を使用しています
- https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

以下のように、マージされた Pull Request の一覧が自動生成されます
![スクリーンショット 2021-11-11 19 28 31](https://user-images.githubusercontent.com/815715/141282468-59d08db7-0d4b-43ab-a5f9-3bf2de961c24.png)
 