### PR TITLE
お問い合わせフォームの入力チェックでシステムエラーになるのを修正

### DIFF
--- a/data/Smarty/templates/default/contact/index.tpl
+++ b/data/Smarty/templates/default/contact/index.tpl
@@ -114,7 +114,7 @@
                     <span class="mini">（全角<!--{$smarty.const.MLTEXT_LEN}-->字以下）</span></th>
                     <td>
                         <span class="attention"><!--{$arrErr.contents}--></span>
-                        <textarea name="contents" class="box380" cols="60" rows="20" style="<!--{$arrErr.contents.value|h|sfGetErrorColor}-->; ime-mode: active;"><!--{"\n"}--><!--{$arrForm.contents.value|h}--></textarea>
+                        <textarea name="contents" class="box380" cols="60" rows="20" style="<!--{$arrErr.contents|sfGetErrorColor}-->; ime-mode: active;"><!--{"\n"}--><!--{$arrForm.contents.value|h}--></textarea>
                         <p class="mini attention">※ご注文に関するお問い合わせには、必ず「ご注文番号」をご記入くださいますようお願いいたします。</p>
                     </td>
                 </tr>

--- a/e2e-tests/test/front_login/contact.test.ts
+++ b/e2e-tests/test/front_login/contact.test.ts
@@ -134,4 +134,16 @@ test.describe.serial('お問い合わせページのテストをします', () =
         .then(alerts => expect(alerts).toEqual([]));
     });
   });
+
+  /**
+   * https://github.com/EC-CUBE/ec-cube2/pull/536 のE2Eテスト
+   */
+  test('ラーメッセージの表示を確認します', async () => {
+    await page.goto(PlaywrightConfig.use.baseURL);       // ログアウトしてしまう場合があるので一旦トップへ遷移する
+    await page.goto(url);
+    await page.click('input[name=confirm]');
+    await page.pause();
+    await expect(page.locator('span.attention >> nth=13')).toContainText('※ お問い合わせ内容が入力されていません。');
+    await expect(page.locator('textarea[name=contents]')).toHaveAttribute('style', 'background-color:#ffe8e8; ime-mode: active;');
+  });
 });


### PR DESCRIPTION
PHP8において、お問い合わせフォームのお問い合わせ覧を空欄で確認画面へ進むとシステムエラーになるのを修正

以下開発コミュニティからの報告
https://xoops.ec-cube.net/modules/newbb/viewtopic.php?topic_id=26712&forum=8&post_id=106064#forumpost106064