### PR TITLE
actions/create-release が開発中止になったため ncipollo/release-action を使用する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,13 +36,11 @@ jobs:
         run: echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
       - name: Create Release
         if: github.event_name == 'schedule' && env.DEPLOY == 1
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ env.TAG_NAME }}
-          release_name: ${{ env.TAG_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.TAG_NAME }}
+          name: ${{ env.TAG_NAME }}
           body: |
             EC-CUBE 2.17系の Weekly build🚀 です。毎週の改善内容を反映しております。
             常に安定して動作するよう努めていますが、思わぬ不具合を取り込んでしまっている場合もあります。十分に検証の上ご利用ください。
@@ -55,39 +53,20 @@ jobs:
             </tbody>
             </table>
 
-          draft: false
           prerelease: true
-      - name: RELEASE_BODY
-        if: github.event_name == 'schedule'
-        env:
-          TAG_NAME: ${{ env.TAG_NAME }}
-        run: |
-          echo 'RELEASE_BODY<<EOF' >> $GITHUB_ENV
-          echo $(curl -sS -H 'Accept: application/vnd.github.v3+json'  https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ env.TAG_NAME }} | jq -r .body | sed 's,",\\",g' | sed "s,',,g") >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-      - name: RELEASE_ID
-        if: github.event_name == 'schedule'
-        env:
-          TAG_NAME: ${{ env.TAG_NAME }}
-        run: |
-          echo "RELEASE_ID=$(curl -sS -H 'Accept: application/vnd.github.v3+json'  https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ env.TAG_NAME }} | jq -r .id)" >> $GITHUB_ENV
-      - name: GENERATED_NOTES
-        if: github.event_name == 'schedule'
-        run: |
-          echo 'GENERATED_NOTES<<EOF' >> $GITHUB_ENV
-          echo $(curl -sS -X POST -H 'Accept: application/vnd.github.v3+json' -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'  https://api.github.com/repos/${{ github.repository }}/releases/generate-notes -d '{"tag_name":"${{ env.TAG_NAME }}", "previous_tag_name":"${{ env.PREVIOUS_TAG_NAME }}"}' | jq .body | sed 's,",,g' | sed "s,',,g") >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          generateReleaseNotes: true
 
       - name: Checkout code
         if: github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'prereleased' )
         uses: actions/checkout@v2
       - name: Checkout code
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' && env.DEPLOY == 1
         uses: actions/checkout@v2
         with:
           ref: ${{ env.TAG_NAME }}
 
       - name: Install to Composer
+        if: env.DEPLOY == 1
         run: composer install --no-scripts --no-dev --no-interaction --optimize-autoloader
 
       - name: Dump GitHub context
@@ -116,6 +95,7 @@ jobs:
         run: echo "$MATRIX_CONTEXT"
 
       - name: Packaging
+        if: env.DEPLOY == 1
         working-directory: ../
         env:
           TAG_NAME: ${{ env.TAG_NAME }}
@@ -178,7 +158,8 @@ jobs:
           sha1sum $TAG_NAME.zip | awk '{ print $1 }' > $TAG_NAME.zip.checksum.sha1
           sha256sum $TAG_NAME.tar.gz | awk '{ print $1 }' > $TAG_NAME.tar.gz.checksum.sha256
           sha256sum $TAG_NAME.zip | awk '{ print $1 }' > $TAG_NAME.zip.checksum.sha256
-          ls -al
+          echo "TGZ_SHA256=$(cat $TAG_NAME.tar.gz.checksum.sha256)" >> $GITHUB_ENV
+          echo "ZIP_SHA256=$(cat $TAG_NAME.zip.checksum.sha256)" >> $GITHUB_ENV
 
       - name: Upload binaries to release of TGZ
         if: env.DEPLOY == 1
@@ -252,13 +233,3 @@ jobs:
           asset_name: ${{ env.TAG_NAME }}.zip.checksum.sha256
           tag: ${{ env.TAG_NAME }}
           overwrite: true
-
-      - name: Update Release notes
-        if: github.event_name == 'schedule' && env.DEPLOY == 1
-        run: |
-          curl -sS \
-          -X PATCH \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }} \
-          -d '{"draft":false, "body":"${{ env.RELEASE_BODY }}\n${{ env.GENERATED_NOTES }}"}'


### PR DESCRIPTION
[ncipollo/release-action](https://github.com/ncipollo/release-action) は `generateReleaseNotes` オプションがあるため、ずいぶんすっきりとしたコードになりました