### PR TITLE
未知の攻撃パターンのためにエスケープ処理を付与

### DIFF
--- a/data/Smarty/templates/admin/basis/delivery.tpl
+++ b/data/Smarty/templates/admin/basis/delivery.tpl
@@ -50,16 +50,16 @@
                 <tr>
                     <td><!--{$arrDelivList[cnt].name|h}--></td>
                     <td><!--{$arrDelivList[cnt].service_name|h}--></td>
-                    <td align="center"><a href="?" onclick="eccube.changeAction('./delivery_input.php'); eccube.setModeAndSubmit('pre_edit', 'deliv_id', <!--{$arrDelivList[cnt].deliv_id}-->); return false;">
+                    <td align="center"><a href="?" onclick="eccube.changeAction('./delivery_input.php'); eccube.setModeAndSubmit('pre_edit', 'deliv_id', <!--{$arrDelivList[cnt].deliv_id|h}-->); return false;">
                         編集</a></td>
-                    <td align="center"><a href="?" onclick="eccube.setModeAndSubmit('delete', 'deliv_id', <!--{$arrDelivList[cnt].deliv_id}-->); return false;">
+                    <td align="center"><a href="?" onclick="eccube.setModeAndSubmit('delete', 'deliv_id', <!--{$arrDelivList[cnt].deliv_id|h}-->); return false;">
                         削除</a></td>
                     <td align="center">
                     <!--{if $smarty.section.cnt.iteration != 1}-->
-                    <a href="?" onclick="eccube.setModeAndSubmit('up','deliv_id', '<!--{$arrDelivList[cnt].deliv_id}-->'); return false;">上へ</a>
+                    <a href="?" onclick="eccube.setModeAndSubmit('up','deliv_id', '<!--{$arrDelivList[cnt].deliv_id|h}-->'); return false;">上へ</a>
                     <!--{/if}-->
                     <!--{if $smarty.section.cnt.iteration != $smarty.section.cnt.last}-->
-                    <a href="?" onclick="eccube.setModeAndSubmit('down','deliv_id', '<!--{$arrDelivList[cnt].deliv_id}-->'); return false;">下へ</a>
+                    <a href="?" onclick="eccube.setModeAndSubmit('down','deliv_id', '<!--{$arrDelivList[cnt].deliv_id|h}-->'); return false;">下へ</a>
                     <!--{/if}-->
                     </td>
                 </tr>

--- a/data/Smarty/templates/admin/basis/holiday.tpl
+++ b/data/Smarty/templates/admin/basis/holiday.tpl
@@ -25,7 +25,7 @@
 <form name="form1" id="form1" method="post" action="?">
     <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
     <input type="hidden" name="mode" value="edit" />
-    <input type="hidden" name="holiday_id" value="<!--{$tpl_holiday_id}-->" />
+    <input type="hidden" name="holiday_id" value="<!--{$tpl_holiday_id|h}-->" />
     <div id="basis" class="contents-main">
 
         <table class="form">
@@ -85,7 +85,7 @@
                 <td><!--{$arrHoliday[cnt].month|h}-->月<!--{$arrHoliday[cnt].day|h}-->日</td>
                 <td class="center">
                     <!--{if $tpl_holiday_id != $arrHoliday[cnt].holiday_id}-->
-                    <a href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'holiday_id', <!--{$arrHoliday[cnt].holiday_id}-->); return false;">編集</a>
+                    <a href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'holiday_id', <!--{$arrHoliday[cnt].holiday_id|h}-->); return false;">編集</a>
                     <!--{else}-->
                     編集中
                     <!--{/if}-->
@@ -94,15 +94,15 @@
                     <!--{if $arrClassCatCount[$class_id] > 0}-->
                     -
                     <!--{else}-->
-                    <a href="?" onclick="eccube.setModeAndSubmit('delete', 'holiday_id', <!--{$arrHoliday[cnt].holiday_id}-->); return false;">削除</a>
+                    <a href="?" onclick="eccube.setModeAndSubmit('delete', 'holiday_id', <!--{$arrHoliday[cnt].holiday_id|h}-->); return false;">削除</a>
                     <!--{/if}-->
                 </td>
                 <td class="center">
                     <!--{if $smarty.section.cnt.iteration != 1}-->
-                    <a href="?" onclick="eccube.setModeAndSubmit('up', 'holiday_id', <!--{$arrHoliday[cnt].holiday_id}-->); return false;">上へ</a>
+                    <a href="?" onclick="eccube.setModeAndSubmit('up', 'holiday_id', <!--{$arrHoliday[cnt].holiday_id|h}-->); return false;">上へ</a>
                     <!--{/if}-->
                     <!--{if $smarty.section.cnt.iteration != $smarty.section.cnt.last}-->
-                    <a href="?" onclick="eccube.setModeAndSubmit('down', 'holiday_id', <!--{$arrHoliday[cnt].holiday_id}-->); return false;">下へ</a>
+                    <a href="?" onclick="eccube.setModeAndSubmit('down', 'holiday_id', <!--{$arrHoliday[cnt].holiday_id|h}-->); return false;">下へ</a>
                     <!--{/if}-->
                 </td>
             </tr>

--- a/data/Smarty/templates/admin/basis/kiyaku.tpl
+++ b/data/Smarty/templates/admin/basis/kiyaku.tpl
@@ -25,7 +25,7 @@
 <form name="form1" id="form1" method="post" action="?">
     <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
     <input type="hidden" name="mode" value="edit" />
-    <input type="hidden" name="kiyaku_id" value="<!--{$tpl_kiyaku_id}-->" />
+    <input type="hidden" name="kiyaku_id" value="<!--{$tpl_kiyaku_id|h}-->" />
     <div id="basis" class="contents-main">
         <table class="form">
             <tr>
@@ -69,7 +69,7 @@
                     <td><!--{* 規格名 *}--><!--{$arrKiyaku[cnt].kiyaku_title|h}--></td>
                     <td align="center">
                         <!--{if $tpl_kiyaku_id != $arrKiyaku[cnt].kiyaku_id}-->
-                        <a href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'kiyaku_id', <!--{$arrKiyaku[cnt].kiyaku_id}-->); return false;">編集</a>
+                        <a href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'kiyaku_id', <!--{$arrKiyaku[cnt].kiyaku_id|h}-->); return false;">編集</a>
                         <!--{else}-->
                         編集中
                         <!--{/if}-->
@@ -78,15 +78,15 @@
                         <!--{if $arrClassCatCount[$class_id] > 0}-->
                         -
                         <!--{else}-->
-                        <a href="?" onclick="eccube.setModeAndSubmit('delete', 'kiyaku_id', <!--{$arrKiyaku[cnt].kiyaku_id}-->); return false;">削除</a>
+                        <a href="?" onclick="eccube.setModeAndSubmit('delete', 'kiyaku_id', <!--{$arrKiyaku[cnt].kiyaku_id|h}-->); return false;">削除</a>
                         <!--{/if}-->
                     </td>
                     <td align="center">
                         <!--{if $smarty.section.cnt.iteration != 1}-->
-                        <a href="?" onclick="eccube.setModeAndSubmit('up', 'kiyaku_id', <!--{$arrKiyaku[cnt].kiyaku_id}-->); return false;">上へ</a>
+                        <a href="?" onclick="eccube.setModeAndSubmit('up', 'kiyaku_id', <!--{$arrKiyaku[cnt].kiyaku_id|h}-->); return false;">上へ</a>
                         <!--{/if}-->
                         <!--{if $smarty.section.cnt.iteration != $smarty.section.cnt.last}-->
-                        <a href="?" onclick="eccube.setModeAndSubmit('down', 'kiyaku_id', <!--{$arrKiyaku[cnt].kiyaku_id}-->); return false;">下へ</a>
+                        <a href="?" onclick="eccube.setModeAndSubmit('down', 'kiyaku_id', <!--{$arrKiyaku[cnt].kiyaku_id|h}-->); return false;">下へ</a>
                         <!--{/if}-->
                     </td>
                 </tr>

--- a/data/Smarty/templates/admin/basis/payment.tpl
+++ b/data/Smarty/templates/admin/basis/payment.tpl
@@ -25,7 +25,7 @@
 <form name="form1" id="form1" method="post" action="?">
     <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
     <input type="hidden" name="mode" value="edit" />
-    <input type="hidden" name="payment_id" value="<!--{$tpl_payment_id}-->" />
+    <input type="hidden" name="payment_id" value="<!--{$tpl_payment_id|h}-->" />
     <div id="basis" class="contents-main">
         <div class="btn">
             <ul>
@@ -62,14 +62,14 @@
                 <td class="center">
                     <!--{if $arrPaymentListFree[cnt].rule_max > 0}--><!--{$arrPaymentListFree[cnt].rule_max|n2s|h}--><!--{else}-->0<!--{/if}-->円
                     <!--{if $arrPaymentListFree[cnt].upper_rule > 0}-->～<!--{$arrPaymentListFree[cnt].upper_rule|n2s|h}-->円<!--{elseif $arrPaymentListFree[cnt].upper_rule == "0"}--><!--{else}-->～無制限<!--{/if}--></td>
-                <td class="center"><!--{if $arrPaymentListFree[cnt].fix != 1}--><a href="?" onclick="eccube.changeAction('./payment_input.php'); eccube.setModeAndSubmit('pre_edit', 'payment_id', <!--{$arrPaymentListFree[cnt].payment_id}-->); return false;">編集</a><!--{else}-->-<!--{/if}--></td>
-                <td class="center"><!--{if $arrPaymentListFree[cnt].fix != 1}--><a href="?" onclick="eccube.setModeAndSubmit('delete', 'payment_id', <!--{$arrPaymentListFree[cnt].payment_id}-->); return false;">削除</a><!--{else}-->-<!--{/if}--></td>
+                <td class="center"><!--{if $arrPaymentListFree[cnt].fix != 1}--><a href="?" onclick="eccube.changeAction('./payment_input.php'); eccube.setModeAndSubmit('pre_edit', 'payment_id', <!--{$arrPaymentListFree[cnt].payment_id|h}-->); return false;">編集</a><!--{else}-->-<!--{/if}--></td>
+                <td class="center"><!--{if $arrPaymentListFree[cnt].fix != 1}--><a href="?" onclick="eccube.setModeAndSubmit('delete', 'payment_id', <!--{$arrPaymentListFree[cnt].payment_id|h}-->); return false;">削除</a><!--{else}-->-<!--{/if}--></td>
                 <td class="center">
                 <!--{if $smarty.section.cnt.iteration != 1}-->
-                <a href="?" onclick="eccube.setModeAndSubmit('up','payment_id', <!--{$arrPaymentListFree[cnt].payment_id}-->); return false;">上へ</a>
+                <a href="?" onclick="eccube.setModeAndSubmit('up','payment_id', <!--{$arrPaymentListFree[cnt].payment_id|h}-->); return false;">上へ</a>
                 <!--{/if}-->
                 <!--{if $smarty.section.cnt.iteration != $smarty.section.cnt.last}-->
-                <a href="?" onclick="eccube.setModeAndSubmit('down','payment_id', <!--{$arrPaymentListFree[cnt].payment_id}-->); return false;">下へ</a>
+                <a href="?" onclick="eccube.setModeAndSubmit('down','payment_id', <!--{$arrPaymentListFree[cnt].payment_id|h}-->); return false;">下へ</a>
                 <!--{/if}-->
                 </td>
             </tr>

--- a/data/Smarty/templates/admin/basis/payment_input.tpl
+++ b/data/Smarty/templates/admin/basis/payment_input.tpl
@@ -79,10 +79,10 @@
                         <!--{assign var=key value="payment_image"}-->
                         <span class="attention"><!--{$arrErr[$key]}--></span>
                         <!--{if $arrFile[$key].filepath != ""}-->
-                        <img src="<!--{$arrFile[$key].filepath}-->" alt="<!--{$arrForm.name|h}-->">　<br /><a href="" onclick="eccube.setModeAndSubmit('delete_image', 'image_key', '<!--{$key}-->'); return false;">[画像の取り消し]</a><br />
+                        <img src="<!--{$arrFile[$key].filepath|h}-->" alt="<!--{$arrForm.name|h}-->">　<br /><a href="" onclick="eccube.setModeAndSubmit('delete_image', 'image_key', '<!--{$key|h}-->'); return false;">[画像の取り消し]</a><br />
                         <!--{/if}-->
-                        <input type="file" name="<!--{$key}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" />
-                        <a class="btn-normal" href="javascript:;" name="btn" onclick="eccube.setModeAndSubmit('upload_image', 'image_key', '<!--{$key}-->'); return false;">アップロード</a>
+                        <input type="file" name="<!--{$key|h}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" />
+                        <a class="btn-normal" href="javascript:;" name="btn" onclick="eccube.setModeAndSubmit('upload_image', 'image_key', '<!--{$key|h}-->'); return false;">アップロード</a>
                     </td>
                 </tr>
             </table>

--- a/data/Smarty/templates/admin/basis/point.tpl
+++ b/data/Smarty/templates/admin/basis/point.tpl
@@ -24,7 +24,7 @@
 
 <form name="point_form" id="point_form" method="post" action="">
     <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
-    <input type="hidden" name="mode" value="<!--{$tpl_mode}-->" />
+    <input type="hidden" name="mode" value="<!--{$tpl_mode|h}-->" />
     <div id="basis" class="contents-main">
         <table>
             <tr>
@@ -51,7 +51,7 @@
 
         <div class="btn-area">
             <ul>
-                <li><a class="btn-action" href="javascript:;" onclick="eccube.fnFormModeSubmit('point_form', '<!--{$tpl_mode}-->', '', ''); return false;"><span class="btn-next">この内容で登録する</span></a></li>
+                <li><a class="btn-action" href="javascript:;" onclick="eccube.fnFormModeSubmit('point_form', '<!--{$tpl_mode|h}-->', '', ''); return false;"><span class="btn-next">この内容で登録する</span></a></li>
             </ul>
         </div>
     </div>

--- a/data/Smarty/templates/admin/basis/tax.tpl
+++ b/data/Smarty/templates/admin/basis/tax.tpl
@@ -126,7 +126,7 @@
             </td>
             <td class="center">
             <!--{if $tpl_tax_rule_id != $arrTaxrule[cnt].tax_rule_id}-->
-                <a href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'tax_rule_id', '<!--{$arrTaxrule[cnt].tax_rule_id}-->'); return false;">編集</a>
+                <a href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'tax_rule_id', '<!--{$arrTaxrule[cnt].tax_rule_id|h}-->'); return false;">編集</a>
             <!--{else}-->
                 編集中
             <!--{/if}-->
@@ -135,7 +135,7 @@
             <!--{if $arrTaxrule[cnt].tax_rule_id == 0}-->
                 -
             <!--{else}-->
-                <a href="?" onclick="eccube.setModeAndSubmit('delete', 'tax_rule_id', '<!--{$arrTaxrule[cnt].tax_rule_id}-->'); return false;">削除</a>
+                <a href="?" onclick="eccube.setModeAndSubmit('delete', 'tax_rule_id', '<!--{$arrTaxrule[cnt].tax_rule_id|h}-->'); return false;">削除</a>
             <!--{/if}-->
             </td>
         </tr>

--- a/data/Smarty/templates/admin/basis/tradelaw.tpl
+++ b/data/Smarty/templates/admin/basis/tradelaw.tpl
@@ -24,7 +24,7 @@
 
 <form name="form1" id="form1" method="post" action="">
     <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
-    <input type="hidden" name="mode" value="<!--{$tpl_mode}-->" />
+    <input type="hidden" name="mode" value="<!--{$tpl_mode|h}-->" />
     <div id="basis" class="contents-main">
         <table class="form">
             <tr>
@@ -197,7 +197,7 @@
 
         <div class="btn-area">
             <ul>
-                <li><a class="btn-action" href="javascript:;" onclick="eccube.fnFormModeSubmit('form1', '<!--{$tpl_mode}-->', '', ''); return false;"><span class="btn-next">この内容で登録する</span></a></li>
+                <li><a class="btn-action" href="javascript:;" onclick="eccube.fnFormModeSubmit('form1', '<!--{$tpl_mode|h}-->', '', ''); return false;"><span class="btn-next">この内容で登録する</span></a></li>
             </ul>
         </div>
     </div>

--- a/data/Smarty/templates/admin/contents/csv_sql.tpl
+++ b/data/Smarty/templates/admin/contents/csv_sql.tpl
@@ -58,8 +58,8 @@ function fnTargetSelf(){
                         </td>
                         <td>
                             <div class="btn">
-                                <a class="btn-normal" href="javascript:;" name='csv' onclick="fnTargetSelf(); eccube.fnFormModeSubmit('form1','csv_output','csv_output_id',<!--{$item.sql_id}-->); return false;"><span>CSV出力</span></a>
-                                <a class="btn-normal" href="javascript:;" name='del' onclick="fnTargetSelf(); eccube.fnFormModeSubmit('form1','delete','sql_id',<!--{$item.sql_id}-->); return false;"><span>削除</span></a>
+                                <a class="btn-normal" href="javascript:;" name='csv' onclick="fnTargetSelf(); eccube.fnFormModeSubmit('form1','csv_output','csv_output_id',<!--{$item.sql_id|h}-->); return false;"><span>CSV出力</span></a>
+                                <a class="btn-normal" href="javascript:;" name='del' onclick="fnTargetSelf(); eccube.fnFormModeSubmit('form1','delete','sql_id',<!--{$item.sql_id|h}-->); return false;"><span>削除</span></a>
                             </div>
                         </td>
                     </tr>

--- a/data/Smarty/templates/admin/contents/file_manager.tpl
+++ b/data/Smarty/templates/admin/contents/file_manager.tpl
@@ -25,7 +25,7 @@
 <script type="text/javascript">//<![CDATA[
     $(function() {
         var bread_crumbs = <!--{$tpl_now_dir}-->;
-        var file_path = '<!--{$tpl_file_path}-->';
+        var file_path = '<!--{$tpl_file_path|h}-->';
         var $delimiter = '<span>&nbsp;&gt;&nbsp;</span>';
         var $node = $('h2');
         var total = bread_crumbs.length;
@@ -114,7 +114,7 @@
                         </td>
                         <!--{if $arrFileList[cnt].is_dir}-->
                             <td class="center">
-                                <a href="javascript:;" onclick="eccube.setValue('tree_select_file', '<!--{$arrFileList[cnt].file_path}-->', 'form1'); eccube.fileManager.selectFile('<!--{$id|h}-->', '#808080');eccube.setModeAndSubmit('move','',''); return false;">表示</a>
+                                <a href="javascript:;" onclick="eccube.setValue('tree_select_file', '<!--{$arrFileList[cnt].file_path|h}-->', 'form1'); eccube.fileManager.selectFile('<!--{$id|h}-->', '#808080');eccube.setModeAndSubmit('move','',''); return false;">表示</a>
                             </td>
                         <!--{else}-->
                             <td class="center">

--- a/data/Smarty/templates/admin/contents/file_manager.tpl
+++ b/data/Smarty/templates/admin/contents/file_manager.tpl
@@ -114,7 +114,7 @@
                         </td>
                         <!--{if $arrFileList[cnt].is_dir}-->
                             <td class="center">
-                                <a href="javascript:;" onclick="eccube.setValue('tree_select_file', '<!--{$arrFileList[cnt].file_path}-->', 'form1'); eccube.fileManager.selectFile('<!--{$id}-->', '#808080');eccube.setModeAndSubmit('move','',''); return false;">表示</a>
+                                <a href="javascript:;" onclick="eccube.setValue('tree_select_file', '<!--{$arrFileList[cnt].file_path}-->', 'form1'); eccube.fileManager.selectFile('<!--{$id|h}-->', '#808080');eccube.setModeAndSubmit('move','',''); return false;">表示</a>
                             </td>
                         <!--{else}-->
                             <td class="center">

--- a/data/Smarty/templates/admin/contents/recommend.tpl
+++ b/data/Smarty/templates/admin/contents/recommend.tpl
@@ -161,10 +161,10 @@ function lfnSortItem(mode,data,form){
                 <td>
                     <!--{* 移動 *}-->
                     <!--{if $smarty.section.cnt.iteration != 1 && $arrItems[$smarty.section.cnt.iteration].best_id}-->
-                        <a href="?" onclick="lfnSortItem('up',<!--{$arrItems[$smarty.section.cnt.iteration].best_id}-->,'form<!--{$smarty.section.cnt.iteration-1}-->'); return false;">上へ</a><br />&nbsp;
+                        <a href="?" onclick="lfnSortItem('up',<!--{$arrItems[$smarty.section.cnt.iteration].best_id|h}-->,'form<!--{$smarty.section.cnt.iteration-1}-->'); return false;">上へ</a><br />&nbsp;
                     <!--{/if}-->
                     <!--{if $smarty.section.cnt.iteration != $tpl_disp_max && $arrItems[$smarty.section.cnt.iteration].best_id}-->
-                        <a href="?" onclick="lfnSortItem('down',<!--{$arrItems[$smarty.section.cnt.iteration].best_id}-->,'form<!--{$smarty.section.cnt.iteration+1}-->'); return false;">下へ</a>
+                        <a href="?" onclick="lfnSortItem('down',<!--{$arrItems[$smarty.section.cnt.iteration].best_id|h}-->,'form<!--{$smarty.section.cnt.iteration+1}-->'); return false;">下へ</a>
                     <!--{/if}-->
                 </td>
             </tr>

--- a/data/Smarty/templates/admin/contents/recommend_search.tpl
+++ b/data/Smarty/templates/admin/contents/recommend_search.tpl
@@ -58,11 +58,11 @@ function func_submit( id ){
         </tr>
         <tr>
             <th>商品コード</th>
-            <td><input type="text" name="search_product_code" value="<!--{$arrForm.search_product_code}-->" size="35" class="box35" /></td>
+            <td><input type="text" name="search_product_code" value="<!--{$arrForm.search_product_code|h}-->" size="35" class="box35" /></td>
         </tr>
         <tr>
             <th>商品名</th>
-            <td><input type="text" name="search_name" value="<!--{$arrForm.search_name}-->" size="35" class="box35" /></td>
+            <td><input type="text" name="search_name" value="<!--{$arrForm.search_name|h}-->" size="35" class="box35" /></td>
         </tr>
         <tr>
             <th>商品ステータス</th>

--- a/data/Smarty/templates/admin/contents/recommend_search.tpl
+++ b/data/Smarty/templates/admin/contents/recommend_search.tpl
@@ -114,7 +114,7 @@ function func_submit( id ){
                 <!--{/if}-->
             </td>
             <td><!--{$arr.name|h}--></td>
-            <td class="center"><a href="" onclick="return func_submit(<!--{$arr.product_id}-->)">決定</a></td>
+            <td class="center"><a href="" onclick="return func_submit(<!--{$arr.product_id|h}-->)">決定</a></td>
         </tr>
         <!--▲商品<!--{$smarty.foreach.loop.iteration}-->-->
         <!--{/foreach}-->

--- a/data/Smarty/templates/admin/customer/edit.tpl
+++ b/data/Smarty/templates/admin/customer/edit.tpl
@@ -267,7 +267,7 @@
         </div>
 
         <input type="hidden" name="order_id" value="" />
-        <input type="hidden" name="search_pageno" value="<!--{$tpl_pageno}-->" />
+        <input type="hidden" name="search_pageno" value="<!--{$tpl_pageno|h}-->" />
         <input type="hidden" name="edit_customer_id" value="<!--{$edit_customer_id|h}-->" />
 
         <h2>購入履歴一覧</h2>

--- a/data/Smarty/templates/admin/customer/edit.tpl
+++ b/data/Smarty/templates/admin/customer/edit.tpl
@@ -268,7 +268,7 @@
 
         <input type="hidden" name="order_id" value="" />
         <input type="hidden" name="search_pageno" value="<!--{$tpl_pageno}-->" />
-        <input type="hidden" name="edit_customer_id" value="<!--{$edit_customer_id}-->" />
+        <input type="hidden" name="edit_customer_id" value="<!--{$edit_customer_id|h}-->" />
 
         <h2>購入履歴一覧</h2>
         <!--{if $tpl_linemax > 0}-->
@@ -288,7 +288,7 @@
                 <!--{section name=cnt loop=$arrPurchaseHistory}-->
                     <tr>
                         <td><!--{$arrPurchaseHistory[cnt].create_date|sfDispDBDate}--></td>
-                        <td class="center"><a href="../order/edit.php?order_id=<!--{$arrPurchaseHistory[cnt].order_id}-->" ><!--{$arrPurchaseHistory[cnt].order_id}--></a></td>
+                        <td class="center"><a href="../order/edit.php?order_id=<!--{$arrPurchaseHistory[cnt].order_id|h}-->" ><!--{$arrPurchaseHistory[cnt].order_id|h}--></a></td>
                         <td class="center"><!--{$arrPurchaseHistory[cnt].payment_total|n2s}-->円</td>
                         <td class="center"><!--{if $arrPurchaseHistory[cnt].status eq 5}--><!--{$arrPurchaseHistory[cnt].commit_date|sfDispDBDate}--><!--{else}-->未発送<!--{/if}--></td>
                         <!--{assign var=payment_id value="`$arrPurchaseHistory[cnt].payment_id`"}-->

--- a/data/Smarty/templates/admin/design/bloc.tpl
+++ b/data/Smarty/templates/admin/design/bloc.tpl
@@ -59,7 +59,7 @@
                 <td colspan="2">
                     <!--{assign var=key value="bloc_html"}-->
                     <textarea class="top" id="<!--{$key}-->" name="<!--{$key}-->" rows="<!--{$text_row}-->" style="width: 99%;"><!--{"\n"}--><!--{$arrForm[$key].value|h nofilter}--></textarea>
-                    <input type="hidden" name="html_area_row" value="<!--{$text_row}-->" />
+                    <input type="hidden" name="html_area_row" value="<!--{$text_row|h}-->" />
                     <div>
                         <a id="resize-btn" class="btn-normal" href="javascript:;" onclick="eccube.toggleRows('#resize-btn', '#bloc_html', 50, 13); return false;">拡大</a>
                     </div>

--- a/data/Smarty/templates/admin/design/css.tpl
+++ b/data/Smarty/templates/admin/design/css.tpl
@@ -52,7 +52,7 @@
                 <td>
                     <!--{assign var=key value="css_data"}-->
                     <textarea id="css" class="top" name="<!--{$key}-->" cols="90" rows="<!--{$area_row}-->" align="left" style="width: 650px;"><!--{"\n"}--><!--{$arrForm[$key].value|h}--></textarea>
-                    <input type="hidden" name="area_row" value="<!--{$area_row}-->" />
+                    <input type="hidden" name="area_row" value="<!--{$area_row|h}-->" />
                     <div class="btn">
                         <a id="resize-btn" class="btn-normal" href="javascript:;" onclick="eccube.toggleRows('#resize-btn', '#css', 50, 30); return false;">拡大</a>
                     </div>

--- a/data/Smarty/templates/admin/design/header.tpl
+++ b/data/Smarty/templates/admin/design/header.tpl
@@ -36,7 +36,7 @@
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
         <input type="hidden" name="mode" value="" />
         <input type="hidden" name="division" value="header" />
-        <input type="hidden" name="header_row" value="<!--{$header_row}-->" />
+        <input type="hidden" name="header_row" value="<!--{$header_row|h}-->" />
         <input type="hidden" name="device_type_id" value="<!--{$device_type_id|h}-->" />
 
         <textarea id="header-area" class="top" name="header" rows="<!--{$header_row}-->" style="width: 100%;"><!--{"\n"}--><!--{$header_data|h nofilter}--></textarea>
@@ -59,7 +59,7 @@
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
         <input type="hidden" name="mode" value="" />
         <input type="hidden" name="division" value="footer" />
-        <input type="hidden" name="footer_row" value="<!--{$footer_row}-->" />
+        <input type="hidden" name="footer_row" value="<!--{$footer_row|h}-->" />
         <input type="hidden" name="device_type_id" value="<!--{$device_type_id|h}-->" />
 
         <textarea id="footer-area" class="top" name="footer" rows="<!--{$footer_row}-->" style="width: 100%;"><!--{"\n"}--><!--{$footer_data|h nofilter}--></textarea>

--- a/data/Smarty/templates/admin/design/index.tpl
+++ b/data/Smarty/templates/admin/design/index.tpl
@@ -50,8 +50,8 @@ function fnTargetSelf(){
                             <!--{if $item.target_id == $arrTarget[$smarty.const.TARGET_ID_HEAD]}-->
                                 <div class="sort<!--{if !$firstflg}--> first<!--{/if}-->">
                                     <input type="hidden" class="name" name="name_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.name}-->" />
-                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id}-->" />
-                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id}-->" />
+                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id|h}-->" />
+                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id|h}-->" />
                                     <input type="hidden" class="top" name="top_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_row}-->" />
                                     <!--{$item.name}-->
                                     <label class="anywherecheck">(<input type="checkbox" class="anywhere" name="anywhere_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="1" <!--{if $item.anywhere == 1}-->checked="checked"<!--{/if}--> />全ページ)</label>
@@ -73,8 +73,8 @@ function fnTargetSelf(){
                             <!--{if $item.target_id == $arrTarget[$smarty.const.TARGET_ID_HEAD_TOP]}-->
                                 <div class="sort<!--{if !$firstflg}--> first<!--{/if}-->">
                                     <input type="hidden" class="name" name="name_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.name}-->" />
-                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id}-->" />
-                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id}-->" />
+                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id|h}-->" />
+                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id|h}-->" />
                                     <input type="hidden" class="top" name="top_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_row}-->" />
                                     <!--{$item.name}-->
                                     <label class="anywherecheck">(<input type="checkbox" class="anywhere" name="anywhere_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="1" <!--{if $item.anywhere == 1}-->checked="checked"<!--{/if}--> />全ページ)</label>
@@ -94,8 +94,8 @@ function fnTargetSelf(){
                             <!--{if $item.target_id == $arrTarget[$smarty.const.TARGET_ID_HEADER_INTERNAL]}-->
                                 <div class="sort<!--{if !$firstflg}--> first<!--{/if}-->">
                                     <input type="hidden" class="name" name="name_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.name}-->" />
-                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id}-->" />
-                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id}-->" />
+                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id|h}-->" />
+                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id|h}-->" />
                                     <input type="hidden" class="top" name="top_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_row}-->" />
                                     <!--{$item.name}-->
                                     <label class="anywherecheck">(<input type="checkbox" class="anywhere" name="anywhere_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="1" <!--{if $item.anywhere == 1}-->checked="checked"<!--{/if}--> />全ページ)</label>
@@ -114,8 +114,8 @@ function fnTargetSelf(){
                             <!--{if $item.target_id == $arrTarget[$smarty.const.TARGET_ID_TOP]}-->
                                 <div class="sort<!--{if !$firstflg}--> first<!--{/if}-->">
                                     <input type="hidden" class="name" name="name_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.name}-->" />
-                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id}-->" />
-                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id}-->" />
+                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id|h}-->" />
+                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id|h}-->" />
                                     <input type="hidden" class="top" name="top_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_row}-->" />
                                     <!--{$item.name}-->
                                     <label class="anywherecheck">(<input type="checkbox" class="anywhere" name="anywhere_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="1" <!--{if $item.anywhere == 1}-->checked="checked"<!--{/if}--> />全ページ)</label>
@@ -136,8 +136,8 @@ function fnTargetSelf(){
                                 <!--{if $item.target_id == $arrTarget[$smarty.const.TARGET_ID_MAIN_HEAD]}-->
                                     <div class="sort<!--{if !$firstflg}--> first<!--{/if}-->">
                                         <input type="hidden" class="name" name="name_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.name}-->" />
-                                        <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id}-->" />
-                                        <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id}-->" />
+                                        <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id|h}-->" />
+                                        <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id|h}-->" />
                                         <input type="hidden" class="top" name="top_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_row}-->" />
                                         <!--{$item.name}-->
                                         <label class="anywherecheck">(<input type="checkbox" class="anywhere" name="anywhere_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="1" <!--{if $item.anywhere == 1}-->checked="checked"<!--{/if}--> />全ページ)</label>
@@ -161,8 +161,8 @@ function fnTargetSelf(){
                                 <!--{if $item.target_id == $arrTarget[$smarty.const.TARGET_ID_MAIN_FOOT]}-->
                                     <div class="sort<!--{if !$firstflg}--> first<!--{/if}-->">
                                         <input type="hidden" class="name" name="name_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.name}-->" />
-                                        <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id}-->" />
-                                        <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id}-->" />
+                                        <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id|h}-->" />
+                                        <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id|h}-->" />
                                         <input type="hidden" class="top" name="top_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_row}-->" />
                                         <!--{$item.name}-->
                                         <label class="anywherecheck">(<input type="checkbox" class="anywhere" name="anywhere_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="1" <!--{if $item.anywhere == 1}-->checked="checked"<!--{/if}--> />全ページ)</label>
@@ -181,8 +181,8 @@ function fnTargetSelf(){
                                 <!--{if $item.target_id == $arrTarget[$smarty.const.TARGET_ID_LEFT]}-->
                                     <div class="sort<!--{if !$firstflg}--> first<!--{/if}-->">
                                         <input type="hidden" class="name" name="name_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.name}-->" />
-                                        <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id}-->" />
-                                        <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id}-->" />
+                                        <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id|h}-->" />
+                                        <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id|h}-->" />
                                         <input type="hidden" class="top" name="top_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_row}-->" />
                                         <!--{$item.name}-->
                                         <label class="anywherecheck">(<input type="checkbox" class="anywhere" name="anywhere_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="1" <!--{if $item.anywhere == 1}-->checked="checked"<!--{/if}--> />全ページ)</label>
@@ -199,8 +199,8 @@ function fnTargetSelf(){
                                 <!--{if $item.target_id == $arrTarget[$smarty.const.TARGET_ID_MAIN_HEAD]}-->
                                     <div class="sort<!--{if !$firstflg}--> first<!--{/if}-->">
                                         <input type="hidden" class="name" name="name_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.name}-->" />
-                                        <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id}-->" />
-                                        <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id}-->" />
+                                        <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id|h}-->" />
+                                        <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id|h}-->" />
                                         <input type="hidden" class="top" name="top_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_row}-->" />
                                         <!--{$item.name}-->
                                         <label class="anywherecheck">(<input type="checkbox" class="anywhere" name="anywhere_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="1" <!--{if $item.anywhere == 1}-->checked="checked"<!--{/if}--> />全ページ)</label>
@@ -217,8 +217,8 @@ function fnTargetSelf(){
                                 <!--{if $item.target_id == $arrTarget[$smarty.const.TARGET_ID_RIGHT]}-->
                                     <div class="sort<!--{if !$firstflg}--> first<!--{/if}-->">
                                         <input type="hidden" class="name" name="name_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.name}-->" />
-                                        <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id}-->" />
-                                        <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id}-->" />
+                                        <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id|h}-->" />
+                                        <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id|h}-->" />
                                         <input type="hidden" class="top" name="top_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_row}-->" />
                                         <!--{$item.name}-->
                                         <label class="anywherecheck">(<input type="checkbox" class="anywhere" name="anywhere_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="1" <!--{if $item.anywhere == 1}-->checked="checked"<!--{/if}--> />全ページ)</label>
@@ -242,8 +242,8 @@ function fnTargetSelf(){
                                 <!--{if $item.target_id == $arrTarget[$smarty.const.TARGET_ID_MAIN_FOOT]}-->
                                     <div class="sort<!--{if !$firstflg}--> first<!--{/if}-->">
                                         <input type="hidden" class="name" name="name_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.name}-->" />
-                                        <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id}-->" />
-                                        <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id}-->" />
+                                        <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id|h}-->" />
+                                        <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id|h}-->" />
                                         <input type="hidden" class="top" name="top_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_row}-->" />
                                         <!--{$item.name}-->
                                         <label class="anywherecheck">(<input type="checkbox" class="anywhere" name="anywhere_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="1" <!--{if $item.anywhere == 1}-->checked="checked"<!--{/if}--> />全ページ)</label>
@@ -263,8 +263,8 @@ function fnTargetSelf(){
                             <!--{if $item.target_id == $arrTarget[$smarty.const.TARGET_ID_BOTTOM]}-->
                                 <div class="sort<!--{if !$firstflg}--> first<!--{/if}-->">
                                     <input type="hidden" class="name" name="name_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.name}-->" />
-                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id}-->" />
-                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id}-->" />
+                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id|h}-->" />
+                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id|h}-->" />
                                     <input type="hidden" class="top" name="top_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_row}-->" />
                                     <!--{$item.name}-->
                                     <label class="anywherecheck">(<input type="checkbox" class="anywhere" name="anywhere_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="1" <!--{if $item.anywhere == 1}-->checked="checked"<!--{/if}--> />全ページ)</label>
@@ -286,8 +286,8 @@ function fnTargetSelf(){
                             <!--{if $item.target_id == $arrTarget[$smarty.const.TARGET_ID_FOOTER_BOTTOM]}-->
                                 <div class="sort<!--{if !$firstflg}--> first<!--{/if}-->">
                                     <input type="hidden" class="name" name="name_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.name}-->" />
-                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id}-->" />
-                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id}-->" />
+                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id|h}-->" />
+                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id|h}-->" />
                                     <input type="hidden" class="top" name="top_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_row}-->" />
                                     <!--{$item.name}-->
                                     <label class="anywherecheck">(<input type="checkbox" class="anywhere" name="anywhere_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="1" <!--{if $item.anywhere == 1}-->checked="checked"<!--{/if}--> />全ページ)</label>
@@ -315,8 +315,8 @@ function fnTargetSelf(){
                             <!--{if $item.target_id == $arrTarget[$smarty.const.TARGET_ID_UNUSED]}-->
                                 <div class="sort<!--{if !$firstflg}--> first<!--{/if}-->">
                                     <input type="hidden" class="name" name="name_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.name}-->" />
-                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id}-->" />
-                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id}-->" />
+                                    <input type="hidden" class="id" name="id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_id|h}-->" />
+                                    <input type="hidden" class="target-id" name="target_id_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.target_id|h}-->" />
                                     <input type="hidden" class="top" name="top_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="<!--{$item.bloc_row}-->" />
                                     <!--{$item.name}-->
                                     <label class="anywherecheck">(<input type="checkbox" class="anywhere" name="anywhere_<!--{$smarty.foreach.bloc_loop.iteration}-->" value="1" <!--{if $item.anywhere == 1}-->checked="checked"<!--{/if}--> />全ページ)</label>
@@ -358,11 +358,11 @@ function fnTargetSelf(){
                     <!--{$item.page_name}-->
                 </td>
                 <td class="center">
-                    <a href="?page_id=<!--{$item.page_id}-->&amp;device_type_id=<!--{$item.device_type_id}-->" >編集</a>
+                    <a href="?page_id=<!--{$item.page_id|h}-->&amp;device_type_id=<!--{$item.device_type_id|h}-->" >編集</a>
                 </td>
                 <td class="center">
                     <!--{if $item.filename|strlen >= 1}-->
-                        <a href="main_edit.php?page_id=<!--{$item.page_id}-->&amp;device_type_id=<!--{$item.device_type_id}-->">編集</a>
+                        <a href="main_edit.php?page_id=<!--{$item.page_id|h}-->&amp;device_type_id=<!--{$item.device_type_id|h}-->">編集</a>
                     <!--{/if}-->
                 </td>
                 <td class="center">

--- a/data/Smarty/templates/admin/design/main_edit.tpl
+++ b/data/Smarty/templates/admin/design/main_edit.tpl
@@ -82,7 +82,7 @@ function fnTargetSelf(){
                 <label for="footer-chk"><input type="checkbox" name="footer_chk" id="footer-chk" value="1" <!--{if $arrForm.footer_chk.value == "1"}-->checked="checked"<!--{/if}--> />共通のフッターを使用する</label>
                 <div>
                     <textarea id="tpl_data" class="top" name="tpl_data" rows="<!--{$text_row}-->" style="width: 98%;"><!--{"\n"}--><!--{$arrForm.tpl_data.value|h nofilter}--></textarea>
-                    <input type="hidden" name="html_area_row" value="<!--{$text_row}-->" /><br />
+                    <input type="hidden" name="html_area_row" value="<!--{$text_row|h}-->" /><br />
                     <a id="resize-btn" class="btn-normal" href="javascript:;" onclick="eccube.toggleRows('#resize-btn', '#tpl_data', 50, 13); return false;"><span>拡大</span></a>
                 </div>
             </td>

--- a/data/Smarty/templates/admin/design/main_edit.tpl
+++ b/data/Smarty/templates/admin/design/main_edit.tpl
@@ -160,7 +160,7 @@ function fnTargetSelf(){
                 </td>
                 <td class="center">
                     <!--{if $item.filename|strlen >= 1}-->
-                        <a href="?page_id=<!--{$item.page_id}-->&amp;device_type_id=<!--{$item.device_type_id}-->">編集</a>
+                        <a href="?page_id=<!--{$item.page_id|h}-->&amp;device_type_id=<!--{$item.device_type_id|h}-->">編集</a>
                     <!--{/if}-->
                 </td>
                 <td class="center">

--- a/data/Smarty/templates/admin/design/template.tpl
+++ b/data/Smarty/templates/admin/design/template.tpl
@@ -71,8 +71,8 @@ function submitRegister() {
                 <td><input type="radio" name="template_code" value="<!--{$tplcode|h}-->" <!--{if $tplcode == $tpl_select}-->checked="checked"<!--{/if}--> /></td>
                 <td class="left"><!--{$tpl.template_name|h}--></td>
                 <td class="left">data/Smarty/templates/<!--{$tplcode|h}-->/</td>
-                <td><span class="icon_confirm"><a href="javascript:;" onclick="eccube.fnFormModeSubmit('form2', 'download','template_code','<!--{$tplcode}-->');return false;">ダウンロード</a></span></td>
-                <td><span class="icon_delete"><a href="javascript:;" onclick="eccube.fnFormModeSubmit('form2', 'delete','template_code','<!--{$tplcode}-->');return false;">削除</a></span></td>
+                <td><span class="icon_confirm"><a href="javascript:;" onclick="eccube.fnFormModeSubmit('form2', 'download','template_code','<!--{$tplcode|h}-->');return false;">ダウンロード</a></span></td>
+                <td><span class="icon_delete"><a href="javascript:;" onclick="eccube.fnFormModeSubmit('form2', 'delete','template_code','<!--{$tplcode|h}-->');return false;">削除</a></span></td>
             </tr>
             <!--{/foreach}-->
         </table>

--- a/data/Smarty/templates/admin/mail/input.tpl
+++ b/data/Smarty/templates/admin/mail/input.tpl
@@ -34,7 +34,7 @@
     <!--{/if}-->
 <!--{/foreach}-->
 <input type="hidden" name="mode" value="template" />
-<input type="hidden" name="mail_method" value="<!--{$arrForm.mail_method.value}-->" />
+<input type="hidden" name="mail_method" value="<!--{$arrForm.mail_method.value|h}-->" />
 <div id="mail" class="contents-main">
     <table class="form">
         <tr>

--- a/data/Smarty/templates/admin/mail/template_input.tpl
+++ b/data/Smarty/templates/admin/mail/template_input.tpl
@@ -24,7 +24,7 @@
 
 <form name="form1" id="form1" method="post" action="?">
     <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
-    <input type="hidden" name="mode" value="<!--{$mode}-->" />
+    <input type="hidden" name="mode" value="<!--{$mode|h}-->" />
     <input type="hidden" name="template_id" value="<!--{$arrForm.template_id|h}-->" />
     <div id="mail" class="contents-main">
         <table class="form">
@@ -56,7 +56,7 @@
         </table>
         <div class="btn-area">
             <ul>
-                <li><a class="btn-action" href="javascript:;" onclick="eccube.fnFormModeSubmit('form1', '<!--{$mode}-->', '', ''); return false;"><span class="btn-next">この内容で登録する</span></a></li>
+                <li><a class="btn-action" href="javascript:;" onclick="eccube.fnFormModeSubmit('form1', '<!--{$mode|h}-->', '', ''); return false;"><span class="btn-next">この内容で登録する</span></a></li>
             </ul>
         </div>
     </div>

--- a/data/Smarty/templates/admin/order/edit.tpl
+++ b/data/Smarty/templates/admin/order/edit.tpl
@@ -404,7 +404,7 @@
                         <!--{if $tpl_shipping_quantity <= 1}-->
                             <a class="btn-normal" href="javascript:;" name="change" onclick="eccube.openWindow('<!--{$smarty.const.ROOT_URLPATH}--><!--{$smarty.const.ADMIN_DIR}-->order/product_select.php?no=<!--{$product_index}-->&amp;order_id=<!--{$arrForm.order_id.value|h}-->&amp;shipping_id=<!--{$top_shipping_id}-->', 'search', '615', '500', {menubar:'no'}); return false;">変更</a>
                             <!--{if !empty($arrForm.quantity.value) && count($arrForm.quantity.value) > 1}-->
-                                <a class="btn-normal" href="javascript:;" name="delete" onclick="eccube.setValue('delete_no', <!--{$product_index}-->, 'form1'); eccube.setValue('select_shipping_id', '<!--{$top_shipping_id}-->', 'form1'); eccube.setModeAndSubmit('delete_product','anchor_key','order_products'); return false;">削除</a>
+                                <a class="btn-normal" href="javascript:;" name="delete" onclick="eccube.setValue('delete_no', <!--{$product_index}-->, 'form1'); eccube.setValue('select_shipping_id', '<!--{$top_shipping_id|h}-->', 'form1'); eccube.setModeAndSubmit('delete_product','anchor_key','order_products'); return false;">削除</a>
                             <!--{/if}-->
                         <!--{/if}-->
                     <input type="hidden" name="product_type_id[<!--{$product_index}-->]" value="<!--{$arrForm.product_type_id.value[$product_index]|h}-->" id="product_type_id_<!--{$product_index}-->" />

--- a/data/Smarty/templates/admin/order/edit.tpl
+++ b/data/Smarty/templates/admin/order/edit.tpl
@@ -97,7 +97,7 @@
     function quantityCopyForSingleShipping(product_index){
         var product_index = parseInt(product_index);
         var input_quantity = $('input[name^="quantity[' + product_index + ']"]').val();
-        $('input[name^="shipment_quantity[<!--{$top_shipping_id}-->][' + product_index + ']"]').val(input_quantity);
+        $('input[name^="shipment_quantity[<!--{$top_shipping_id|h}-->][' + product_index + ']"]').val(input_quantity);
     }
 
 //-->
@@ -371,7 +371,7 @@
             受注商品情報
             <a class="btn-normal" href="javascript:;" name="recalculate" onclick="eccube.setModeAndSubmit('recalculate','anchor_key','order_products');">計算結果の確認</a>
             <!--{if $tpl_shipping_quantity <= 1}-->
-                <a class="btn-normal" href="javascript:;" name="add_product" onclick="eccube.openWindow('<!--{$smarty.const.ROOT_URLPATH}--><!--{$smarty.const.ADMIN_DIR}-->order/product_select.php?order_id=<!--{$arrForm.order_id.value|h}-->&amp;shipping_id=<!--{$top_shipping_id}-->', 'search', '615', '500', {menubar:'no'}); return false;">商品の追加</a>
+                <a class="btn-normal" href="javascript:;" name="add_product" onclick="eccube.openWindow('<!--{$smarty.const.ROOT_URLPATH}--><!--{$smarty.const.ADMIN_DIR}-->order/product_select.php?order_id=<!--{$arrForm.order_id.value|h}-->&amp;shipping_id=<!--{$top_shipping_id|h}-->', 'search', '615', '500', {menubar:'no'}); return false;">商品の追加</a>
             <!--{/if}-->
         </h2>
 
@@ -402,7 +402,7 @@
                         <input type="hidden" name="classcategory_name2[<!--{$product_index}-->]" value="<!--{$arrForm.classcategory_name2.value[$product_index]|h}-->" id="classcategory_name2_<!--{$product_index}-->" />
                         <br />
                         <!--{if $tpl_shipping_quantity <= 1}-->
-                            <a class="btn-normal" href="javascript:;" name="change" onclick="eccube.openWindow('<!--{$smarty.const.ROOT_URLPATH}--><!--{$smarty.const.ADMIN_DIR}-->order/product_select.php?no=<!--{$product_index}-->&amp;order_id=<!--{$arrForm.order_id.value|h}-->&amp;shipping_id=<!--{$top_shipping_id}-->', 'search', '615', '500', {menubar:'no'}); return false;">変更</a>
+                            <a class="btn-normal" href="javascript:;" name="change" onclick="eccube.openWindow('<!--{$smarty.const.ROOT_URLPATH}--><!--{$smarty.const.ADMIN_DIR}-->order/product_select.php?no=<!--{$product_index}-->&amp;order_id=<!--{$arrForm.order_id.value|h}-->&amp;shipping_id=<!--{$top_shipping_id|h}-->', 'search', '615', '500', {menubar:'no'}); return false;">変更</a>
                             <!--{if !empty($arrForm.quantity.value) && count($arrForm.quantity.value) > 1}-->
                                 <a class="btn-normal" href="javascript:;" name="delete" onclick="eccube.setValue('delete_no', <!--{$product_index}-->, 'form1'); eccube.setValue('select_shipping_id', '<!--{$top_shipping_id|h}-->', 'form1'); eccube.setModeAndSubmit('delete_product','anchor_key','order_products'); return false;">削除</a>
                             <!--{/if}-->
@@ -530,9 +530,9 @@
                 <h3>お届け先<!--{$smarty.foreach.shipping.iteration}--></h3>
             <!--{/if}-->
             <!--{assign var=key value="shipping_id"}-->
-            <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key]|default:"0"|h}-->" id="<!--{$key}-->_<!--{$shipping_index}-->" />
+            <input type="hidden" name="<!--{$key|h}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key]|default:"0"|h}-->" id="<!--{$key|h}-->_<!--{$shipping_index|h}-->" />
             <!--{if $tpl_shipping_quantity > 1}-->
-                <h2>届け先商品情報&nbsp;<a class="btn-normal" href="javascript:;" name="add_product" onclick="eccube.openWindow('<!--{$smarty.const.ROOT_URLPATH}--><!--{$smarty.const.ADMIN_DIR}-->order/product_select.php?order_id=<!--{$arrForm.order_id.value|h}-->&shipping_id=<!--{$shipping_index}-->', 'search', '615', '500', {menubar:'no'}); return false;">商品の追加</a>
+                <h2>届け先商品情報&nbsp;<a class="btn-normal" href="javascript:;" name="add_product" onclick="eccube.openWindow('<!--{$smarty.const.ROOT_URLPATH}--><!--{$smarty.const.ADMIN_DIR}-->order/product_select.php?order_id=<!--{$arrForm.order_id.value|h}-->&shipping_id=<!--{$shipping_index|h}-->', 'search', '615', '500', {menubar:'no'}); return false;">商品の追加</a>
                 </h2>
 
                 <!--{if !empty($arrShipping.shipment_product_class_id)}-->
@@ -549,34 +549,34 @@
                             <tr>
                                 <td class="center">
                                     <!--{assign var=key value="shipment_product_class_id"}-->
-                                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
+                                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
                                     <!--{assign var=key value="shipment_product_code"}-->
-                                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
+                                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
                                     <!--{$arrShipping[$key][$item_index]|h}-->
                                 </td>
                                 <td class="center">
                                     <!--{assign var=key1 value="shipment_product_name"}-->
                                     <!--{assign var=key2 value="shipment_classcategory_name1"}-->
                                     <!--{assign var=key3 value="shipment_classcategory_name2"}-->
-                                    <input type="hidden" name="<!--{$key1}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key1][$item_index]|h}-->" />
-                                    <input type="hidden" name="<!--{$key2}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key2][$item_index]|h}-->" />
-                                    <input type="hidden" name="<!--{$key3}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key3][$item_index]|h}-->" />
+                                    <input type="hidden" name="<!--{$key1}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key1][$item_index]|h}-->" />
+                                    <input type="hidden" name="<!--{$key2}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key2][$item_index]|h}-->" />
+                                    <input type="hidden" name="<!--{$key3}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key3][$item_index]|h}-->" />
                                     <!--{$arrShipping[$key1][$item_index]|h}-->/<!--{$arrShipping[$key2][$item_index]|default:"(なし)"|h}-->/<!--{$arrShipping[$key3][$item_index]|default:"(なし)"|h}-->
                                     <br />
-                                    <a class="btn-normal" href="javascript:;" name="change" onclick="eccube.openWindow('<!--{$smarty.const.ROOT_URLPATH}--><!--{$smarty.const.ADMIN_DIR}-->order/product_select.php?no=<!--{$item_index}-->&amp;order_id=<!--{$arrForm.order_id.value|h}-->&amp;shipping_id=<!--{$shipping_index}-->', 'search', '615', '500', {menubar:'no'}); return false;">変更</a>
+                                    <a class="btn-normal" href="javascript:;" name="change" onclick="eccube.openWindow('<!--{$smarty.const.ROOT_URLPATH}--><!--{$smarty.const.ADMIN_DIR}-->order/product_select.php?no=<!--{$item_index}-->&amp;order_id=<!--{$arrForm.order_id.value|h}-->&amp;shipping_id=<!--{$shipping_index|h}-->', 'search', '615', '500', {menubar:'no'}); return false;">変更</a>
                                     <!--{if !empty($arrShipping.shipment_product_class_id)}-->
-                                    <a class="btn-normal" href="javascript:;" name="delete" onclick="eccube.setValue('delete_no', <!--{$item_index}-->, 'form1'); eccube.setValue('select_shipping_id', <!--{$shipping_index}-->, 'form1'); eccube.setModeAndSubmit('delete_product','anchor_key','order_products'); return false;">削除</a>
+                                    <a class="btn-normal" href="javascript:;" name="delete" onclick="eccube.setValue('delete_no', <!--{$item_index|h}-->, 'form1'); eccube.setValue('select_shipping_id', <!--{$shipping_index|h}-->, 'form1'); eccube.setModeAndSubmit('delete_product','anchor_key','order_products'); return false;">削除</a>
                                     <!--{/if}-->
                                 </td>
                                 <td class="right">
                                     <!--{assign var=key value="shipment_price"}-->
                                     <!--{$arrShipping[$key][$item_index]|n2s}-->円
-                                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
+                                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
                                 </td>
                                 <td class="center">
                                     <!--{assign var=key value="shipment_quantity"}-->
                                     <span class="attention"><!--{$arrErr[$key][$shipping_index][$item_index]}--></span>
-                                    <input type="text" name="<!--{$key}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" size="3" class="box3" maxlength="<!--{$arrForm[$key].length}-->" />
+                                    <input type="text" name="<!--{$key}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" size="3" class="box3" maxlength="<!--{$arrForm[$key].length}-->" />
                                 </td>
                             </tr>
                         <!--{/section}-->
@@ -588,19 +588,19 @@
                 <!--{section name=item loop=$arrShipping.shipment_product_class_id|@count}-->
                     <!--{assign var=item_index value="`$smarty.section.item.index`"}-->
                     <!--{assign var=key value="shipment_product_class_id"}-->
-                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
+                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
                     <!--{assign var=key value="shipment_product_code"}-->
-                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
+                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
                     <!--{assign var=key1 value="shipment_product_name"}-->
                     <!--{assign var=key2 value="shipment_classcategory_name1"}-->
                     <!--{assign var=key3 value="shipment_classcategory_name2"}-->
-                    <input type="hidden" name="<!--{$key1}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key1][$item_index]|h}-->" />
-                    <input type="hidden" name="<!--{$key2}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key2][$item_index]|h}-->" />
-                    <input type="hidden" name="<!--{$key3}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key3][$item_index]|h}-->" />
+                    <input type="hidden" name="<!--{$key1}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key1][$item_index]|h}-->" />
+                    <input type="hidden" name="<!--{$key2}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key2][$item_index]|h}-->" />
+                    <input type="hidden" name="<!--{$key3}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key3][$item_index]|h}-->" />
                     <!--{assign var=key value="shipment_price"}-->
-                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
+                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
                     <!--{assign var=key value="shipment_quantity"}-->
-                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
+                    <input type="hidden" name="<!--{$key}-->[<!--{$shipping_index|h}-->][<!--{$item_index}-->]" value="<!--{$arrShipping[$key][$item_index]|h}-->" />
                 <!--{/section}-->
             <!--{/if}-->
 
@@ -611,8 +611,8 @@
                         <!--{assign var=key1 value="shipping_name01"}-->
                         <!--{assign var=key2 value="shipping_name02"}-->
                         <span class="attention"><!--{$arrErr[$key1][$shipping_index]}--><!--{$arrErr[$key2][$shipping_index]}--></span>
-                        <input type="text" name="<!--{$key1}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key1]|h}-->" maxlength="<!--{$arrForm[$key1].length}-->" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->" size="15" class="box15" />
-                        <input type="text" name="<!--{$key2}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key2]|h}-->" maxlength="<!--{$arrForm[$key2].length}-->" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->" size="15" class="box15" />
+                        <input type="text" name="<!--{$key1}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key1]|h}-->" maxlength="<!--{$arrForm[$key1].length}-->" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->" size="15" class="box15" />
+                        <input type="text" name="<!--{$key2}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key2]|h}-->" maxlength="<!--{$arrForm[$key2].length}-->" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->" size="15" class="box15" />
                     </td>
                 </tr>
                 <tr>
@@ -621,8 +621,8 @@
                         <!--{assign var=key1 value="shipping_kana01"}-->
                         <!--{assign var=key2 value="shipping_kana02"}-->
                         <span class="attention"><!--{$arrErr[$key1][$shipping_index]}--><!--{$arrErr[$key2][$shipping_index]}--></span>
-                        <input type="text" name="<!--{$key1}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key1]|h}-->" maxlength="<!--{$arrForm[$key1].length}-->" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->" size="15" class="box15" />
-                        <input type="text" name="<!--{$key2}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key2]|h}-->" maxlength="<!--{$arrForm[$key2].length}-->" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->" size="15" class="box15" />
+                        <input type="text" name="<!--{$key1}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key1]|h}-->" maxlength="<!--{$arrForm[$key1].length}-->" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->" size="15" class="box15" />
+                        <input type="text" name="<!--{$key2}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key2]|h}-->" maxlength="<!--{$arrForm[$key2].length}-->" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->" size="15" class="box15" />
                     </td>
                 </tr>
                 <tr>
@@ -630,7 +630,7 @@
                     <td>
                         <!--{assign var=key1 value="shipping_company_name"}-->
                         <span class="attention"><!--{$arrErr[$key1][$shipping_index]}--></span>
-                        <input type="text" name="<!--{$key1}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key1]|h}-->" maxlength="<!--{$arrForm[$key1].length}-->" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->" size="30" class="box30" />
+                        <input type="text" name="<!--{$key1}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key1]|h}-->" maxlength="<!--{$arrForm[$key1].length}-->" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->" size="30" class="box30" />
                     </td>
                 </tr>
                 <tr>
@@ -642,9 +642,9 @@
                         <span class="attention"><!--{$arrErr[$key1][$shipping_index]}--></span>
                         <span class="attention"><!--{$arrErr[$key2][$shipping_index]}--></span>
                         <span class="attention"><!--{$arrErr[$key3][$shipping_index]}--></span>
-                        <input type="text" name="<!--{$key1}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key1]|h}-->" maxlength="<!--{$arrForm[$key1].length}-->" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" /> -
-                        <input type="text" name="<!--{$key2}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key2]|h}-->" maxlength="<!--{$arrForm[$key2].length}-->" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" /> -
-                        <input type="text" name="<!--{$key3}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key3]|h}-->" maxlength="<!--{$arrForm[$key3].length}-->" style="<!--{$arrErr[$key3][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" />
+                        <input type="text" name="<!--{$key1}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key1]|h}-->" maxlength="<!--{$arrForm[$key1].length}-->" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" /> -
+                        <input type="text" name="<!--{$key2}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key2]|h}-->" maxlength="<!--{$arrForm[$key2].length}-->" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" /> -
+                        <input type="text" name="<!--{$key3}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key3]|h}-->" maxlength="<!--{$arrForm[$key3].length}-->" style="<!--{$arrErr[$key3][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" />
                     </td>
                 </tr>
                 <tr>
@@ -656,21 +656,21 @@
                         <span class="attention"><!--{$arrErr[$key1][$shipping_index]}--></span>
                         <span class="attention"><!--{$arrErr[$key2][$shipping_index]}--></span>
                         <span class="attention"><!--{$arrErr[$key3][$shipping_index]}--></span>
-                        <input type="text" name="<!--{$key1}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key1]|h}-->" maxlength="<!--{$arrForm[$key1].length}-->" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" /> -
-                        <input type="text" name="<!--{$key2}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key2]|h}-->" maxlength="<!--{$arrForm[$key2].length}-->" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" /> -
-                        <input type="text" name="<!--{$key3}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key3]|h}-->" maxlength="<!--{$arrForm[$key3].length}-->" style="<!--{$arrErr[$key3][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" />
+                        <input type="text" name="<!--{$key1}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key1]|h}-->" maxlength="<!--{$arrForm[$key1].length}-->" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" /> -
+                        <input type="text" name="<!--{$key2}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key2]|h}-->" maxlength="<!--{$arrForm[$key2].length}-->" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" /> -
+                        <input type="text" name="<!--{$key3}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key3]|h}-->" maxlength="<!--{$arrForm[$key3].length}-->" style="<!--{$arrErr[$key3][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" />
                     </td>
                 </tr>
                 <!--{assign var=key1 value="shipping_country_id"}-->
                 <!--{assign var=key2 value="shipping_zipcode"}-->
                 <!--{if !$smarty.const.FORM_COUNTRY_ENABLE}-->
-                <input type="hidden" name="<!--{$key1}-->[<!--{$shipping_index}-->]" value="<!--{$smarty.const.DEFAULT_COUNTRY_ID}-->" />
+                <input type="hidden" name="<!--{$key1}-->[<!--{$shipping_index|h}-->]" value="<!--{$smarty.const.DEFAULT_COUNTRY_ID}-->" />
                 <!--{else}-->
                 <tr>
                     <th>国</th>
                     <td>
                         <span class="attention"><!--{$arrErr[$key1][$shipping_index]}--></span>
-                        <select name="<!--{$key1}-->[<!--{$shipping_index}-->]" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->">
+                        <select name="<!--{$key1}-->[<!--{$shipping_index|h}-->]" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->">
                                 <!--{html_options options=$arrCountry selected=$arrShipping[$key1]|default:$smarty.const.DEFAULT_COUNTRY_ID}-->
                         </select>
                     </td>
@@ -679,7 +679,7 @@
                     <th>ZIP CODE</th>
                     <td>
                         <span class="attention"><!--{$arrErr[$key2][$shipping_index]}--></span>
-                        <input type="text" name="<!--{$key2}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key2]|h}-->" maxlength="<!--{$arrForm[$key2].length}-->" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->;" size="15" class="box15"/>
+                        <input type="text" name="<!--{$key2}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key2]|h}-->" maxlength="<!--{$arrForm[$key2].length}-->" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->;" size="15" class="box15"/>
                     </td>
                 </tr>
                 <!--{/if}-->
@@ -690,22 +690,22 @@
                         <!--{assign var=key2 value="shipping_zip02"}-->
                         <span class="attention"><!--{$arrErr[$key1][$shipping_index]}--><!--{$arrErr[$key2][$shipping_index]}--></span>
                         〒
-                        <input type="text" name="<!--{$key1}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key1]|h}-->" maxlength="<!--{$arrForm[$key1].length}-->" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" />
+                        <input type="text" name="<!--{$key1}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key1]|h}-->" maxlength="<!--{$arrForm[$key1].length}-->" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" />
                         -
-                        <input type="text" name="<!--{$key2}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key2]|h}-->" maxlength="<!--{$arrForm[$key2].length}-->" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" />
-                        <a class="btn-normal" href="javascript:;" name="address_input" onclick="eccube.getAddress('<!--{$smarty.const.INPUT_ZIP_URLPATH}-->', 'shipping_zip01[<!--{$shipping_index}-->]', 'shipping_zip02[<!--{$shipping_index}-->]', 'shipping_pref[<!--{$shipping_index}-->]', 'shipping_addr01[<!--{$shipping_index}-->]'); return false;">住所入力</a><br />
+                        <input type="text" name="<!--{$key2}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key2]|h}-->" maxlength="<!--{$arrForm[$key2].length}-->" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->" size="6" class="box6" />
+                        <a class="btn-normal" href="javascript:;" name="address_input" onclick="eccube.getAddress('<!--{$smarty.const.INPUT_ZIP_URLPATH}-->', 'shipping_zip01[<!--{$shipping_index|h}-->]', 'shipping_zip02[<!--{$shipping_index|h}-->]', 'shipping_pref[<!--{$shipping_index|h}-->]', 'shipping_addr01[<!--{$shipping_index|h}-->]'); return false;">住所入力</a><br />
                         <!--{assign var=key value="shipping_pref"}-->
                         <span class="attention"><!--{$arrErr[$key][$shipping_index]}--></span>
-                        <select class="top" name="<!--{$key}-->[<!--{$shipping_index}-->]" style="<!--{$arrErr[$key][$shipping_index]|sfGetErrorColor}-->">
+                        <select class="top" name="<!--{$key}-->[<!--{$shipping_index|h}-->]" style="<!--{$arrErr[$key][$shipping_index]|sfGetErrorColor}-->">
                             <option value="" selected="">都道府県を選択</option>
                             <!--{html_options options=$arrPref selected=$arrShipping[$key]}-->
                         </select><br />
                         <!--{assign var=key value="shipping_addr01"}-->
                         <span class="attention"><!--{$arrErr[$key][$shipping_index]}--></span>
-                        <input type="text" name="<!--{$key}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key]|h}-->" size="60" class="box60 top" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key][$shipping_index]|sfGetErrorColor}-->" /><br />
+                        <input type="text" name="<!--{$key}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key]|h}-->" size="60" class="box60 top" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key][$shipping_index]|sfGetErrorColor}-->" /><br />
                         <!--{assign var=key value="shipping_addr02"}-->
                         <span class="attention"><!--{$arrErr[$key][$shipping_index]}--></span>
-                        <input type="text" name="<!--{$key}-->[<!--{$shipping_index}-->]" value="<!--{$arrShipping[$key]|h}-->" size="60" class="box60" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key][$shipping_index]|sfGetErrorColor}-->" />
+                        <input type="text" name="<!--{$key}-->[<!--{$shipping_index|h}-->]" value="<!--{$arrShipping[$key]|h}-->" size="60" class="box60" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key][$shipping_index]|sfGetErrorColor}-->" />
                     </td>
                 </tr>
                 <tr>
@@ -713,7 +713,7 @@
                     <td>
                         <!--{assign var=key value="time_id"}-->
                         <span class="attention"><!--{$arrErr[$key][$shipping_index]}--></span>
-                        <select name="<!--{$key}-->[<!--{$shipping_index}-->]" style="<!--{$arrErr[$key][$shipping_index]|sfGetErrorColor}-->">
+                        <select name="<!--{$key}-->[<!--{$shipping_index|h}-->]" style="<!--{$arrErr[$key][$shipping_index]|sfGetErrorColor}-->">
                             <option value="">指定無し</option>
                             <!--{html_options options=$arrDelivTime selected=$arrShipping[$key]}-->
                         </select>
@@ -728,13 +728,13 @@
                         <span class="attention"><!--{$arrErr[$key1][$shipping_index]}--></span>
                         <span class="attention"><!--{$arrErr[$key2][$shipping_index]}--></span>
                         <span class="attention"><!--{$arrErr[$key3][$shipping_index]}--></span>
-                        <select name="<!--{$key1}-->[<!--{$shipping_index}-->]" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->">
+                        <select name="<!--{$key1}-->[<!--{$shipping_index|h}-->]" style="<!--{$arrErr[$key1][$shipping_index]|sfGetErrorColor}-->">
                             <!--{html_options options=$arrYearShippingDate selected=$arrShipping[$key1]|default:""}-->
                         </select>年
-                        <select name="<!--{$key2}-->[<!--{$shipping_index}-->]" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->">
+                        <select name="<!--{$key2}-->[<!--{$shipping_index|h}-->]" style="<!--{$arrErr[$key2][$shipping_index]|sfGetErrorColor}-->">
                             <!--{html_options options=$arrMonthShippingDate selected=$arrShipping[$key2]|default:""}-->
                         </select>月
-                        <select name="<!--{$key3}-->[<!--{$shipping_index}-->]" style="<!--{$arrErr[$key3][$shipping_index]|sfGetErrorColor}-->">
+                        <select name="<!--{$key3}-->[<!--{$shipping_index|h}-->]" style="<!--{$arrErr[$key3][$shipping_index]|sfGetErrorColor}-->">
                             <!--{html_options options=$arrDayShippingDate selected=$arrShipping[$key3]|default:""}-->
                         </select>日
                     </td>

--- a/data/Smarty/templates/admin/order/index.tpl
+++ b/data/Smarty/templates/admin/order/index.tpl
@@ -388,17 +388,17 @@
                                 <td class="center"><!--{$arrResults[cnt].commit_date|sfDispDBDate|default:"未発送"}--></td>
                                 <td class="center"><!--{$arrORDERSTATUS[$status]}--></td>
                                 <td class="center">
-                                    <input type="checkbox" name="pdf_order_id[]" value="<!--{$arrResults[cnt].order_id}-->" id="pdf_order_id_<!--{$arrResults[cnt].order_id}-->"/><label for="pdf_order_id_<!--{$arrResults[cnt].order_id}-->">一括出力</label><br />
-                                    <a href="./" onClick="eccube.openWindow('pdf.php?order_id=<!--{$arrResults[cnt].order_id}-->','pdf_input','620','650'); return false;"><span class="icon_class">個別出力</span></a>
+                                    <input type="checkbox" name="pdf_order_id[]" value="<!--{$arrResults[cnt].order_id|h}-->" id="pdf_order_id_<!--{$arrResults[cnt].order_id|h}-->"/><label for="pdf_order_id_<!--{$arrResults[cnt].order_id|h}-->">一括出力</label><br />
+                                    <a href="./" onClick="eccube.openWindow('pdf.php?order_id=<!--{$arrResults[cnt].order_id|h}-->','pdf_input','620','650'); return false;"><span class="icon_class">個別出力</span></a>
                                 </td>
                                 <td class="center"><a href="?" onclick="eccube.changeAction('<!--{$smarty.const.ADMIN_ORDER_EDIT_URLPATH}-->'); eccube.setModeAndSubmit('pre_edit', 'order_id', '<!--{$arrResults[cnt].order_id}-->'); return false;"><span class="icon_edit">編集</span></a></td>
                                 <td class="center">
                                     <!--{if $arrResults[cnt].order_email|strlen >= 1}-->
-                                        <input type="checkbox" name="mail_order_id[]" value="<!--{$arrResults[cnt].order_id}-->" id="mail_order_id_<!--{$arrResults[cnt].order_id}-->"/><label for="mail_order_id_<!--{$arrResults[cnt].order_id}-->">一括通知</label><br />
+                                        <input type="checkbox" name="mail_order_id[]" value="<!--{$arrResults[cnt].order_id|h}-->" id="mail_order_id_<!--{$arrResults[cnt].order_id|h}-->"/><label for="mail_order_id_<!--{$arrResults[cnt].order_id|h}-->">一括通知</label><br />
                                         <a href="?" onclick="eccube.changeAction('<!--{$smarty.const.ADMIN_ORDER_MAIL_URLPATH}-->'); eccube.setModeAndSubmit('pre_edit', 'order_id', '<!--{$arrResults[cnt].order_id}-->'); return false;"><span class="icon_mail">個別通知</span></a>
                                     <!--{/if}-->
                                 </td>
-                                <td class="center"><a href="?" onclick="eccube.setModeAndSubmit('delete', 'order_id', <!--{$arrResults[cnt].order_id}-->); return false;"><span class="icon_delete">削除</span></a></td>
+                                <td class="center"><a href="?" onclick="eccube.setModeAndSubmit('delete', 'order_id', <!--{$arrResults[cnt].order_id|h}-->); return false;"><span class="icon_delete">削除</span></a></td>
                             </tr>
                         <!--{/section}-->
                     <!--{/if}-->

--- a/data/Smarty/templates/admin/order/mail.tpl
+++ b/data/Smarty/templates/admin/order/mail.tpl
@@ -25,7 +25,7 @@
 <form name="form1" id="form1" method="post" action="?">
     <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
     <input type="hidden" name="mode" value="confirm" />
-    <input type="hidden" name="order_id_array" value="<!--{$order_id_array}-->" />
+    <input type="hidden" name="order_id_array" value="<!--{$order_id_array|h}-->" />
     <!--{foreach key=key item=item from=$arrSearchHidden}-->
         <!--{if is_array($item)}-->
             <!--{foreach item=c_item from=$item}-->

--- a/data/Smarty/templates/admin/order/mail_confirm.tpl
+++ b/data/Smarty/templates/admin/order/mail_confirm.tpl
@@ -25,7 +25,7 @@
 <form name="form1" id="form1" method="post" action="?">
     <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
     <input type="hidden" name="mode" value="send" />
-    <input type="hidden" name="order_id_array" value="<!--{$order_id_array}-->" />
+    <input type="hidden" name="order_id_array" value="<!--{$order_id_array|h}-->" />
     <!--{foreach key=key item=item from=$arrForm}-->
     <input type="hidden" name="<!--{$key}-->" value="<!--{$item.value|h}-->" />
     <!--{/foreach}-->

--- a/data/Smarty/templates/admin/order/multiple.tpl
+++ b/data/Smarty/templates/admin/order/multiple.tpl
@@ -151,7 +151,7 @@ function func_submit() {
     <input name="mode" type="hidden" value="search" />
     <input name="anchor_key" type="hidden" value="" />
     <input name="search_pageno" type="hidden" value="" />
-    <input name="no" type="hidden" value="<!--{$tpl_no}-->" />
+    <input name="no" type="hidden" value="<!--{$tpl_no|h}-->" />
     <table summary="配送情報" class="list">
         <thead>
             <tr>

--- a/data/Smarty/templates/admin/order/product_select.tpl
+++ b/data/Smarty/templates/admin/order/product_select.tpl
@@ -120,7 +120,7 @@
     <input name="mode" type="hidden" value="search" />
     <input name="anchor_key" type="hidden" value="" />
     <input name="search_pageno" type="hidden" value="" />
-    <input name="shipping_id" type="hidden" value="<!--{$shipping_id}-->" />
+    <input name="shipping_id" type="hidden" value="<!--{$shipping_id|h}-->" />
     <input name="no" type="hidden" value="<!--{$tpl_no|h}-->" />
     <table class="form">
         <col width="20%" />
@@ -230,7 +230,7 @@
                             <input type="hidden" name="product_type" id="product_type<!--{$id|h}-->" value="<!--{$tpl_product_type[$id]}-->" />
                         </form>
                     </td>
-                    <td class="center"><a href="javascript:;" onclick="return func_submit('<!--{$arrProducts[cnt].product_id}-->', '<!--{$tpl_class_name1[$id]}-->', '<!--{$tpl_class_name2[$id]}-->'); return false;">決定</a></td>
+                    <td class="center"><a href="javascript:;" onclick="return func_submit('<!--{$arrProducts[cnt].product_id|h}-->', '<!--{$tpl_class_name1[$id]}-->', '<!--{$tpl_class_name2[$id]}-->'); return false;">決定</a></td>
                 </tr>
                 <!--▲商品<!--{$smarty.section.cnt.iteration}-->-->
         <!--{sectionelse}-->

--- a/data/Smarty/templates/admin/order/product_select.tpl
+++ b/data/Smarty/templates/admin/order/product_select.tpl
@@ -205,7 +205,7 @@
                                 </dd>
                             </dl>
                             <!--{else}-->
-                            <input type="hidden" name="classcategory_id1" id="<!--{$class1}-->" value="" />
+                            <input type="hidden" name="classcategory_id1" id="<!--{$class1|h}-->" value="" />
                             <!--{/if}-->
 
                             <!--{if $tpl_classcat_find2[$id]}-->
@@ -219,7 +219,7 @@
                                 </dd>
                             </dl>
                             <!--{else}-->
-                            <input type="hidden" name="classcategory_id2" id="<!--{$class2}-->" value="" />
+                            <input type="hidden" name="classcategory_id2" id="<!--{$class2|h}-->" value="" />
                             <!--{/if}-->
 
                             <!--{if !$tpl_stock_find[$id]}-->

--- a/data/Smarty/templates/admin/order/status.tpl
+++ b/data/Smarty/templates/admin/order/status.tpl
@@ -88,9 +88,9 @@
                 <!--{section name=cnt loop=$arrStatus}-->
                 <!--{assign var=status value="`$arrStatus[cnt].status`"}-->
                 <tr style="background:<!--{$arrORDERSTATUS_COLOR[$status]}-->;">
-                    <td class="center"><input type="checkbox" name="move[]" value="<!--{$arrStatus[cnt].order_id}-->" ></td>
+                    <td class="center"><input type="checkbox" name="move[]" value="<!--{$arrStatus[cnt].order_id|h}-->" ></td>
                     <td class="center"><!--{$arrORDERSTATUS[$status]}--></td>
-                    <td class="center"><a href="#" onclick="eccube.openWindow('./disp.php?order_id=<!--{$arrStatus[cnt].order_id}-->','order_disp','800','900',{resizable:'no',focus:false}); return false;" ><!--{$arrStatus[cnt].order_id}--></a></td>
+                    <td class="center"><a href="#" onclick="eccube.openWindow('./disp.php?order_id=<!--{$arrStatus[cnt].order_id|h}-->','order_disp','800','900',{resizable:'no',focus:false}); return false;" ><!--{$arrStatus[cnt].order_id|h}--></a></td>
                     <td class="center"><!--{$arrStatus[cnt].create_date|sfDispDBDate}--></td>
                     <td><!--{$arrStatus[cnt].order_name01|h}--> <!--{$arrStatus[cnt].order_name02|h}--></td>
                     <!--{assign var=payment_id value="`$arrStatus[cnt].payment_id`"}-->

--- a/data/Smarty/templates/admin/ownersstore/plugin.tpl
+++ b/data/Smarty/templates/admin/ownersstore/plugin.tpl
@@ -189,25 +189,25 @@
                                 <span class="attention"><!--{$arrErr[$plugin.plugin_code]}--></span>
                                 <!-- 設定 -->
                                     <!--{if $plugin.config_flg == true && $plugin.status != $smarty.const.PLUGIN_STATUS_UPLOADED}-->
-                                        <a href="?" onclick="eccube.openWindow('../load_plugin_config.php?plugin_id=<!--{$plugin.plugin_id}-->', 'load', 615, 400);return false;">プラグイン設定</a>&nbsp;|&nbsp;
+                                        <a href="?" onclick="eccube.openWindow('../load_plugin_config.php?plugin_id=<!--{$plugin.plugin_id|h}-->', 'load', 615, 400);return false;">プラグイン設定</a>&nbsp;|&nbsp;
                                     <!--{else}-->
                                         <span>プラグイン設定&nbsp;|&nbsp;</span>
                                     <!--{/if}-->
                                 <!-- アップデート -->
-                                    <a class="update_link" href="javascript:;" name="<!--{$plugin.plugin_id}-->">アップデート</a>&nbsp;|&nbsp;
+                                    <a class="update_link" href="javascript:;" name="<!--{$plugin.plugin_id|h}-->">アップデート</a>&nbsp;|&nbsp;
                                 <!-- 削除 -->
-                                    <a  href="javascript:;" name="uninstall" onclick="uninstall(<!--{$plugin.plugin_id}-->, '<!--{$plugin.plugin_code}-->'); return false;">削除</a>&nbsp;|&nbsp;
+                                    <a  href="javascript:;" name="uninstall" onclick="uninstall(<!--{$plugin.plugin_id|h}-->, '<!--{$plugin.plugin_code}-->'); return false;">削除</a>&nbsp;|&nbsp;
                                 <!-- 有効/無効 -->
                                     <!--{if $plugin.enable == $smarty.const.PLUGIN_ENABLE_TRUE}-->
-                                        <label><input id="plugin_enable" type="checkbox" name="disable" value="<!--{$plugin.plugin_id}-->" checked="checked" />有効</label><br/>
+                                        <label><input id="plugin_enable" type="checkbox" name="disable" value="<!--{$plugin.plugin_id|h}-->" checked="checked" />有効</label><br/>
                                     <!--{else}-->
-                                        <label><input id="plugin_enable" type="checkbox" name="enable" value="<!--{$plugin.plugin_id}-->" />有効にする</label><br/>
+                                        <label><input id="plugin_enable" type="checkbox" name="enable" value="<!--{$plugin.plugin_id|h}-->" />有効にする</label><br/>
                                     <!--{/if}-->
 
                                     <!-- アップデートリンク押下時に表示する. -->
                                     <div id="plugin_update_<!--{$plugin.plugin_id}-->" style="display: none">
                                         <input id="update_file_<!--{$plugin.plugin_id}-->" name="<!--{$plugin.plugin_code}-->" type="file" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="box30" size="30" <!--{if $arrErr[$key]}-->style="background-color:<!--{$smarty.const.ERR_COLOR|h}-->"<!--{/if}--> />
-                                        <a class="btn-action" href="javascript:;" onclick="update(<!--{$plugin.plugin_id}-->, '<!--{$plugin.plugin_code}-->'); return false;"><span class="btn-next">アップデート</span></a>
+                                        <a class="btn-action" href="javascript:;" onclick="update(<!--{$plugin.plugin_id|h}-->, '<!--{$plugin.plugin_code}-->'); return false;"><span class="btn-next">アップデート</span></a>
                                     </div>
                             </div>
                     </td>
@@ -215,7 +215,7 @@
                     <td class="center">
                         <span class="attention"><!--{$arrErr.priority[$plugin.plugin_id]}--></span>
                         <input type="text" class="center" name="priority_<!--{$plugin.plugin_code}-->" value="<!--{$plugin.priority|h}-->" size="1" />
-                        <a class="btn-action" href="javascript:;" onclick="update_priority(<!--{$plugin.plugin_id}-->, '<!--{$plugin.plugin_code}-->'); return false;"><span class="btn-next">変更</span></a><br/>
+                        <a class="btn-action" href="javascript:;" onclick="update_priority(<!--{$plugin.plugin_id|h}-->, '<!--{$plugin.plugin_code}-->'); return false;"><span class="btn-next">変更</span></a><br/>
                         <span><!--{$plugin.priority_message}--></span>
                     </td>
                 </tr>

--- a/data/Smarty/templates/admin/ownersstore/products_list.tpl
+++ b/data/Smarty/templates/admin/ownersstore/products_list.tpl
@@ -73,13 +73,13 @@
                     <!--{* インストール済みなら設定ボタン表示 *}-->
                     <!--{if $product.installed_flg}-->
                         <span class="icon_confirm">
-                        <a href="#" onclick="eccube.openWindow('../load_module_config.php?module_id=<!--{$product.product_id}-->', 'load', 615, 400);return false;">
+                        <a href="#" onclick="eccube.openWindow('../load_module_config.php?module_id=<!--{$product.product_id|h}-->', 'load', 615, 400);return false;">
                             設定</a>
                         </span>
                     <!--{else}-->
                         <div id='ownersstore_settings<!--{$product.product_id|h}-->' style="display:none">
                         <span class="icon_confirm">
-                        <a href="#" onclick="eccube.openWindow('../load_module_config.php?module_id=<!--{$product.product_id}-->', 'load', 615, 400);return false;">
+                        <a href="#" onclick="eccube.openWindow('../load_module_config.php?module_id=<!--{$product.product_id|h}-->', 'load', 615, 400);return false;">
                             設定</a>
                         </span>
                         </div>

--- a/data/Smarty/templates/admin/pager.tpl
+++ b/data/Smarty/templates/admin/pager.tpl
@@ -2,7 +2,7 @@
 <div class="pager">
     <ul>
     <!--{foreach from=$arrPagenavi.arrPageno key="key" item="item"}-->
-        <li<!--{if $arrPagenavi.now_page == $item}--> class="on"<!--{/if}-->><a href="#" onclick="eccube.moveNaviPage(<!--{$item}-->, '<!--{$arrPagenavi.mode}-->'); return false;"><span><!--{$item}--></span></a></li>
+        <li<!--{if $arrPagenavi.now_page == $item}--> class="on"<!--{/if}-->><a href="#" onclick="eccube.moveNaviPage(<!--{$item|h}-->, '<!--{$arrPagenavi.mode|h}-->'); return false;"><span><!--{$item|h}--></span></a></li>
     <!--{/foreach}-->
     </ul>
 </div>

--- a/data/Smarty/templates/admin/products/category.tpl
+++ b/data/Smarty/templates/admin/products/category.tpl
@@ -93,21 +93,21 @@
                     </td>
                     <td class="center">
                         <!--{if $arrForm.category_id != $arrList[cnt].category_id}-->
-                        <a href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'category_id', <!--{$arrList[cnt].category_id}-->); return false;">編集</a>
+                        <a href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'category_id', <!--{$arrList[cnt].category_id|h}-->); return false;">編集</a>
                         <!--{else}-->
                         編集中
                         <!--{/if}-->
                     </td>
                     <td class="center">
-                        <a href="?" onclick="eccube.setModeAndSubmit('delete', 'category_id', <!--{$arrList[cnt].category_id}-->); return false;">削除</a>
+                        <a href="?" onclick="eccube.setModeAndSubmit('delete', 'category_id', <!--{$arrList[cnt].category_id|h}-->); return false;">削除</a>
                     </td>
                     <td class="center">
                     <!--{* 移動 *}-->
                     <!--{if $smarty.section.cnt.iteration != 1}-->
-                    <a href="?" onclick="eccube.setModeAndSubmit('up','category_id', <!--{$arrList[cnt].category_id}-->); return false;">上へ</a>
+                    <a href="?" onclick="eccube.setModeAndSubmit('up','category_id', <!--{$arrList[cnt].category_id|h}-->); return false;">上へ</a>
                     <!--{/if}-->
                     <!--{if $smarty.section.cnt.iteration != $smarty.section.cnt.last}-->
-                    <a href="?" onclick="eccube.setModeAndSubmit('down','category_id', <!--{$arrList[cnt].category_id}-->); return false;">下へ</a>
+                    <a href="?" onclick="eccube.setModeAndSubmit('down','category_id', <!--{$arrList[cnt].category_id|h}-->); return false;">下へ</a>
                     <!--{/if}-->
                     </td>
 

--- a/data/Smarty/templates/admin/products/category_tree_fork.tpl
+++ b/data/Smarty/templates/admin/products/category_tree_fork.tpl
@@ -26,7 +26,7 @@
             <!--{* カテゴリ名表示 *}-->
             <!--{assign var=disp_name value="`$child.category_id`.`$child.category_name`"}-->
             <!--{if $child.level != $smarty.const.LEVEL_MAX}-->
-                <a href="?" onclick="eccube.setModeAndSubmit('tree', 'parent_category_id', <!--{$child.category_id}-->); return false;">
+                <a href="?" onclick="eccube.setModeAndSubmit('tree', 'parent_category_id', <!--{$child.category_id|h}-->); return false;">
                 <!--{if $arrForm.parent_category_id == $child.category_id}-->
                     <img src="<!--{$TPL_URLPATH}-->img/contents/folder_open.gif" alt="フォルダ" />
                 <!--{else}-->

--- a/data/Smarty/templates/admin/products/class.tpl
+++ b/data/Smarty/templates/admin/products/class.tpl
@@ -63,10 +63,10 @@
                 <tr style="background:<!--{if $tpl_class_id != $arrClass[cnt].class_id}-->#ffffff<!--{else}--><!--{$smarty.const.SELECT_RGB}--><!--{/if}-->;">
                     <!--{assign var=class_id value=$arrClass[cnt].class_id}-->
                     <td><!--{* 規格名 *}--><!--{$arrClass[cnt].name|h}--> (<!--{$arrClassCatCount[$class_id]|default:0}-->)</td>
-                    <td align="center"><a href="javascript:;" onclick="eccube.moveClassCatPage(<!--{$arrClass[cnt].class_id}-->); return false;">分類登録</a></td>
+                    <td align="center"><a href="javascript:;" onclick="eccube.moveClassCatPage(<!--{$arrClass[cnt].class_id|h}-->); return false;">分類登録</a></td>
                     <td align="center">
                         <!--{if $tpl_class_id != $arrClass[cnt].class_id}-->
-                            <a href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'class_id', <!--{$arrClass[cnt].class_id}-->); return false;">編集</a>
+                            <a href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'class_id', <!--{$arrClass[cnt].class_id|h}-->); return false;">編集</a>
                         <!--{else}-->
                             編集中
                         <!--{/if}-->
@@ -75,15 +75,15 @@
                         <!--{if $arrClassCatCount[$class_id] > 0}-->
                             -
                         <!--{else}-->
-                            <a href="?" onclick="eccube.setModeAndSubmit('delete', 'class_id', <!--{$arrClass[cnt].class_id}-->); return false;">削除</a>
+                            <a href="?" onclick="eccube.setModeAndSubmit('delete', 'class_id', <!--{$arrClass[cnt].class_id|h}-->); return false;">削除</a>
                         <!--{/if}-->
                     </td>
                     <td align="center">
                         <!--{if $smarty.section.cnt.iteration != 1}-->
-                            <a href="?" onclick="eccube.setModeAndSubmit('up', 'class_id', <!--{$arrClass[cnt].class_id}-->); return false;">上へ</a>
+                            <a href="?" onclick="eccube.setModeAndSubmit('up', 'class_id', <!--{$arrClass[cnt].class_id|h}-->); return false;">上へ</a>
                         <!--{/if}-->
                         <!--{if $smarty.section.cnt.iteration != $smarty.section.cnt.last}-->
-                            <a href="?" onclick="eccube.setModeAndSubmit('down', 'class_id', <!--{$arrClass[cnt].class_id}-->); return false;">下へ</a>
+                            <a href="?" onclick="eccube.setModeAndSubmit('down', 'class_id', <!--{$arrClass[cnt].class_id|h}-->); return false;">下へ</a>
                         <!--{/if}-->
                     </td>
                 </tr>

--- a/data/Smarty/templates/admin/products/classcategory.tpl
+++ b/data/Smarty/templates/admin/products/classcategory.tpl
@@ -25,7 +25,7 @@
 <form name="form1" id="form1" method="post" action="">
     <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
     <input type="hidden" name="mode" value="edit" />
-    <input type="hidden" name="classcategory_id" value="<!--{$tpl_classcategory_id}-->" />
+    <input type="hidden" name="classcategory_id" value="<!--{$tpl_classcategory_id|h}-->" />
     <!--{foreach key=key item=item from=$arrHidden}-->
         <input type="hidden" name="<!--{$key}-->" value="<!--{$item|h}-->" />
     <!--{/foreach}-->
@@ -69,20 +69,20 @@
                     <td><!--{* 規格名 *}--><!--{$arrClassCat[cnt].name|h}--></td>
                     <td align="center" >
                         <!--{if $tpl_classcategory_id != $arrClassCat[cnt].classcategory_id}-->
-                            <a href="?" onclick="eccube.setModeAndSubmit('pre_edit','classcategory_id', <!--{$arrClassCat[cnt].classcategory_id}-->); return false;">編集</a>
+                            <a href="?" onclick="eccube.setModeAndSubmit('pre_edit','classcategory_id', <!--{$arrClassCat[cnt].classcategory_id|h}-->); return false;">編集</a>
                         <!--{else}-->
                             編集中
                         <!--{/if}-->
                     </td>
                     <td align="center">
-                        <a href="?" onclick="if(window.confirm('分類名を削除すると、その分類を利用している商品規格が無効になります。\n整合性の問題を把握し、バックアップを行ってから削除することを推奨致します。')){ eccube.setModeAndSubmit('delete','classcategory_id', <!--{$arrClassCat[cnt].classcategory_id}-->); } return false;">削除</a>
+                        <a href="?" onclick="if(window.confirm('分類名を削除すると、その分類を利用している商品規格が無効になります。\n整合性の問題を把握し、バックアップを行ってから削除することを推奨致します。')){ eccube.setModeAndSubmit('delete','classcategory_id', <!--{$arrClassCat[cnt].classcategory_id|h}-->); } return false;">削除</a>
                     </td>
                     <td align="center">
                         <!--{if $smarty.section.cnt.iteration != 1}-->
-                            <a href="?" onclick="eccube.setModeAndSubmit('up','classcategory_id', <!--{$arrClassCat[cnt].classcategory_id}-->); return false;">上へ</a>
+                            <a href="?" onclick="eccube.setModeAndSubmit('up','classcategory_id', <!--{$arrClassCat[cnt].classcategory_id|h}-->); return false;">上へ</a>
                         <!--{/if}-->
                         <!--{if $smarty.section.cnt.iteration != $smarty.section.cnt.last}-->
-                            <a href="?" onclick="eccube.setModeAndSubmit('down','classcategory_id', <!--{$arrClassCat[cnt].classcategory_id}-->); return false;">下へ</a>
+                            <a href="?" onclick="eccube.setModeAndSubmit('down','classcategory_id', <!--{$arrClassCat[cnt].classcategory_id|h}-->); return false;">下へ</a>
                         <!--{/if}-->
                     </td>
                 </tr>

--- a/data/Smarty/templates/admin/products/complete.tpl
+++ b/data/Smarty/templates/admin/products/complete.tpl
@@ -48,7 +48,7 @@
                 <li><a class="btn-action" href="javascript:;" onclick="eccube.changeAction('<!--{$smarty.const.ADMIN_PRODUCTS_URLPATH}-->'); eccube.setModeAndSubmit('search','',''); return false;"><span class="btn-prev">検索結果へ戻る</span></a></li>
                 <li><a class="btn-action" href="./product.php"><span class="btn-next">続けて登録を行う</span></a></li>
                 <!--{if $smarty.const.OPTION_CLASS_REGIST == 1}-->
-                <li><a class="btn-action" href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'product_id', '<!--{$arrForm.product_id}-->'); return false;"><span class="btn-next">この商品の規格を登録する</span></a></li>
+                <li><a class="btn-action" href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'product_id', '<!--{$arrForm.product_id|h}-->'); return false;"><span class="btn-next">この商品の規格を登録する</span></a></li>
                 <!--{/if}-->
             </ul>
         </div>

--- a/data/Smarty/templates/admin/products/index.tpl
+++ b/data/Smarty/templates/admin/products/index.tpl
@@ -267,13 +267,13 @@ function lfnDispChange(){
                             <!--{* 表示 *}-->
                             <!--{assign var=key value=$arrProducts[cnt].status}-->
                             <td class="menu" rowspan="2"><!--{$arrDISP[$key]}--></td>
-                            <td class="menu" rowspan="2"><span class="icon_edit"><a href="javascript:;" onclick="eccube.changeAction('./product.php'); eccube.setModeAndSubmit('pre_edit', 'product_id', <!--{$arrProducts[cnt].product_id}-->); return false;" >編集</a></span></td>
+                            <td class="menu" rowspan="2"><span class="icon_edit"><a href="javascript:;" onclick="eccube.changeAction('./product.php'); eccube.setModeAndSubmit('pre_edit', 'product_id', <!--{$arrProducts[cnt].product_id|h}-->); return false;" >編集</a></span></td>
                             <td class="menu" rowspan="2"><span class="icon_confirm"><a href="<!--{$smarty.const.HTTP_URL}-->products/detail.php?product_id=<!--{$arrProducts[cnt].product_id}-->&amp;admin=on" target="_blank">確認</a></span></td>
                             <!--{if $smarty.const.OPTION_CLASS_REGIST == 1}-->
-                            <td class="menu" rowspan="2"><span class="icon_class"><a href="javascript:;" onclick="eccube.changeAction('./product_class.php'); eccube.setModeAndSubmit('pre_edit', 'product_id', <!--{$arrProducts[cnt].product_id}-->); return false;" >規格</a></span></td>
+                            <td class="menu" rowspan="2"><span class="icon_class"><a href="javascript:;" onclick="eccube.changeAction('./product_class.php'); eccube.setModeAndSubmit('pre_edit', 'product_id', <!--{$arrProducts[cnt].product_id|h}-->); return false;" >規格</a></span></td>
                             <!--{/if}-->
-                            <td class="menu" rowspan="2"><span class="icon_delete"><a href="javascript:;" onclick="eccube.setValue('category_id', '<!--{$arrProducts[cnt].category_id}-->'); eccube.setModeAndSubmit('delete', 'product_id', <!--{$arrProducts[cnt].product_id}-->); return false;">削除</a></span></td>
-                            <td class="menu" rowspan="2"><span class="icon_copy"><a href="javascript:;" onclick="eccube.changeAction('./product.php'); eccube.setModeAndSubmit('copy', 'product_id', <!--{$arrProducts[cnt].product_id}-->); return false;" >複製</a></span></td>
+                            <td class="menu" rowspan="2"><span class="icon_delete"><a href="javascript:;" onclick="eccube.setValue('category_id', '<!--{$arrProducts[cnt].category_id|h}-->'); eccube.setModeAndSubmit('delete', 'product_id', <!--{$arrProducts[cnt].product_id|h}-->); return false;">削除</a></span></td>
+                            <td class="menu" rowspan="2"><span class="icon_copy"><a href="javascript:;" onclick="eccube.changeAction('./product.php'); eccube.setModeAndSubmit('copy', 'product_id', <!--{$arrProducts[cnt].product_id|h}-->); return false;" >複製</a></span></td>
                         </tr>
                         <tr style="background:<!--{$arrPRODUCTSTATUS_COLOR[$status]}-->;">
                             <td>

--- a/data/Smarty/templates/admin/products/maker.tpl
+++ b/data/Smarty/templates/admin/products/maker.tpl
@@ -25,7 +25,7 @@
 <form name="form1" id="form1" method="post" action="?">
     <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
     <input type="hidden" name="mode" value="edit" />
-    <input type="hidden" name="maker_id" value="<!--{$tpl_maker_id}-->" />
+    <input type="hidden" name="maker_id" value="<!--{$tpl_maker_id|h}-->" />
     <div id="products" class="contents-main">
 
         <table class="form">
@@ -66,7 +66,7 @@
                 <td><!--{$arrMaker[cnt].name|h}--></td>
                 <td class="center">
                     <!--{if $tpl_maker_id != $arrMaker[cnt].maker_id}-->
-                    <a href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'maker_id', <!--{$arrMaker[cnt].maker_id}-->); return false;">編集</a>
+                    <a href="?" onclick="eccube.setModeAndSubmit('pre_edit', 'maker_id', <!--{$arrMaker[cnt].maker_id|h}-->); return false;">編集</a>
                     <!--{else}-->
                     編集中
                     <!--{/if}-->
@@ -75,15 +75,15 @@
                     <!--{if $arrClassCatCount[$class_id] > 0}-->
                     -
                     <!--{else}-->
-                    <a href="?" onclick="eccube.setModeAndSubmit('delete', 'maker_id', <!--{$arrMaker[cnt].maker_id}-->); return false;">削除</a>
+                    <a href="?" onclick="eccube.setModeAndSubmit('delete', 'maker_id', <!--{$arrMaker[cnt].maker_id|h}-->); return false;">削除</a>
                     <!--{/if}-->
                 </td>
                 <td class="center">
                     <!--{if $smarty.section.cnt.iteration != 1}-->
-                    <a href="?" onclick="eccube.setModeAndSubmit('up', 'maker_id', <!--{$arrMaker[cnt].maker_id}-->); return false;">上へ</a>
+                    <a href="?" onclick="eccube.setModeAndSubmit('up', 'maker_id', <!--{$arrMaker[cnt].maker_id|h}-->); return false;">上へ</a>
                     <!--{/if}-->
                     <!--{if $smarty.section.cnt.iteration != $smarty.section.cnt.last}-->
-                    <a href="?" onclick="eccube.setModeAndSubmit('down', 'maker_id', <!--{$arrMaker[cnt].maker_id}-->); return false;">下へ</a>
+                    <a href="?" onclick="eccube.setModeAndSubmit('down', 'maker_id', <!--{$arrMaker[cnt].maker_id|h}-->); return false;">下へ</a>
                     <!--{/if}-->
                 </td>
             </tr>

--- a/data/Smarty/templates/admin/products/product.tpl
+++ b/data/Smarty/templates/admin/products/product.tpl
@@ -179,11 +179,11 @@
             <!--{assign var=key value="down_file"}-->
             <th>ダウンロード商品用<br />ファイルアップロード<span class="attention"> *</span></th>
             <td>
-                <a name="<!--{$key}-->"></a>
+                <a name="<!--{$key|h}-->"></a>
                 <span class="attention"><!--{$arrErr[$key]}--><!--{$arrErr.down_realfilename}--></span>
                     <!--{if $arrForm.down_realfilename != ""}-->
                         <!--{$arrForm.down_realfilename|h}--><input type="hidden" name="down_realfilename" value="<!--{$arrForm.down_realfilename|h}-->">
-                        <a href="" onclick="selectAll('category_id'); eccube.setModeAndSubmit('delete_down', 'down_key', '<!--{$key}-->'); return false;">[ファイルの取り消し]</a><br />
+                        <a href="" onclick="selectAll('category_id'); eccube.setModeAndSubmit('delete_down', 'down_key', '<!--{$key|h}-->'); return false;">[ファイルの取り消し]</a><br />
                     <!--{/if}-->
                     <input type="file" name="down_file" size="40" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" />
                     <a class="btn-normal" href="javascript:;" name="btn" onclick="selectAll('category_id'); eccube.setModeAndSubmit('upload_down', 'down_key', '<!--{$key}-->'); return false;">アップロード</a><br />登録可能拡張子：<!--{$smarty.const.DOWNLOAD_EXTENSION}-->　(パラメーター DOWNLOAD_EXTENSION)
@@ -322,15 +322,15 @@
             <!--{assign var=key value="main_list_image"}-->
             <th>一覧-メイン画像<br />[<!--{$smarty.const.SMALL_IMAGE_WIDTH}-->×<!--{$smarty.const.SMALL_IMAGE_HEIGHT}-->]</th>
             <td>
-                <a name="<!--{$key}-->"></a>
+                <a name="<!--{$key|h}-->"></a>
                 <a name="main_image"></a>
                 <a name="main_large_image"></a>
                 <span class="attention"><!--{$arrErr[$key]}--></span>
                 <!--{if $arrForm.arrFile[$key].filepath != ""}-->
-                <img src="<!--{$arrForm.arrFile[$key].filepath}-->" alt="<!--{$arrForm.name|h}-->" />　<a href="" onclick="selectAll('category_id'); eccube.setModeAndSubmit('delete_image', 'image_key', '<!--{$key}-->'); return false;">[画像の取り消し]</a><br />
+                <img src="<!--{$arrForm.arrFile[$key].filepath|h}-->" alt="<!--{$arrForm.name|h}-->" />　<a href="" onclick="selectAll('category_id'); eccube.setModeAndSubmit('delete_image', 'image_key', '<!--{$key|h}-->'); return false;">[画像の取り消し]</a><br />
                 <!--{/if}-->
                 <input type="file" name="main_list_image" size="40" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" />
-                <a class="btn-normal" href="javascript:;" name="btn" onclick="selectAll('category_id'); eccube.setModeAndSubmit('upload_image', 'image_key', '<!--{$key}-->'); return false;">アップロード</a>
+                <a class="btn-normal" href="javascript:;" name="btn" onclick="selectAll('category_id'); eccube.setModeAndSubmit('upload_image', 'image_key', '<!--{$key|h}-->'); return false;">アップロード</a>
             </td>
         </tr>
         <tr>
@@ -339,10 +339,10 @@
             <td>
                 <span class="attention"><!--{$arrErr[$key]}--></span>
                 <!--{if $arrForm.arrFile[$key].filepath != ""}-->
-                <img src="<!--{$arrForm.arrFile[$key].filepath}-->" alt="<!--{$arrForm.name|h}-->" />　<a href="" onclick="selectAll('category_id'); eccube.setModeAndSubmit('delete_image', 'image_key', '<!--{$key}-->'); return false;">[画像の取り消し]</a><br />
+                <img src="<!--{$arrForm.arrFile[$key].filepath|h}-->" alt="<!--{$arrForm.name|h}-->" />　<a href="" onclick="selectAll('category_id'); eccube.setModeAndSubmit('delete_image', 'image_key', '<!--{$key|h}-->'); return false;">[画像の取り消し]</a><br />
                 <!--{/if}-->
                 <input type="file" name="main_image" size="40" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" />
-                <a class="btn-normal" href="javascript:;" name="btn" onclick="selectAll('category_id'); eccube.setModeAndSubmit('upload_image', 'image_key', '<!--{$key}-->'); return false;">アップロード</a>
+                <a class="btn-normal" href="javascript:;" name="btn" onclick="selectAll('category_id'); eccube.setModeAndSubmit('upload_image', 'image_key', '<!--{$key|h}-->'); return false;">アップロード</a>
             </td>
         </tr>
         <tr>
@@ -351,10 +351,10 @@
             <td>
                 <span class="attention"><!--{$arrErr[$key]}--></span>
                 <!--{if $arrForm.arrFile[$key].filepath != ""}-->
-                <img src="<!--{$arrForm.arrFile[$key].filepath}-->" alt="<!--{$arrForm.name|h}-->" />　<a href="" onclick="selectAll('category_id'); eccube.setModeAndSubmit('delete_image', 'image_key', '<!--{$key}-->'); return false;">[画像の取り消し]</a><br />
+                <img src="<!--{$arrForm.arrFile[$key].filepath|h}-->" alt="<!--{$arrForm.name|h}-->" />　<a href="" onclick="selectAll('category_id'); eccube.setModeAndSubmit('delete_image', 'image_key', '<!--{$key|h}-->'); return false;">[画像の取り消し]</a><br />
                 <!--{/if}-->
-                <input type="file" name="<!--{$key}-->" size="40" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" />
-                <a class="btn-normal" href="javascript:;" name="btn" onclick="selectAll('category_id'); eccube.setModeAndSubmit('upload_image', 'image_key', '<!--{$key}-->'); return false;">アップロード</a>
+                <input type="file" name="<!--{$key|h}-->" size="40" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" />
+                <a class="btn-normal" href="javascript:;" name="btn" onclick="selectAll('category_id'); eccube.setModeAndSubmit('upload_image', 'image_key', '<!--{$key|h}-->'); return false;">アップロード</a>
             </td>
         </tr>
     </table>
@@ -399,15 +399,15 @@
             <!--{assign var=key value="sub_image`$smarty.section.cnt.iteration`"}-->
             <th>詳細-サブ画像(<!--{$smarty.section.cnt.iteration}-->)<br />[<!--{$smarty.const.NORMAL_SUBIMAGE_WIDTH}-->×<!--{$smarty.const.NORMAL_SUBIMAGE_HEIGHT}-->]</th>
             <td>
-                <a name="<!--{$key}-->"></a>
+                <a name="<!--{$key|h}-->"></a>
                 <!--{assign var=largekey value="sub_large_image`$smarty.section.cnt.iteration`"}-->
-                <a name="<!--{$largekey}-->"></a>
+                <a name="<!--{$largekey|h}-->"></a>
                 <span class="attention"><!--{$arrErr[$key]}--></span>
                 <!--{if $arrForm.arrFile[$key].filepath != ""}-->
-                <img src="<!--{$arrForm.arrFile[$key].filepath}-->" alt="<!--{$arrForm.name|h}-->" />　<a href="" onclick="selectAll('category_id'); eccube.setModeAndSubmit('delete_image', 'image_key', '<!--{$key}-->'); return false;">[画像の取り消し]</a><br />
+                <img src="<!--{$arrForm.arrFile[$key].filepath|h}-->" alt="<!--{$arrForm.name|h}-->" />　<a href="" onclick="selectAll('category_id'); eccube.setModeAndSubmit('delete_image', 'image_key', '<!--{$key|h}-->'); return false;">[画像の取り消し]</a><br />
                 <!--{/if}-->
-                <input type="file" name="<!--{$key}-->" size="40" style="<!--{$arrErr[$key]|sfGetErrorColor}-->"/>
-                <a class="btn-normal" href="javascript:;" name="btn" onclick="selectAll('category_id'); eccube.setModeAndSubmit('upload_image', 'image_key', '<!--{$key}-->'); return false;">アップロード</a>
+                <input type="file" name="<!--{$key|h}-->" size="40" style="<!--{$arrErr[$key]|sfGetErrorColor}-->"/>
+                <a class="btn-normal" href="javascript:;" name="btn" onclick="selectAll('category_id'); eccube.setModeAndSubmit('upload_image', 'image_key', '<!--{$key|h}-->'); return false;">アップロード</a>
             </td>
         </tr>
         <tr>
@@ -416,10 +416,10 @@
             <td>
                 <span class="attention"><!--{$arrErr[$key]}--></span>
                 <!--{if $arrForm.arrFile[$key].filepath != ""}-->
-                <img src="<!--{$arrForm.arrFile[$key].filepath}-->" alt="<!--{$arrForm.name|h}-->" />　<a href="" onclick="selectAll('category_id'); eccube.setModeAndSubmit('delete_image', 'image_key', '<!--{$key}-->'); return false;">[画像の取り消し]</a><br />
+                <img src="<!--{$arrForm.arrFile[$key].filepath|h}-->" alt="<!--{$arrForm.name|h}-->" />　<a href="" onclick="selectAll('category_id'); eccube.setModeAndSubmit('delete_image', 'image_key', '<!--{$key|h}-->'); return false;">[画像の取り消し]</a><br />
                 <!--{/if}-->
-                <input type="file" name="<!--{$key}-->" size="40" style="<!--{$arrErr[$key]|sfGetErrorColor}-->"/>
-                <a class="btn-normal" href="javascript:;" name="btn" onclick="selectAll('category_id'); eccube.setModeAndSubmit('upload_image', 'image_key', '<!--{$key}-->'); return false;">アップロード</a>
+                <input type="file" name="<!--{$key|h}-->" size="40" style="<!--{$arrErr[$key]|sfGetErrorColor}-->"/>
+                <a class="btn-normal" href="javascript:;" name="btn" onclick="selectAll('category_id'); eccube.setModeAndSubmit('upload_image', 'image_key', '<!--{$key|h}-->'); return false;">アップロード</a>
             </td>
         </tr>
         <!--▲商品<!--{$smarty.section.cnt.iteration}-->-->
@@ -451,11 +451,11 @@
                 <!--{/if}-->
             </th>
             <td>
-                <a name="<!--{$anckey}-->"></a>
+                <a name="<!--{$anckey|h}-->"></a>
                 <input type="hidden" name="<!--{$key}-->" value="<!--{$arrRecommend[$recommend_no].product_id|h}-->" />
                 <a class="btn-normal" href="javascript:;" name="change" onclick="selectAll('category_id'); eccube.openWindow('./product_select.php?no=<!--{$smarty.section.cnt.iteration}-->', 'search', '615', '500', {menubar:'no'}); return false;">変更</a>
                 <!--{assign var=key value="recommend_delete`$smarty.section.cnt.iteration`"}-->
-                <input type="checkbox" name="<!--{$key}-->" value="1" />削除<br />
+                <input type="checkbox" name="<!--{$key|h}-->" value="1" />削除<br />
                 <!--{assign var=key value="recommend_comment`$smarty.section.cnt.iteration`"}-->
                 <span class="attention"><!--{$arrErr[$key]}--></span>
                 商品コード:<!--{$arrRecommend[$recommend_no].product_code_min}--> 

--- a/data/Smarty/templates/admin/products/product_class.tpl
+++ b/data/Smarty/templates/admin/products/product_class.tpl
@@ -222,7 +222,7 @@
                         <!--{if $arrErr[$key][$index]}-->
                             <span class="attention"><!--{$arrErr[$key][$index]}--></span>
                         <!--{/if}-->
-                        <input type="checkbox" name="<!--{$key}-->[<!--{$index}-->]" value="1" <!--{if $arrForm[$key].value[$index] == 1}-->checked="checked"<!--{/if}--> id="<!--{$key}-->_<!--{$index}-->" />
+                        <input type="checkbox" name="<!--{$key|h}-->[<!--{$index|h}-->]" value="1" <!--{if $arrForm[$key].value[$index] == 1}-->checked="checked"<!--{/if}--> id="<!--{$key|h}-->_<!--{$index|h}-->" />
                     </td>
                     <td class="center">
                         <!--{assign var=key value="classcategory_name1"}-->
@@ -257,7 +257,7 @@
                         <!--{if $arrErr[$key][$index]}-->
                             <span class="attention"><!--{$arrErr[$key][$index]}--></span>
                         <!--{/if}-->
-                        <input type="checkbox" name="<!--{$key}-->[<!--{$index}-->]" value="1" <!--{if $arrForm[$key].value[$index] == "1"}-->checked="checked"<!--{/if}--> id="chk_<!--{$key}-->_<!--{$index}-->" /><label for="chk_<!--{$key}-->_<!--{$index}-->">無制限</label>
+                        <input type="checkbox" name="<!--{$key|h}-->[<!--{$index|h}-->]" value="1" <!--{if $arrForm[$key].value[$index] == "1"}-->checked="checked"<!--{/if}--> id="chk_<!--{$key|h}-->_<!--{$index|h}-->" /><label for="chk_<!--{$key|h}-->_<!--{$index|h}-->">無制限</label>
                     </td>
                     <td class="center">
                         <!--{assign var=key value="price01"}-->
@@ -279,7 +279,7 @@
                             <span class="attention"><!--{$arrErr[$key][$index]}--></span>
                         <!--{/if}-->
                         <!--{foreach from=$arrProductType key=productTypeKey item=productType name=productType}-->
-                            <input type="radio" name="<!--{$key}-->[<!--{$index}-->]" value="<!--{$productTypeKey}-->" <!--{if $arrForm[$key].value[$index] == $productTypeKey}-->checked="checked"<!--{/if}--> <!--{if $arrErr[$key][$index] != ""}--><!--{sfSetErrorStyle}--><!--{/if}--> id="<!--{$key}-->_<!--{$index}-->_<!--{$smarty.foreach.productType.index}-->"><label for="<!--{$key}-->_<!--{$index}-->_<!--{$smarty.foreach.productType.index}-->"<!--{if $arrErr[$key][$index] != ""}--><!--{sfSetErrorStyle}--><!--{/if}--> ><!--{$productType}--></label><!--{if !$smarty.foreach.productType.last}--><br /><!--{/if}-->
+                            <input type="radio" name="<!--{$key|h}-->[<!--{$index|h}-->]" value="<!--{$productTypeKey|h}-->" <!--{if $arrForm[$key].value[$index] == $productTypeKey}-->checked="checked"<!--{/if}--> <!--{if $arrErr[$key][$index] != ""}--><!--{sfSetErrorStyle}--><!--{/if}--> id="<!--{$key|h}-->_<!--{$index|h}-->_<!--{$smarty.foreach.productType.index}-->"><label for="<!--{$key|h}-->_<!--{$index|h}-->_<!--{$smarty.foreach.productType.index}-->"<!--{if $arrErr[$key][$index] != ""}--><!--{sfSetErrorStyle}--><!--{/if}--> ><!--{$productType|h}--></label><!--{if !$smarty.foreach.productType.last}--><br /><!--{/if}-->
                         <!--{/foreach}-->
                     </td>
                     <td class="center">
@@ -297,10 +297,10 @@
                         <!--{if $arrForm[$key].value[$index] != ""}-->
                             <!--{$arrForm[$key].value[$index]|h}--><br />
                             <input type="hidden" name="<!--{$key}-->[<!--{$index}-->]" value="<!--{$arrForm[$key].value[$index]|h}-->" />
-                            <a href="?" onclick="eccube.fnFormModeSubmit('form1', 'file_delete', 'upload_index', '<!--{$index}-->'); return false;">[ファイルの取り消し]</a>
+                            <a href="?" onclick="eccube.fnFormModeSubmit('form1', 'file_delete', 'upload_index', '<!--{$index|h}-->'); return false;">[ファイルの取り消し]</a>
                         <!--{else}-->
-                        <input type="file" name="<!--{$key}-->[<!--{$index}-->]" size="10" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" /><br />
-                        <a class="btn-normal" href="javascript:;" name="btn" onclick="eccube.fnFormModeSubmit('form1', 'file_upload', 'upload_index', '<!--{$index}-->'); return false;">アップロード</a>
+                        <input type="file" name="<!--{$key|h}-->[<!--{$index|h}-->]" size="10" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" /><br />
+                        <a class="btn-normal" href="javascript:;" name="btn" onclick="eccube.fnFormModeSubmit('form1', 'file_upload', 'upload_index', '<!--{$index|h}-->'); return false;">アップロード</a>
                         <!--{/if}-->
                     </td>
                 </tr>

--- a/data/Smarty/templates/admin/products/product_rank.tpl
+++ b/data/Smarty/templates/admin/products/product_rank.tpl
@@ -97,13 +97,13 @@
                             <td align="center">
                             <!--{* 移動 *}-->
                             <!--{if !(count($arrProductsList) == 1 && $rank == 1)}-->
-                            <input type="text" name="pos-<!--{$arrProductsList[cnt].product_id}-->" size="3" class="box3" />番目へ<a href="?" onclick="eccube.setModeAndSubmit('move','product_id', '<!--{$arrProductsList[cnt].product_id}-->'); return false;">移動</a><br />
+                            <input type="text" name="pos-<!--{$arrProductsList[cnt].product_id|h}-->" size="3" class="box3" />番目へ<a href="?" onclick="eccube.setModeAndSubmit('move','product_id', '<!--{$arrProductsList[cnt].product_id|h}-->'); return false;">移動</a><br />
                             <!--{/if}-->
                             <!--{if !($smarty.section.cnt.first && $tpl_disppage eq 1)}-->
-                            <a href="?" onclick="eccube.setModeAndSubmit('up','product_id', '<!--{$arrProductsList[cnt].product_id}-->'); return false;">上へ</a>
+                            <a href="?" onclick="eccube.setModeAndSubmit('up','product_id', '<!--{$arrProductsList[cnt].product_id|h}-->'); return false;">上へ</a>
                             <!--{/if}-->
                             <!--{if !($smarty.section.cnt.last && $tpl_disppage eq $tpl_pagemax)}-->
-                            <a href="?" onclick="eccube.setModeAndSubmit('down','product_id', '<!--{$arrProductsList[cnt].product_id}-->'); return false;">下へ</a>
+                            <a href="?" onclick="eccube.setModeAndSubmit('down','product_id', '<!--{$arrProductsList[cnt].product_id|h}-->'); return false;">下へ</a>
                             <!--{/if}-->
                             </td>
                         </tr>

--- a/data/Smarty/templates/admin/products/product_rank_tree_fork.tpl
+++ b/data/Smarty/templates/admin/products/product_rank_tree_fork.tpl
@@ -26,7 +26,7 @@
             <!--{* カテゴリ名表示 *}-->
             <!--{assign var=disp_name value="`$child.category_id`.`$child.category_name`"}-->
             <!--{if $child.level != $smarty.const.LEVEL_MAX}-->
-                <a href="?" onclick="eccube.setModeAndSubmit('tree', 'parent_category_id', <!--{$child.category_id}-->); return false;">
+                <a href="?" onclick="eccube.setModeAndSubmit('tree', 'parent_category_id', <!--{$child.category_id|h}-->); return false;">
                 <!--{if $arrForm.parent_category_id == $child.category_id}-->
                     <img src="<!--{$TPL_URLPATH}-->img/contents/folder_open.gif" alt="フォルダ" />
                 <!--{else}-->

--- a/data/Smarty/templates/admin/products/review.tpl
+++ b/data/Smarty/templates/admin/products/review.tpl
@@ -154,8 +154,8 @@
                             <!--{assign var=key value="`$arrReview[cnt].recommend_level`"}-->
                             <td><!--{$arrRECOMMEND[$key]|h}--></td>
                             <td class="menu"><!--{if $arrReview[cnt].status eq 1}-->表示<!--{elseif $arrReview[cnt].status eq 2}-->非表示<!--{/if}--></td>
-                            <td class="menu"><a href="javascript:;" onclick="eccube.changeAction('./review_edit.php'); eccube.setModeAndSubmit('','review_id','<!--{$arrReview[cnt].review_id}-->'); return false;">編集</a></td>
-                            <td class="menu"><a href="javascript:;" onclick="eccube.setModeAndSubmit('delete','review_id','<!--{$arrReview[cnt].review_id}-->'); return false;">削除</a></td>
+                            <td class="menu"><a href="javascript:;" onclick="eccube.changeAction('./review_edit.php'); eccube.setModeAndSubmit('','review_id','<!--{$arrReview[cnt].review_id|h}-->'); return false;">編集</a></td>
+                            <td class="menu"><a href="javascript:;" onclick="eccube.setModeAndSubmit('delete','review_id','<!--{$arrReview[cnt].review_id|h}-->'); return false;">削除</a></td>
                         </tr>
                     <!--{/section}-->
                 </table>

--- a/data/Smarty/templates/admin/system/adminarea.tpl
+++ b/data/Smarty/templates/admin/system/adminarea.tpl
@@ -56,7 +56,7 @@ jQuery(function(){
                 <td>
                     <!--{assign var=key value="admin_force_ssl"}-->
                     <span class="attention"><!--{$arrErr[$key]}--></span>
-                    <input type="checkbox" name="<!--{$key}-->" value="1" id="<!--{$key}-->" <!--{if $arrForm[$key] == 1}-->checked="checked"<!--{/if}--><!--{if !$tpl_enable_ssl}--> disabled="disabled"<!--{/if}--> /><label for="<!--{$key}-->">SSLを強制する。</label>
+                    <input type="checkbox" name="<!--{$key|h}-->" value="1" id="<!--{$key|h}-->" <!--{if $arrForm[$key] == 1}-->checked="checked"<!--{/if}--><!--{if !$tpl_enable_ssl}--> disabled="disabled"<!--{/if}--> /><label for="<!--{$key|h}-->">SSLを強制する。</label>
                 </td>
             </tr>
             <tr>

--- a/data/Smarty/templates/admin/system/bkup.tpl
+++ b/data/Smarty/templates/admin/system/bkup.tpl
@@ -86,10 +86,10 @@
                         <td ><!--{$arrBkupList[cnt].bkup_name|h}--></td>
                         <td ><!--{$arrBkupList[cnt].bkup_memo|h}--></td>
                         <td align="center"><!--{$arrBkupList[cnt].create_date|sfCutString:19:true:false}--></td>
-                        <td align="center"><a href="javascript:;" onclick="fnRestore('<!--{$arrBkupList[cnt].bkup_name}-->'); return false;">リストア</a></td>
-                        <td align="center"><a href="javascript:;" onclick="eccube.setModeAndSubmit('download','list_name','<!--{$arrBkupList[cnt].bkup_name}-->'); return false;">ダウンロード</a></td>
+                        <td align="center"><a href="javascript:;" onclick="fnRestore('<!--{$arrBkupList[cnt].bkup_name|h}-->'); return false;">リストア</a></td>
+                        <td align="center"><a href="javascript:;" onclick="eccube.setModeAndSubmit('download','list_name','<!--{$arrBkupList[cnt].bkup_name|h}-->'); return false;">ダウンロード</a></td>
                         <td align="center">
-                            <a href="javascript:;" onclick="eccube.setModeAndSubmit('delete','list_name','<!--{$arrBkupList[cnt].bkup_name}-->'); return false;">削除</a>
+                            <a href="javascript:;" onclick="eccube.setModeAndSubmit('delete','list_name','<!--{$arrBkupList[cnt].bkup_name|h}-->'); return false;">削除</a>
                         </td>
                     </tr>
                 <!--{/section}-->

--- a/data/Smarty/templates/admin/system/index.tpl
+++ b/data/Smarty/templates/admin/system/index.tpl
@@ -58,13 +58,13 @@
                 <td><!--{$list_data[data].name|h}--></td>
                 <td><!--{$list_data[data].department|h}--></td>
                 <!--{assign var="work" value=$list_data[data].work}--><td><!--{$arrWORK[$work]|h}--></td>
-                <td align="center"><a href="#" onclick="eccube.openWindow('./input.php?id=<!--{$list_data[data].member_id}-->&amp;pageno=<!--{$tpl_disppage}-->','member_edit','620','450'); return false;">編集</a></td>
-                <td align="center"><!--{if $workmax > 1}--><a href="#" onclick="eccube.deleteMember(<!--{$list_data[data].member_id}-->,<!--{$tpl_disppage}-->,<!--{if $list_data[data].authority==0}--><!--{$tpl_last_admin}--><!--{else}-->false<!--{/if}-->); return false;">削除</a>
+                <td align="center"><a href="#" onclick="eccube.openWindow('./input.php?id=<!--{$list_data[data].member_id|h}-->&amp;pageno=<!--{$tpl_disppage}-->','member_edit','620','450'); return false;">編集</a></td>
+                <td align="center"><!--{if $workmax > 1}--><a href="#" onclick="eccube.deleteMember(<!--{$list_data[data].member_id|h}-->,<!--{$tpl_disppage}-->,<!--{if $list_data[data].authority==0}--><!--{$tpl_last_admin}--><!--{else}-->false<!--{/if}-->); return false;">削除</a>
                 <!--{else}-->-<!--{/if}--></td>
                 <td align="center">
                 <!--{$tpl_nomove}-->
-                <!--{if !($smarty.section.data.first && $tpl_disppage eq 1)}--><a href="./rank.php?id=<!--{$list_data[data].member_id}-->&amp;move=up&amp;pageno=<!--{$tpl_disppage}-->">上へ</a><!--{/if}-->
-                <!--{if !($smarty.section.data.last && $tpl_disppage eq $tpl_pagemax)}--><a href="./rank.php?id=<!--{$list_data[data].member_id}-->&amp;move=down&amp;pageno=<!--{$tpl_disppage}-->">下へ</a><!--{/if}-->
+                <!--{if !($smarty.section.data.first && $tpl_disppage eq 1)}--><a href="./rank.php?id=<!--{$list_data[data].member_id|h}-->&amp;move=up&amp;pageno=<!--{$tpl_disppage}-->">上へ</a><!--{/if}-->
+                <!--{if !($smarty.section.data.last && $tpl_disppage eq $tpl_pagemax)}--><a href="./rank.php?id=<!--{$list_data[data].member_id|h}-->&amp;move=down&amp;pageno=<!--{$tpl_disppage}-->">下へ</a><!--{/if}-->
                 </td>
             </tr>
             <!--▲メンバー<!--{$smarty.section.data.iteration}-->-->

--- a/data/Smarty/templates/admin/system/masterdata.tpl
+++ b/data/Smarty/templates/admin/system/masterdata.tpl
@@ -38,7 +38,7 @@
         <form name="form2" id="form2" method="post" action="?">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
             <input type="hidden" name="mode" value="edit" />
-            <input type="hidden" name="master_data_name" value="<!--{$masterDataName}-->" />
+            <input type="hidden" name="master_data_name" value="<!--{$masterDataName|h}-->" />
             <p class="remark attention">
                 マスターデータの値を設定できます。<br />
                 重複したIDを登録することはできません。<br />

--- a/data/Smarty/templates/default/mypage/delivery.tpl
+++ b/data/Smarty/templates/default/mypage/delivery.tpl
@@ -44,7 +44,7 @@
                 <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
                 <input type="hidden" name="mode" value="" />
                 <input type="hidden" name="other_deliv_id" value="" />
-                <input type="hidden" name="pageno" value="<!--{$tpl_pageno}-->" />
+                <input type="hidden" name="pageno" value="<!--{$tpl_pageno|h}-->" />
 
                 <table summary="お届け先">
                 <col width="5%" />

--- a/data/Smarty/templates/default/mypage/delivery.tpl
+++ b/data/Smarty/templates/default/mypage/delivery.tpl
@@ -70,10 +70,10 @@
                                 <!--{$arrOtherDeliv[cnt].company_name|h}-->&nbsp;<!--{$arrOtherDeliv[cnt].name01|h}-->&nbsp;<!--{$arrOtherDeliv[cnt].name02|h}-->
                             </td>
                             <td class="alignC">
-                                <a href="./delivery_addr.php" onclick="eccube.openWindow('./delivery_addr.php?other_deliv_id=<!--{$arrOtherDeliv[cnt].other_deliv_id}-->','deliv_disp','600','640'); return false;">変更</a>
+                                <a href="./delivery_addr.php" onclick="eccube.openWindow('./delivery_addr.php?other_deliv_id=<!--{$arrOtherDeliv[cnt].other_deliv_id|h}-->','deliv_disp','600','640'); return false;">変更</a>
                             </td>
                             <td class="alignC">
-                                <a href="#" onclick="eccube.setModeAndSubmit('delete','other_deliv_id','<!--{$arrOtherDeliv[cnt].other_deliv_id}-->'); return false;">削除</a>
+                                <a href="#" onclick="eccube.setModeAndSubmit('delete','other_deliv_id','<!--{$arrOtherDeliv[cnt].other_deliv_id|h}-->'); return false;">削除</a>
                             </td>
                         </tr>
                     <!--{/section}-->

--- a/data/Smarty/templates/default/mypage/delivery_addr.tpl
+++ b/data/Smarty/templates/default/mypage/delivery_addr.tpl
@@ -32,7 +32,7 @@
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
         <input type="hidden" name="mode" value="edit" />
         <input type="hidden" name="other_deliv_id" value="<!--{$smarty.session.other_deliv_id|h}-->" />
-        <input type="hidden" name="ParentPage" value="<!--{$ParentPage}-->" />
+        <input type="hidden" name="ParentPage" value="<!--{$ParentPage|h}-->" />
 
         <table summary="お届け先登録">
             <!--{include file="`$smarty.const.TEMPLATE_REALDIR`frontparts/form_personal_input.tpl" flgFields=1 emailMobile=false prefix=""}-->

--- a/data/Smarty/templates/default/mypage/favorite.tpl
+++ b/data/Smarty/templates/default/mypage/favorite.tpl
@@ -33,7 +33,7 @@
         <form name="form1" id="form1" method="post" action="?">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
             <input type="hidden" name="order_id" value="" />
-            <input type="hidden" name="pageno" value="<!--{$tpl_pageno}-->" />
+            <input type="hidden" name="pageno" value="<!--{$tpl_pageno|h}-->" />
             <input type="hidden" name="mode" value="" />
             <input type="hidden" name="product_id" value="" />
             <h3><!--{$tpl_subtitle|h}--></h3>

--- a/data/Smarty/templates/default/mypage/index.tpl
+++ b/data/Smarty/templates/default/mypage/index.tpl
@@ -33,7 +33,7 @@
         <form name="form1" id="form1" method="post" action="?">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
             <input type="hidden" name="order_id" value="" />
-            <input type="hidden" name="pageno" value="<!--{$objNavi->nowpage}-->" />
+            <input type="hidden" name="pageno" value="<!--{$objNavi->nowpage|h}-->" />
             <h3><!--{$tpl_subtitle|h}--></h3>
 
             <!--{if $objNavi->all_row > 0}-->

--- a/data/Smarty/templates/default/mypage/login.tpl
+++ b/data/Smarty/templates/default/mypage/login.tpl
@@ -54,7 +54,7 @@
                         </dt>
                         <dd>
                             <span class="attention"><!--{$arrErr[$key]}--></span>
-                            <input type="password" name="<!--{$key}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="box300" />
+                            <input type="password" name="<!--{$key|h}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="box300" />
                         </dd>
                     </dl>
                     <div class="btn_area">

--- a/data/Smarty/templates/default/products/detail.tpl
+++ b/data/Smarty/templates/default/products/detail.tpl
@@ -182,8 +182,8 @@
                 <!--▼買い物カゴ-->
                 <div class="cart_area clearfix">
                     <input type="hidden" name="mode" value="cart" />
-                    <input type="hidden" name="product_id" value="<!--{$tpl_product_id}-->" />
-                    <input type="hidden" name="product_class_id" value="<!--{$tpl_product_class_id}-->" id="product_class_id" />
+                    <input type="hidden" name="product_id" value="<!--{$tpl_product_id|h}-->" />
+                    <input type="hidden" name="product_class_id" value="<!--{$tpl_product_class_id|h}-->" id="product_class_id" />
                     <input type="hidden" name="favorite_product_id" value="" />
 
                     <!--{if $tpl_stock_find}-->

--- a/data/Smarty/templates/default/products/list.tpl
+++ b/data/Smarty/templates/default/products/list.tpl
@@ -239,7 +239,7 @@
                                 <div class="cartin_btn">
                                     <!--★カゴに入れる★-->
                                     <div id="cartbtn_default_<!--{$id}-->">
-                                        <input type="image" id="cart<!--{$id}-->" src="<!--{$TPL_URLPATH}-->img/button/btn_cartin.jpg" alt="カゴに入れる" onclick="fnInCart(this.form); return false;" class="hover_change_image" />
+                                        <input type="image" id="cart<!--{$id|h}-->" src="<!--{$TPL_URLPATH}-->img/button/btn_cartin.jpg" alt="カゴに入れる" onclick="fnInCart(this.form); return false;" class="hover_change_image" />
                                     </div>
                                     <div class="attention" id="cartbtn_dynamic_<!--{$id}-->"></div>
                                 </div>

--- a/data/Smarty/templates/default/shopping/confirm.tpl
+++ b/data/Smarty/templates/default/shopping/confirm.tpl
@@ -45,7 +45,7 @@
         <form name="form1" id="form1" method="post" action="?">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
             <input type="hidden" name="mode" value="confirm" />
-            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->" />
+            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->" />
 
             <div class="btn_area">
                 <ul>

--- a/data/Smarty/templates/default/shopping/deliv.tpl
+++ b/data/Smarty/templates/default/shopping/deliv.tpl
@@ -56,7 +56,7 @@
         <form name="form1" id="form1" method="post" action="?">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
             <input type="hidden" name="mode" value="customer_addr" />
-            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->" />
+            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->" />
             <input type="hidden" name="other_deliv_id" value="" />
             <!--{if $arrErr.deli != ""}-->
                 <p class="attention"><!--{$arrErr.deli}--></p>
@@ -80,7 +80,7 @@
                             <!--{if $smarty.section.cnt.first}-->
                                 <input type="radio" name="deliv_check" id="chk_id_<!--{$smarty.section.cnt.iteration}-->" value="-1" <!--{if $arrForm.deliv_check.value == "" || $arrForm.deliv_check.value == -1}--> checked="checked"<!--{/if}--> />
                             <!--{else}-->
-                                <input type="radio" name="deliv_check" id="chk_id_<!--{$smarty.section.cnt.iteration}-->" value="<!--{$arrAddr[cnt].other_deliv_id}-->"<!--{if $arrForm.deliv_check.value == $arrAddr[cnt].other_deliv_id}--> checked="checked"<!--{/if}--> />
+                                <input type="radio" name="deliv_check" id="chk_id_<!--{$smarty.section.cnt.iteration}-->" value="<!--{$arrAddr[cnt].other_deliv_id|h}-->"<!--{if $arrForm.deliv_check.value == $arrAddr[cnt].other_deliv_id|h}--> checked="checked"<!--{/if}--> />
                             <!--{/if}-->
                         </td>
                         <td class="alignC">
@@ -110,7 +110,7 @@
                         </td>
                         <td class="alignC">
                             <!--{if !$smarty.section.cnt.first}-->
-                                <a href="?" onclick="eccube.setModeAndSubmit('delete', 'other_deliv_id', '<!--{$arrAddr[cnt].other_deliv_id}-->'); return false">削除</a>
+                                <a href="?" onclick="eccube.setModeAndSubmit('delete', 'other_deliv_id', '<!--{$arrAddr[cnt].other_deliv_id|h}-->'); return false">削除</a>
                                 <!--{else}-->
                                     -
                                 <!--{/if}-->

--- a/data/Smarty/templates/default/shopping/index.tpl
+++ b/data/Smarty/templates/default/shopping/index.tpl
@@ -51,7 +51,7 @@
                             パスワード&nbsp;：
                         </dt>
                         <dd>
-                            <input type="password" name="<!--{$key}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="box300" />
+                            <input type="password" name="<!--{$key|h}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="box300" />
                         </dd>
                     </dl>
                     <div class="btn_area">

--- a/data/Smarty/templates/default/shopping/multiple.tpl
+++ b/data/Smarty/templates/default/shopping/multiple.tpl
@@ -41,7 +41,7 @@
         <!--{/if}-->
         <form name="form1" id="form1" method="post" action="?">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
-            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->" />
+            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->" />
             <input type="hidden" name="line_of_num" value="<!--{$arrForm.line_of_num.value}-->" />
             <input type="hidden" name="mode" value="confirm" />
             <table summary="商品情報">

--- a/data/Smarty/templates/default/shopping/multiple.tpl
+++ b/data/Smarty/templates/default/shopping/multiple.tpl
@@ -42,7 +42,7 @@
         <form name="form1" id="form1" method="post" action="?">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
             <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->" />
-            <input type="hidden" name="line_of_num" value="<!--{$arrForm.line_of_num.value}-->" />
+            <input type="hidden" name="line_of_num" value="<!--{$arrForm.line_of_num.value|h}-->" />
             <input type="hidden" name="mode" value="confirm" />
             <table summary="商品情報">
                 <col width="10%" />
@@ -82,7 +82,7 @@
                             <input type="text" name="<!--{$key}-->[<!--{$index}-->]" value="<!--{$arrForm[$key].value[$index]|h}-->" class="box40" style="<!--{$arrErr[$key][$index]|sfGetErrorColor}-->" maxlength="<!--{$arrForm[$key].length}-->" />
                         </td>
                         <td>
-                            <input type="hidden" name="cart_no[<!--{$index}-->]" value="<!--{$index}-->" />
+                            <input type="hidden" name="cart_no[<!--{$index|h}-->]" value="<!--{$index|h}-->" />
                             <!--{assign var=key value="product_class_id"}-->
                             <input type="hidden" name="<!--{$key}-->[<!--{$index}-->]" value="<!--{$arrForm[$key].value[$index]|h}-->" />
                             <!--{assign var=key value="name"}-->

--- a/data/Smarty/templates/default/shopping/nonmember_input.tpl
+++ b/data/Smarty/templates/default/shopping/nonmember_input.tpl
@@ -39,7 +39,7 @@
         <form name="form1" id="form1" method="post" action="?">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
             <input type="hidden" name="mode" value="nonmember_confirm" />
-            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->" />
+            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->" />
             <table summary=" ">
             <!--{include file="`$smarty.const.TEMPLATE_REALDIR`frontparts/form_personal_input.tpl" flgFields=2 emailMobile=false prefix="order_"}-->
                 <tr>

--- a/data/Smarty/templates/default/shopping/payment.tpl
+++ b/data/Smarty/templates/default/shopping/payment.tpl
@@ -127,7 +127,7 @@
         <form name="form1" id="form1" method="post" action="?">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
             <input type="hidden" name="mode" value="confirm" />
-            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->" />
+            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->" />
 
             <!--{assign var=key value="deliv_id"}-->
             <!--{if $is_single_deliv}-->

--- a/data/Smarty/templates/default/shopping/payment.tpl
+++ b/data/Smarty/templates/default/shopping/payment.tpl
@@ -252,7 +252,7 @@
                                 <li>
                                 <input type="radio" id="point_on" name="point_check" value="1" <!--{$arrForm.point_check.value|sfGetChecked:1}--> onclick="eccube.togglePointForm();" /><label for="point_on">ポイントを使用する</label>
                                     <!--{assign var=key value="use_point"}--><br />
-                                今回のお買い物で、<input type="text" name="<!--{$key}-->" value="<!--{$arrForm[$key].value|default:$tpl_user_point}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="box60" />&nbsp;Ptを使用する。<span class="attention"><!--{$arrErr[$key]}--></span>
+                                今回のお買い物で、<input type="text" name="<!--{$key|h}-->" value="<!--{$arrForm[$key].value|h|default:$tpl_user_point}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="box60" />&nbsp;Ptを使用する。<span class="attention"><!--{$arrErr[$key]}--></span>
                                 </li>
                                 <li><input type="radio" id="point_off" name="point_check" value="2" <!--{$arrForm.point_check.value|sfGetChecked:2}--> onclick="eccube.togglePointForm();" /><label for="point_off">ポイントを使用しない</label></li>
                             </ul>

--- a/data/Smarty/templates/mobile/mypage/history.tpl
+++ b/data/Smarty/templates/mobile/mypage/history.tpl
@@ -29,7 +29,7 @@
 
     <form action="order.php" method="post">
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->">
-        <input type="hidden" name="order_id" value="<!--{$tpl_arrOrderData.order_id}-->">
+        <input type="hidden" name="order_id" value="<!--{$tpl_arrOrderData.order_id|h}-->">
         <input type="submit" name="submit" value="再注文">
     </form>
 

--- a/data/Smarty/templates/mobile/mypage/index.tpl
+++ b/data/Smarty/templates/mobile/mypage/index.tpl
@@ -63,7 +63,7 @@
                 <!--{/if}-->
             <!--{/if}-->
 
-            <div align="right"><a href="./history.php?order_id=<!--{$arrOrder[cnt].order_id}-->">→詳細を見る</a></div><br>
+            <div align="right"><a href="./history.php?order_id=<!--{$arrOrder[cnt].order_id|h}-->">→詳細を見る</a></div><br>
         <!--{/section}-->
         <hr>
     <!--{else}-->

--- a/data/Smarty/templates/mobile/products/detail.tpl
+++ b/data/Smarty/templates/mobile/products/detail.tpl
@@ -39,7 +39,7 @@
             <!--{if ($smarty.get.image == "" || $smarty.get.image == "main_image")}-->
                 [1]
             <!--{else}-->
-                [<a href="?product_id=<!--{$smarty.get.product_id}-->&amp;image=main_image">1</a>]
+                [<a href="?product_id=<!--{$smarty.get.product_id|h}-->&amp;image=main_image">1</a>]
             <!--{/if}-->
 
             <!--{assign var=num value="2"}-->
@@ -49,7 +49,7 @@
                     <!--{if $key == $smarty.get.image}-->
                         [<!--{$num}-->]
                     <!--{else}-->
-                        [<a href="?product_id=<!--{$smarty.get.product_id}-->&amp;image=<!--{$key}-->"><!--{$num}--></a>]
+                        [<a href="?product_id=<!--{$smarty.get.product_id|h}-->&amp;image=<!--{$key}-->"><!--{$num}--></a>]
                     <!--{/if}-->
                     <!--{assign var=num value="`$num+1`"}-->
                 <!--{/if}-->
@@ -144,7 +144,7 @@
         <input type="hidden" name="mode" value="select">
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->">
 
-        <input type="hidden" name="product_id" value="<!--{$tpl_product_id}-->">
+        <input type="hidden" name="product_id" value="<!--{$tpl_product_id|h}-->">
         <!--{if $tpl_stock_find}-->
             <!--★商品を選ぶ★-->
             <center><input type="submit" name="select" id="cart" value="この商品を選ぶ"></center>

--- a/data/Smarty/templates/mobile/products/select_find1.tpl
+++ b/data/Smarty/templates/mobile/products/select_find1.tpl
@@ -37,7 +37,7 @@
             <!--{html_options options=$arrClassCat1 selected=$arrForm.classcategory_id1.value}-->
         </select><br>
         <input type="hidden" name="mode" value="select2">
-        <input type="hidden" name="product_id" value="<!--{$tpl_product_id}-->">
+        <input type="hidden" name="product_id" value="<!--{$tpl_product_id|h}-->">
         <center><input type="submit" name="submit" value="次へ"></center>
     </form>
 <!--{/strip}-->

--- a/data/Smarty/templates/mobile/products/select_find2.tpl
+++ b/data/Smarty/templates/mobile/products/select_find2.tpl
@@ -38,7 +38,7 @@
         </select><br>
         <input type="hidden" name="mode" value="selectItem">
         <input type="hidden" name="classcategory_id1" value="<!--{$arrForm.classcategory_id1.value|h}-->">
-        <input type="hidden" name="product_id" value="<!--{$tpl_product_id}-->">
+        <input type="hidden" name="product_id" value="<!--{$tpl_product_id|h}-->">
         <center><input type="submit" name="submit" value="次へ"></center>
     </form>
 <!--{/strip}-->

--- a/data/Smarty/templates/mobile/products/select_item.tpl
+++ b/data/Smarty/templates/mobile/products/select_item.tpl
@@ -41,8 +41,8 @@
         <input type="hidden" name="mode" value="cart">
         <input type="hidden" name="classcategory_id1" value="<!--{$arrForm.classcategory_id1.value|h}-->">
         <input type="hidden" name="classcategory_id2" value="<!--{$arrForm.classcategory_id2.value|h}-->">
-        <input type="hidden" name="product_id" value="<!--{$tpl_product_id}-->">
-        <input type="hidden" name="product_class_id" value="<!--{$tpl_product_class_id}-->">
+        <input type="hidden" name="product_id" value="<!--{$tpl_product_id|h}-->">
+        <input type="hidden" name="product_class_id" value="<!--{$tpl_product_class_id|h}-->">
         <input type="hidden" name="product_type" value="<!--{$tpl_product_type}-->">
         <center><input type="submit" name="submit" value="カゴに入れる"></center>
     </form>

--- a/data/Smarty/templates/mobile/shopping/confirm.tpl
+++ b/data/Smarty/templates/mobile/shopping/confirm.tpl
@@ -26,7 +26,7 @@
     <form method="post" action="<!--{$smarty.const.MOBILE_SHOPPING_CONFIRM_URLPATH}-->">
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->">
         <input type="hidden" name="mode" value="confirm">
-        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->">
+        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->">
 
         下記のご注文内容に間違いはございませんか？<br>
 
@@ -149,7 +149,7 @@
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->">
         <input type="hidden" name="mode" value="select_deliv">
         <input type="hidden" name="deliv_id" value="<!--{$arrForm.deliv_id|h}-->">
-        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->">
+        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->">
         <center><input type="submit" value="戻る"></center>
     </form>
 <!--{/strip}-->

--- a/data/Smarty/templates/mobile/shopping/deliv.tpl
+++ b/data/Smarty/templates/mobile/shopping/deliv.tpl
@@ -30,15 +30,15 @@
         <!--{section name=cnt loop=$arrAddr}-->
         <form method="post" action="?">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->">
-            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->">
+            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->">
             <input type="hidden" name="deli" value="<!--{$smarty.section.cnt.iteration}-->">
             <input type="hidden" name="mode" value="customer_addr">
             <!--{if $smarty.section.cnt.first}-->
                 <input type="hidden" name="other_deliv_id" value="">
                 <input type="hidden" name="deliv_check" value="-1">
             <!--{else}-->
-                <input type="hidden" name="other_deliv_id" value="<!--{$arrAddr[cnt].other_deliv_id}-->">
-                <input type="hidden" name="deliv_check" value="<!--{$arrAddr[cnt].other_deliv_id}-->">
+                <input type="hidden" name="other_deliv_id" value="<!--{$arrAddr[cnt].other_deliv_id|h}-->">
+                <input type="hidden" name="deliv_check" value="<!--{$arrAddr[cnt].other_deliv_id|h}-->">
                 <br>
             <!--{/if}-->
 
@@ -62,15 +62,15 @@
             <form method="get" action="<!--{$smarty.const.ROOT_URLPATH}-->mypage/delivery_addr.php">
                 <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->">
                 <input type="hidden" name="page" value="<!--{$smarty.server.SCRIPT_NAME|h}-->">
-                <input type="hidden" name="other_deliv_id" value="<!--{$arrAddr[cnt].other_deliv_id}-->">
+                <input type="hidden" name="other_deliv_id" value="<!--{$arrAddr[cnt].other_deliv_id|h}-->">
                 <center><input type="submit" value="お届け先情報変更"></center>
             </form>
 
             <form method="post" action="?">
                 <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->">
-                <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->">
+                <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->">
                 <input type="hidden" name="mode" value="delete">
-                <input type="hidden" name="other_deliv_id" value="<!--{$arrAddr[cnt].other_deliv_id}-->">
+                <input type="hidden" name="other_deliv_id" value="<!--{$arrAddr[cnt].other_deliv_id|h}-->">
                 <center><input type="submit" value="お届け先を削除"></center>
             </form>
         <!--{/if}-->
@@ -91,7 +91,7 @@
         ■お届け先を複数指定する<br>
         <form method="post" action="?">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->">
-            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->">
+            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->">
             <input type="hidden" name="mode" value="multiple">
             <center><input type="submit" value="複数お届け先"></center>
         </form>

--- a/data/Smarty/templates/mobile/shopping/multiple.tpl
+++ b/data/Smarty/templates/mobile/shopping/multiple.tpl
@@ -27,7 +27,7 @@
 
     <form method="post" action="?">
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->">
-        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->">
+        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->">
         <input type="hidden" name="line_of_num" value="<!--{$arrForm.line_of_num.value}-->">
         <input type="hidden" name="mode" value="confirm">
         <!--{section name=line loop=$arrForm.line_of_num.value}-->

--- a/data/Smarty/templates/mobile/shopping/payment.tpl
+++ b/data/Smarty/templates/mobile/shopping/payment.tpl
@@ -26,7 +26,7 @@
     <form method="post" action="<!--{$smarty.const.MOBILE_SHOPPING_PAYMENT_URLPATH}-->">
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->">
         <input type="hidden" name="mode" value="confirm">
-        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->">
+        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->">
         <!--{assign var=key value="deliv_id"}-->
         <input type="hidden" name="<!--{$key}-->" value="<!--{$arrForm[$key].value|h}-->">
         ■お支払方法 <font color="#FF0000">*</font><br>
@@ -35,7 +35,7 @@
             <font color="#FF0000"><!--{$arrErr[$key]}--></font>
         <!--{/if}-->
         <!--{section name=cnt loop=$arrPayment}-->
-            <input type="radio" name="<!--{$key}-->" value="<!--{$arrPayment[cnt].payment_id}-->" <!--{$arrPayment[cnt].payment_id|sfGetChecked:$arrForm[$key].value}-->>
+            <input type="radio" name="<!--{$key}-->" value="<!--{$arrPayment[cnt].payment_id|h}-->" <!--{$arrPayment[cnt].payment_id|sfGetChecked:$arrForm[$key].value}-->>
             <!--{$arrPayment[cnt].payment_method|h}-->
             <br>
         <!--{/section}-->

--- a/data/Smarty/templates/mobile/shopping/select_deliv.tpl
+++ b/data/Smarty/templates/mobile/shopping/select_deliv.tpl
@@ -26,14 +26,14 @@
     <form method="post" action="<!--{$smarty.const.MOBILE_SHOPPING_PAYMENT_URLPATH}-->">
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->">
         <input type="hidden" name="mode" value="select_deliv">
-        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->">
+        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->">
         ■配送方法 <font color="#FF0000">*</font><br>
         <!--{assign var=key value="deliv_id"}-->
         <!--{if $arrErr[$key] != ""}-->
             <font color="#FF0000"><!--{$arrErr[$key]}--></font>
         <!--{/if}-->
         <!--{section name=cnt loop=$arrDeliv}-->
-            <input type="radio" name="<!--{$key}-->" value="<!--{$arrDeliv[cnt].deliv_id}-->" <!--{$arrDeliv[cnt].deliv_id|sfGetChecked:$arrForm[$key].value}-->>
+            <input type="radio" name="<!--{$key}-->" value="<!--{$arrDeliv[cnt].deliv_id|h}-->" <!--{$arrDeliv[cnt].deliv_id|sfGetChecked:$arrForm[$key].value}-->>
             <!--{$arrDeliv[cnt].name|h}-->
             <br>
         <!--{/section}-->

--- a/data/Smarty/templates/sphone/forgot/complete.tpl
+++ b/data/Smarty/templates/sphone/forgot/complete.tpl
@@ -30,7 +30,7 @@
 
         <div class="window_area clearfix">
             <!--{if $smarty.const.FORGOT_MAIL != 1}-->
-                <input id="completebox" type="text" value="<!--{$arrForm.new_password}-->" readonly="readonly" />
+                <input id="completebox" type="text" value="<!--{$arrForm.new_password|h}-->" readonly="readonly" />
             <!--{else}-->
                 <p  class="attention">ご登録メールアドレスに送付致しました。</p>
             <!--{/if}-->

--- a/data/Smarty/templates/sphone/frontparts/bloc/news.tpl
+++ b/data/Smarty/templates/sphone/frontparts/bloc/news.tpl
@@ -26,7 +26,7 @@
     <ul class="newslist">
         <!--{section name=data loop=$arrNews max=3}-->
             <li>
-                <a id="windowcolumn<!--{$smarty.section.data.index}-->" href="javascript:getNewsDetail(<!--{$arrNews[data].news_id}-->);">
+                <a id="windowcolumn<!--{$smarty.section.data.index}-->" href="javascript:getNewsDetail(<!--{$arrNews[data].news_id|h}-->);">
                 <span class="news_title"><!--{$arrNews[data].news_title|h}--></span></a><br />
                 <span class="news_date"><!--{$arrNews[data].cast_news_date|date_format:"%Y年 %m月 %d日"}--></span>
             </li>

--- a/data/Smarty/templates/sphone/frontparts/form_personal_input.tpl
+++ b/data/Smarty/templates/sphone/frontparts/form_personal_input.tpl
@@ -235,7 +235,7 @@
             <!--{/if}-->
             <ul style="<!--{$arrErr.mailmaga_flg|sfGetErrorColor}-->">
                 <!--{foreach from=$arrMAILMAGATYPE name=cnt item=type key=key}-->
-                <li><input type="radio" name="<!--{$key1}-->" value="<!--{$key}-->" id="<!--{$key1}--><!--{$key}-->" <!--{if $arrForm[$key1].value == $key}--> checked="checked" <!--{/if}--> class="data-role-none" /><label for="<!--{$key1}--><!--{$key}-->"><!--{$type}--></label></li>
+                <li><input type="radio" name="<!--{$key1|h}-->" value="<!--{$key|h}-->" id="<!--{$key1|h}--><!--{$key|h}-->" <!--{if $arrForm[$key1].value == $key}--> checked="checked" <!--{/if}--> class="data-role-none" /><label for="<!--{$key1|h}--><!--{$key|h}-->"><!--{$type|h}--></label></li>
                 <!--{/foreach}-->
             </ul>
         </dd>

--- a/data/Smarty/templates/sphone/mypage/delivery.tpl
+++ b/data/Smarty/templates/sphone/mypage/delivery.tpl
@@ -63,8 +63,8 @@
                                 <span class="name01"><!--{$arrOtherDeliv[cnt].name01|h}--></span>&nbsp;<span class="name02"><!--{$arrOtherDeliv[cnt].name02|h}--></span></p>
 
                             <ul class="edit">
-                                <li><a href="#" onClick="eccube.openWindow('./delivery_addr.php?other_deliv_id=<!--{$arrOtherDeliv[cnt].other_deliv_id}-->','deliv_disp','600','640'); return false;" class="b_edit deliv_edit" rel="external">編集</a></li>
-                                <li><a href="#" onClick="eccube.setModeAndSubmit('delete','other_deliv_id','<!--{$arrOtherDeliv[cnt].other_deliv_id}-->'); return false;" class="deliv_delete" rel="external"><img src="<!--{$TPL_URLPATH}-->img/button/btn_delete.png" class="pointer" width="21" height="20" alt="削除" /></a></li>
+                                <li><a href="#" onClick="eccube.openWindow('./delivery_addr.php?other_deliv_id=<!--{$arrOtherDeliv[cnt].other_deliv_id|h}-->','deliv_disp','600','640'); return false;" class="b_edit deliv_edit" rel="external">編集</a></li>
+                                <li><a href="#" onClick="eccube.setModeAndSubmit('delete','other_deliv_id','<!--{$arrOtherDeliv[cnt].other_deliv_id|h}-->'); return false;" class="deliv_delete" rel="external"><img src="<!--{$TPL_URLPATH}-->img/button/btn_delete.png" class="pointer" width="21" height="20" alt="削除" /></a></li>
                             </ul>
                         </div>
                         <!--▲お届け先-->

--- a/data/Smarty/templates/sphone/mypage/delivery.tpl
+++ b/data/Smarty/templates/sphone/mypage/delivery.tpl
@@ -48,7 +48,7 @@
                 <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
                 <input type="hidden" name="mode" value="" />
                 <input type="hidden" name="other_deliv_id" value="" />
-                <input type="hidden" name="pageno" value="<!--{$tpl_pageno}-->" />
+                <input type="hidden" name="pageno" value="<!--{$tpl_pageno|h}-->" />
 
                 <!--▼フォームボックスここから -->
                 <div class="formBox">
@@ -77,7 +77,7 @@
         <!--{/if}-->
 
         <!--{if count($arrOtherDeliv) > $dispNumber}-->
-            <p><a rel="external" href="javascript: void(0);" class="btn_more" id="btn_more_delivery" onClick="getDelivery(<!--{$dispNumber}-->); return false;" rel="external">もっとみる(＋<!--{$dispNumber}-->件)</a></p>
+            <p><a rel="external" href="javascript: void(0);" class="btn_more" id="btn_more_delivery" onClick="getDelivery(<!--{$dispNumber|h}-->); return false;" rel="external">もっとみる(＋<!--{$dispNumber|h}-->件)</a></p>
         <!--{/if}-->
 
     </div><!-- /.form_area -->

--- a/data/Smarty/templates/sphone/mypage/delivery_addr.tpl
+++ b/data/Smarty/templates/sphone/mypage/delivery_addr.tpl
@@ -36,7 +36,7 @@
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
         <input type="hidden" name="mode" value="edit" />
         <input type="hidden" name="other_deliv_id" value="<!--{$smarty.session.other_deliv_id|h}-->" />
-        <input type="hidden" name="ParentPage" value="<!--{$ParentPage}-->" />
+        <input type="hidden" name="ParentPage" value="<!--{$ParentPage|h}-->" />
 
         <dl class="form_entry">
             <!--{include file="`$smarty.const.SMARTPHONE_TEMPLATE_REALDIR`frontparts/form_personal_input.tpl" flgFields=1 emailMobile=false prefix=""}-->

--- a/data/Smarty/templates/sphone/mypage/favorite.tpl
+++ b/data/Smarty/templates/sphone/mypage/favorite.tpl
@@ -78,7 +78,7 @@
 
         <div class="btn_area">
             <!--{if $tpl_linemax > $dispNumber}-->
-                <p><a rel="external" href="javascript: void(0);" class="btn_more" id="btn_more_product" onclick="getProducts(<!--{$dispNumber}-->); return false;">もっとみる(＋<!--{$dispNumber}-->件)</a></p>
+                <p><a rel="external" href="javascript: void(0);" class="btn_more" id="btn_more_product" onclick="getProducts(<!--{$dispNumber|h}-->); return false;">もっとみる(＋<!--{$dispNumber|h}-->件)</a></p>
             <!--{/if}-->
         </div>
 

--- a/data/Smarty/templates/sphone/mypage/history.tpl
+++ b/data/Smarty/templates/sphone/mypage/history.tpl
@@ -38,7 +38,7 @@
 
             <form action="order.php" method="post">
                 <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
-                <input type="hidden" name="order_id" value="<!--{$tpl_arrOrderData.order_id}-->">
+                <input type="hidden" name="order_id" value="<!--{$tpl_arrOrderData.order_id|h}-->">
                 <input class="btn_reorder btn data-role-none" type="submit" name="submit" value="再注文">
             </form>
         </div>

--- a/data/Smarty/templates/sphone/mypage/index.tpl
+++ b/data/Smarty/templates/sphone/mypage/index.tpl
@@ -34,7 +34,7 @@
         <form name="form1" id="form1" method="post" action="<!--{$smarty.const.ROOT_URLPATH}-->mypage/index.php">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
             <input type="hidden" name="order_id" value="" />
-            <input type="hidden" name="pageno" value="<!--{$objNavi->nowpage}-->" />
+            <input type="hidden" name="pageno" value="<!--{$objNavi->nowpage|h}-->" />
 
             <h3 class="title_mypage"><!--{$tpl_subtitle|h}--></h3>
             <!--{if $objNavi->all_row > 0}-->
@@ -74,7 +74,7 @@
                 </div><!-- /.form_area-->
                 <div class="btn_area">
                     <!--{if $objNavi->all_row > $dispNumber}-->
-                        <p><a href="javascript: void(0);" class="btn_more" id="btn_more_history" onClick="getHistory(<!--{$dispNumber}-->); return false;" rel="external">もっとみる(＋<!--{$dispNumber}-->件)</a></p>
+                        <p><a href="javascript: void(0);" class="btn_more" id="btn_more_history" onClick="getHistory(<!--{$dispNumber|h}-->); return false;" rel="external">もっとみる(＋<!--{$dispNumber|h}-->件)</a></p>
                     <!--{/if}-->
                 </div>
             <!--{else}-->

--- a/data/Smarty/templates/sphone/mypage/login.tpl
+++ b/data/Smarty/templates/sphone/mypage/login.tpl
@@ -67,7 +67,7 @@
 
                 <!--{assign var=key value="login_pass"}-->
                 <span class="attention"><!--{$arrErr[$key]}--></span>
-                <input type="password" name="<!--{$key}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="passtextBox data-role-none" placeholder="パスワード" />
+                <input type="password" name="<!--{$key|h}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="passtextBox data-role-none" placeholder="パスワード" />
             </div><!-- /.loginareaBox -->
 
             <p class="arrowRtxt"><a rel="external" href="<!--{$smarty.const.HTTPS_URL}-->forgot/<!--{$smarty.const.DIR_INDEX_PATH}-->">パスワードを忘れた方</a></p>

--- a/data/Smarty/templates/sphone/products/detail.tpl
+++ b/data/Smarty/templates/sphone/products/detail.tpl
@@ -239,8 +239,8 @@
 
                 <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
                 <input type="hidden" name="mode" value="cart" />
-                <input type="hidden" name="product_id" value="<!--{$tpl_product_id}-->" />
-                <input type="hidden" name="product_class_id" value="<!--{$tpl_product_class_id}-->" id="product_class_id" />
+                <input type="hidden" name="product_id" value="<!--{$tpl_product_id|h}-->" />
+                <input type="hidden" name="product_class_id" value="<!--{$tpl_product_class_id|h}-->" id="product_class_id" />
                 <input type="hidden" name="favorite_product_id" value="" />
 
                 <!--▼買い物カゴ-->
@@ -375,7 +375,7 @@
             <div class="review_btn">
                 <!--{if is_array($arrReview) && count($arrReview) < $smarty.const.REVIEW_REGIST_MAX}-->
                     <!--★新規コメントを書き込む★-->
-                    <a href="./review.php?product_id=<!--{$arrProduct.product_id}-->" target="_blank" class="btn_sub">新規コメントを書き込む</a>
+                    <a href="./review.php?product_id=<!--{$arrProduct.product_id|h}-->" target="_blank" class="btn_sub">新規コメントを書き込む</a>
                 <!--{/if}-->
             </div>
             </div>

--- a/data/Smarty/templates/sphone/shopping/confirm.tpl
+++ b/data/Smarty/templates/sphone/shopping/confirm.tpl
@@ -84,7 +84,7 @@
     <form name="form1" id="form1" method="post" action="<!--{$smarty.const.ROOT_URLPATH}-->shopping/confirm.php">
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
         <input type="hidden" name="mode" value="confirm" />
-        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->" />
+        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->" />
 
         <h3 class="subtitle">ご注文内容</h3>
 

--- a/data/Smarty/templates/sphone/shopping/deliv.tpl
+++ b/data/Smarty/templates/sphone/shopping/deliv.tpl
@@ -35,7 +35,7 @@
         <form name="form1" id="form1" method="post" action="<!--{$smarty.const.ROOT_URLPATH}-->shopping/deliv.php">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
             <input type="hidden" name="mode" value="customer_addr" />
-            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->" />
+            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->" />
             <input type="hidden" name="other_deliv_id" value="" />
             <!--{if $arrErr.deli != ""}-->
                 <p class="attention"><!--{$arrErr.deli}--></p>
@@ -65,7 +65,7 @@
                         <!--{else}-->
                             <dt>
                                 <p>
-                                    <input type="radio" name="deliv_check" id="chk_id_<!--{$smarty.section.cnt.iteration}-->" value="<!--{$arrAddr[cnt].other_deliv_id}-->"<!--{if $arrForm.deliv_check.value == $arrAddr[cnt].other_deliv_id}--> checked="checked"<!--{/if}--> class="data-role-none" />
+                                    <input type="radio" name="deliv_check" id="chk_id_<!--{$smarty.section.cnt.iteration}-->" value="<!--{$arrAddr[cnt].other_deliv_id|h}-->"<!--{if $arrForm.deliv_check.value == $arrAddr[cnt].other_deliv_id|h}--> checked="checked"<!--{/if}--> class="data-role-none" />
                                     <label for="chk_id_<!--{$smarty.section.cnt.iteration}-->">追加登録住所</label>
                                 </p>
                                 <ul class="edit">

--- a/data/Smarty/templates/sphone/shopping/index.tpl
+++ b/data/Smarty/templates/sphone/shopping/index.tpl
@@ -67,7 +67,7 @@
         <input type="email" name="<!--{$key}-->" value="<!--{$tpl_login_email|h}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="mailtextBox data-role-none" placeholder="メールアドレス" />
         <!--{assign var=key value="login_pass"}-->
         <span class="attention"><!--{$arrErr[$key]}--></span>
-        <input type="password" name="<!--{$key}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="passtextBox data-role-none" placeholder="パスワード" />
+        <input type="password" name="<!--{$key|h}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="passtextBox data-role-none" placeholder="パスワード" />
         </div>
 
         <p class="arrowRtxt"><a rel="external" href="<!--{$smarty.const.HTTPS_URL}-->forgot/<!--{$smarty.const.DIR_INDEX_PATH}-->">パスワードを忘れた方</a></p>

--- a/data/Smarty/templates/sphone/shopping/multiple.tpl
+++ b/data/Smarty/templates/sphone/shopping/multiple.tpl
@@ -42,7 +42,7 @@
     <div class="form_area">
         <form name="form1" id="form1" method="post" action="<!--{$smarty.const.ROOT_URLPATH}-->shopping/multiple.php">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
-            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->" />
+            <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->" />
             <input type="hidden" name="line_of_num" value="<!--{$arrForm.line_of_num.value}-->" />
             <input type="hidden" name="mode" value="confirm" />
 

--- a/data/Smarty/templates/sphone/shopping/multiple.tpl
+++ b/data/Smarty/templates/sphone/shopping/multiple.tpl
@@ -43,7 +43,7 @@
         <form name="form1" id="form1" method="post" action="<!--{$smarty.const.ROOT_URLPATH}-->shopping/multiple.php">
             <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
             <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->" />
-            <input type="hidden" name="line_of_num" value="<!--{$arrForm.line_of_num.value}-->" />
+            <input type="hidden" name="line_of_num" value="<!--{$arrForm.line_of_num.value|h}-->" />
             <input type="hidden" name="mode" value="confirm" />
 
             <!--{section name=line loop=$arrForm.line_of_num.value}-->
@@ -79,7 +79,7 @@
                     <!--▲商品 -->
 
                     <div class="btn_area_btm">
-                        <input type="hidden" name="cart_no[<!--{$index}-->]" value="<!--{$index}-->" />
+                        <input type="hidden" name="cart_no[<!--{$index|h}-->]" value="<!--{$index|h}-->" />
                         <!--{assign var=key value="product_class_id"}-->
                         <input type="hidden" name="<!--{$key}-->[<!--{$index}-->]" value="<!--{$arrForm[$key].value[$index]|h}-->" />
                         <!--{assign var=key value="name"}-->

--- a/data/Smarty/templates/sphone/shopping/nonmember_input.tpl
+++ b/data/Smarty/templates/sphone/shopping/nonmember_input.tpl
@@ -49,7 +49,7 @@
     <form name="form1" id="form1" method="post" action="?">
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
         <input type="hidden" name="mode" value="nonmember_confirm" />
-        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->" />
+        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->" />
 
         <dl class="form_entry">
             <dt>お名前&nbsp;<span class="attention">※</span></dt>

--- a/data/Smarty/templates/sphone/shopping/nonmember_input.tpl
+++ b/data/Smarty/templates/sphone/shopping/nonmember_input.tpl
@@ -23,7 +23,7 @@
 <script type="text/javascript">//<![CDATA[
     $(function(){
         //お届け先エリアを非表示にする（初期値）
-        if ('1' != '<!--{$arrForm.deliv_check.value}-->') {
+        if ('1' != '<!--{$arrForm.deliv_check.value|h}-->') {
             $("#add_deliv_area").hide();
         }
     });
@@ -57,12 +57,12 @@
                 <!--{assign var=key1 value="order_name01"}-->
                 <!--{assign var=key2 value="order_name02"}-->
                 <span class="attention"><!--{$arrErr[$key1]}--><!--{$arrErr[$key2]}--></span>
-                <input type="text" name="<!--{$key1}-->"
+                <input type="text" name="<!--{$key1|h}-->"
                     value="<!--{$arrForm[$key1].value|h}-->"
                     maxlength="<!--{$arrForm[$key1].length}-->"
                     style="<!--{$arrErr[$key1]|sfGetErrorColor}-->"
                     class="boxHarf text data-role-none" placeholder="姓" />&nbsp;&nbsp;
-                <input type="text" name="<!--{$key2}-->"
+                <input type="text" name="<!--{$key2|h}-->"
                     value="<!--{$arrForm[$key2].value|h}-->"
                     maxlength="<!--{$arrForm[$key2].length}-->"
                     style="<!--{$arrErr[$key2]|sfGetErrorColor}-->"
@@ -74,12 +74,12 @@
                 <!--{assign var=key1 value="order_kana01"}-->
                 <!--{assign var=key2 value="order_kana02"}-->
                 <span class="attention"><!--{$arrErr[$key1]}--><!--{$arrErr[$key2]}--></span>
-                <input type="text" name="<!--{$key1}-->"
+                <input type="text" name="<!--{$key1|h}-->"
                     value="<!--{$arrForm[$key1].value|h}-->"
                     maxlength="<!--{$arrForm[$key1].length}-->"
                     style="<!--{$arrErr[$key1]|sfGetErrorColor}-->"
                     class="boxHarf text data-role-none" placeholder="セイ"/>&nbsp;&nbsp;
-                <input type="text" name="<!--{$key2}-->"
+                <input type="text" name="<!--{$key2|h}-->"
                     value="<!--{$arrForm[$key2].value|h}-->"
                     maxlength="<!--{$arrForm[$key2].length}-->"
                     style="<!--{$arrErr[$key2]|sfGetErrorColor}-->"
@@ -121,11 +121,11 @@
                 <!--{assign var=key2 value="order_zip02"}-->
                 <span class="attention"><!--{$arrErr[$key1]}--><!--{$arrErr[$key2]}--></span>
                 <p>
-                    <input type="tel" name="<!--{$key1}-->"
+                    <input type="tel" name="<!--{$key1|h}-->"
                         value="<!--{$arrForm[$key1].value|h}-->"
                         maxlength="<!--{$arrForm[$key1].length}-->"
                         style="<!--{$arrErr[$key1]|sfGetErrorColor}-->" class="boxShort text data-role-none" />&nbsp;－&nbsp;
-                    <input type="tel" name="<!--{$key2}-->"
+                    <input type="tel" name="<!--{$key2|h}-->"
                         value="<!--{$arrForm[$key2].value|h}-->"
                         maxlength="<!--{$arrForm[$key2].length}-->"
                         style="<!--{$arrErr[$key2]|sfGetErrorColor}-->" class="boxShort text data-role-none" />&nbsp;
@@ -157,17 +157,17 @@
                 <span class="attention"><!--{$arrErr[$key1]}--></span>
                 <span class="attention"><!--{$arrErr[$key2]}--></span>
                 <span class="attention"><!--{$arrErr[$key3]}--></span>
-                <input type="tel" name="<!--{$key1}-->"
+                <input type="tel" name="<!--{$key1|h}-->"
                     value="<!--{$arrForm[$key1].value|h}-->"
                     maxlength="<!--{$arrForm[$key1].length}-->"
                     style="<!--{$arrErr[$key1]|sfGetErrorColor}-->"
                     class="boxShort text data-role-none" />&nbsp;－&nbsp;
-                <input type="tel" name="<!--{$key2}-->"
+                <input type="tel" name="<!--{$key2|h}-->"
                     value="<!--{$arrForm[$key2].value|h}-->"
                     maxlength="<!--{$arrForm[$key2].length}-->"
                     style="<!--{$arrErr[$key2]|sfGetErrorColor}-->"
                     class="boxShort text data-role-none" />&nbsp;－&nbsp;
-                <input type="tel" name="<!--{$key3}-->"
+                <input type="tel" name="<!--{$key3|h}-->"
                     value="<!--{$arrForm[$key3].value|h}-->"
                     maxlength="<!--{$arrForm[$key3].length}-->"
                     style="<!--{$arrErr[$key3]|sfGetErrorColor}-->"
@@ -182,17 +182,17 @@
                 <span class="attention"><!--{$arrErr[$key1]}--></span>
                 <span class="attention"><!--{$arrErr[$key2]}--></span>
                 <span class="attention"><!--{$arrErr[$key3]}--></span>
-                <input type="tel" name="<!--{$key1}-->"
+                <input type="tel" name="<!--{$key1|h}-->"
                     value="<!--{$arrForm[$key1].value|h}-->"
                     maxlength="<!--{$arrForm[$key1].length}-->"
                     style="<!--{$arrErr[$key1]|sfGetErrorColor}-->"
                     class="boxShort text data-role-none" />&nbsp;－&nbsp;
-                <input type="tel" name="<!--{$key2}-->"
+                <input type="tel" name="<!--{$key2|h}-->"
                     value="<!--{$arrForm[$key2].value|h}-->"
                     maxlength="<!--{$arrForm[$key2].length}-->"
                     style="<!--{$arrErr[$key2]|sfGetErrorColor}-->"
                     class="boxShort text data-role-none" />&nbsp;－&nbsp;
-                <input type="tel" name="<!--{$key3}-->"
+                <input type="tel" name="<!--{$key3|h}-->"
                     value="<!--{$arrForm[$key3].value|h}-->"
                     maxlength="<!--{$arrForm[$key3].length}-->"
                     style="<!--{$arrErr[$key3]|sfGetErrorColor}-->"
@@ -203,13 +203,13 @@
             <dd>
                 <!--{assign var=key value="order_email"}-->
                 <span class="attention"><!--{$arrErr[$key]}--></span>
-                <input type="email" name="<!--{$key}-->"
+                <input type="email" name="<!--{$key|h}-->"
                     value="<!--{$arrForm[$key].value|h}-->"
                     style="<!--{$arrErr[$key]|sfGetErrorColor}-->"
                     maxlength="<!--{$arrForm[$key].length}-->" class="boxLong top data-role-none" />
                 <!--{assign var=key value="order_email02"}-->
                 <span class="attention"><!--{$arrErr[$key]}--></span>
-                <input type="email" name="<!--{$key}-->"
+                <input type="email" name="<!--{$key|h}-->"
                     value="<!--{$arrForm[$key].value|h}-->"
                     style="<!--{$arrErr[$key]|sfGetErrorColor}-->"
                     maxlength="<!--{$arrForm[$key].length}-->" class="boxLong data-role-none" placeholder="確認のため2回入力してください" />
@@ -223,8 +223,8 @@
                     <!--{assign var=err value="background-color: `$smarty.const.ERR_COLOR`"}-->
                 <!--{/if}-->
                 <p style="<!--{$arrErr[$key]|sfGetErrorColor}-->">
-                    <input type="radio" id="man" name="<!--{$key}-->" value="1" <!--{if $arrForm[$key].value eq 1}--> checked="checked" <!--{/if}--> class="data-role-none" /><label for="man">男性</label>&nbsp;&nbsp;
-                    <input type="radio" id="woman" name="<!--{$key}-->" value="2" <!--{if $arrForm[$key].value eq 2}--> checked="checked" <!--{/if}--> class="data-role-none" /><label for="woman">女性</label>
+                    <input type="radio" id="man" name="<!--{$key|h}-->" value="1" <!--{if $arrForm[$key].value eq 1}--> checked="checked" <!--{/if}--> class="data-role-none" /><label for="man">男性</label>&nbsp;&nbsp;
+                    <input type="radio" id="woman" name="<!--{$key|h}-->" value="2" <!--{if $arrForm[$key].value eq 2}--> checked="checked" <!--{/if}--> class="data-role-none" /><label for="woman">女性</label>
                 </p>
             </dd>
 
@@ -277,12 +277,12 @@
                     <!--{assign var=key1 value="shipping_name01"}-->
                     <!--{assign var=key2 value="shipping_name02"}-->
                     <span class="attention"><!--{$arrErr[$key1]}--><!--{$arrErr[$key2]}--></span>
-                    <input type="text" name="<!--{$key1}-->"
+                    <input type="text" name="<!--{$key1|h}-->"
                         value="<!--{$arrForm[$key1].value|h}-->"
                         maxlength="<!--{$arrForm[$key1].length}-->"
                         style="<!--{$arrErr[$key1]|sfGetErrorColor}-->"
                         class="boxHarf text data-role-none" placeholder="姓" />&nbsp;&nbsp;
-                    <input type="text" name="<!--{$key2}-->"
+                    <input type="text" name="<!--{$key2|h}-->"
                         value="<!--{$arrForm[$key2].value|h}-->"
                         maxlength="<!--{$arrForm[$key2].length}-->"
                         style="<!--{$arrErr[$key2]|sfGetErrorColor}-->"
@@ -294,12 +294,12 @@
                     <!--{assign var=key1 value="shipping_kana01"}-->
                     <!--{assign var=key2 value="shipping_kana02"}-->
                     <span class="attention"><!--{$arrErr[$key1]}--><!--{$arrErr[$key2]}--></span>
-                    <input type="text" name="<!--{$key1}-->"
+                    <input type="text" name="<!--{$key1|h}-->"
                         value="<!--{$arrForm[$key1].value|h}-->"
                         maxlength="<!--{$arrForm[$key1].length}-->"
                         style="<!--{$arrErr[$key1]|sfGetErrorColor}-->"
                         class="boxHarf text data-role-none" placeholder="セイ"/>&nbsp;&nbsp;
-                    <input type="text" name="<!--{$key2}-->"
+                    <input type="text" name="<!--{$key2|h}-->"
                         value="<!--{$arrForm[$key2].value|h}-->"
                         maxlength="<!--{$arrForm[$key2].length}-->"
                         style="<!--{$arrErr[$key2]|sfGetErrorColor}-->"
@@ -341,11 +341,11 @@
                     <!--{assign var=key2 value="shipping_zip02"}-->
                     <span class="attention"><!--{$arrErr[$key1]}--><!--{$arrErr[$key2]}--></span>
                     <p>
-                        <input type="tel" name="<!--{$key1}-->"
+                        <input type="tel" name="<!--{$key1|h}-->"
                             value="<!--{$arrForm[$key1].value|h}-->"
                             maxlength="<!--{$arrForm[$key1].length}-->"
                             style="<!--{$arrErr[$key1]|sfGetErrorColor}-->" class="boxShort text data-role-none" />&nbsp;－&nbsp;
-                        <input type="tel" name="<!--{$key2}-->"
+                        <input type="tel" name="<!--{$key2|h}-->"
                             value="<!--{$arrForm[$key2].value|h}-->"
                             maxlength="<!--{$arrForm[$key2].length}-->"
                             style="<!--{$arrErr[$key2]|sfGetErrorColor}-->" class="boxShort text data-role-none" />&nbsp;
@@ -364,13 +364,13 @@
                         <!--{html_options options=$arrPref selected=$arrForm[$key].value}-->
                     </select>
                     <!--{assign var=key value="shipping_addr01"}-->
-                    <input type="text" name="<!--{$key}-->"
+                    <input type="text" name="<!--{$key|h}-->"
                         value="<!--{$arrForm[$key].value|h}-->"
                         class="boxLong top data-role-none"
                         style="<!--{$arrErr[$key]|sfGetErrorColor}-->"
                         placeholder="市区町村名" />
                     <!--{assign var=key value="shipping_addr02"}-->
-                    <input type="text" name="<!--{$key}-->"
+                    <input type="text" name="<!--{$key|h}-->"
                         value="<!--{$arrForm[$key].value|h}-->"
                         class="boxLong data-role-none"
                         style="<!--{$arrErr[$key]|sfGetErrorColor}-->"
@@ -385,17 +385,17 @@
                     <span class="attention"><!--{$arrErr[$key1]}--></span>
                     <span class="attention"><!--{$arrErr[$key2]}--></span>
                     <span class="attention"><!--{$arrErr[$key3]}--></span>
-                    <input type="tel" name="<!--{$key1}-->"
+                    <input type="tel" name="<!--{$key1|h}-->"
                         value="<!--{$arrForm[$key1].value|h}-->"
                         maxlength="<!--{$arrForm[$key1].length}-->"
                         style="<!--{$arrErr[$key1]|sfGetErrorColor}-->"
                         class="boxShort text data-role-none" />&nbsp;－&nbsp;
-                    <input type="tel" name="<!--{$key2}-->"
+                    <input type="tel" name="<!--{$key2|h}-->"
                         value="<!--{$arrForm[$key2].value|h}-->"
                         maxlength="<!--{$arrForm[$key2].length}-->"
                         style="<!--{$arrErr[$key2]|sfGetErrorColor}-->"
                         class="boxShort text data-role-none" />&nbsp;－&nbsp;
-                    <input type="tel" name="<!--{$key3}-->"
+                    <input type="tel" name="<!--{$key3|h}-->"
                         value="<!--{$arrForm[$key3].value|h}-->"
                         maxlength="<!--{$arrForm[$key3].length}-->"
                         style="<!--{$arrErr[$key3]|sfGetErrorColor}-->"

--- a/data/Smarty/templates/sphone/shopping/payment.tpl
+++ b/data/Smarty/templates/sphone/shopping/payment.tpl
@@ -120,7 +120,7 @@
     <form name="form1" id="form1" method="post" action="<!--{$smarty.const.ROOT_URLPATH}-->shopping/payment.php">
         <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
         <input type="hidden" name="mode" value="confirm" />
-        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid}-->" />
+        <input type="hidden" name="uniqid" value="<!--{$tpl_uniqid|h}-->" />
 
         <!--★インフォメーション★-->
         <div class="information end">

--- a/data/Smarty/templates/sphone/shopping/payment.tpl
+++ b/data/Smarty/templates/sphone/shopping/payment.tpl
@@ -245,7 +245,7 @@
                                     <label for="point_on">ポイントを使用する</label>
                                 </p>
                                 <!--{assign var=key value="use_point"}-->
-                                <p class="check_point"><input type="text" name="<!--{$key}-->" value="<!--{$arrForm[$key].value|default:$tpl_user_point}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="box_point data-role-none" />ポイントを使用する。<span class="attention"><!--{$arrErr[$key]}--></span></p>
+                                <p class="check_point"><input type="text" name="<!--{$key|h}-->" value="<!--{$arrForm[$key].value|h|default:$tpl_user_point}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" class="box_point data-role-none" />ポイントを使用する。<span class="attention"><!--{$arrErr[$key]}--></span></p>
                             </div>
                         <div class="innerBox fb">
                             <input type="radio" id="point_off" name="point_check" value="2" <!--{$arrForm.point_check.value|sfGetChecked:2}--> onchange="eccube.togglePointForm();" class="data-role-none" />


### PR DESCRIPTION
- 主に未知の攻撃パターンによるXSSを防止する目的
- エスケープ漏れがあった場合でも、デフォルトフィルターによってサニタイズされるため実害は無いが、未知の攻撃パターン防止のためエスケープ処理を追加
  - OWASP ZAP で警告が出たケースを修正
  - 以下のような grep で対象をざっくり抽出し、目視で修正
```shell
grep -r --color -nH --null -P  '(?!.*(\|h|\$smarty\.const|transactionid|nofilter|TPL_URLPATH|escape:|sfGetCheck|\.iteration}))<(a|input).*<!--{\$.*}-->' --exclude-dir=mobile data/Smarty/templates
```