### PR TITLE
faker-js 更新に伴う修正

### DIFF
--- a/e2e-tests/test/front_guest/entry.test.ts
+++ b/e2e-tests/test/front_guest/entry.test.ts
@@ -71,7 +71,7 @@ test.describe.serial('会員登録のテストをします', () => {
     await page.check(`input[name=sex][value="${sex}"]`);
     const job = faker.datatype.number({ min: 1, max: 18 });
     await page.selectOption('select[name=job]', { value: String(job) });
-    const birth = faker.date.past(20, addYears(new Date(), -20));
+    const birth = faker.date.past(20, addYears(new Date(), -20).toISOString());
     await page.selectOption('select[name=year]', String(birth.getFullYear()));
     await page.selectOption('select[name=month]', String(birth.getMonth() + 1));
     await page.selectOption('select[name=day]', String(birth.getDate()));

--- a/e2e-tests/test/front_guest/shopping.test.ts
+++ b/e2e-tests/test/front_guest/shopping.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, chromium, Page, request, APIRequestContext } from '@playwright/test';
 import PlaywrightConfig from '../../../playwright.config';
-import * as faker from 'faker/locale/ja';
-import * as fakerEN from 'faker/locale/en_US';
+import * as faker from '@faker-js/faker/locale/ja';
+import * as fakerEN from '@faker-js/faker/locale/en_US';
 import { addYears } from 'date-fns';
 
 import { ZapClient, Mode, ContextType } from '../../utils/ZapClient';
@@ -76,7 +76,7 @@ test.describe.serial('購入フロー(ゲスト)のテストをします', () =>
     await page.check(`input[name=order_sex][value="${sex}"]`);
     const job = faker.datatype.number({ min: 1, max: 18 });
     await page.selectOption('select[name=order_job]', { value: String(job) });
-    const birth = faker.date.past(20, addYears(new Date(), -20));
+    const birth = faker.date.past(20, addYears(new Date(), -20).toISOString());
     await page.selectOption('select[name=order_year]', String(birth.getFullYear()));
     await page.selectOption('select[name=order_month]', String(birth.getMonth() + 1));
     await page.selectOption('select[name=order_day]', String(birth.getDate()));

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,7 +42,7 @@ const config: PlaywrightTestConfig = {
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     baseURL: 'https://ec-cube',
-    trace: 'retain-on-failure',
+    trace: 'off',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
     ignoreHTTPSErrors: true,


### PR DESCRIPTION
- #527 
- `@faker-js/faker`  の導入に伴い、エラーになったテストを修正
- `tracing.startChunk: Tracing is already stopping` のエラーになるため、 `trace: 'off'` に設定