### PR TITLE
SC_Response::reload() のテストケース追加

### DIFF
--- a/data/class/SC_Response.php
+++ b/data/class/SC_Response.php
@@ -258,10 +258,9 @@ class SC_Response
         // 現在の URL を取得
         $netUrl = new Net_URL($_SERVER['REQUEST_URI']);
 
-        if (!$removeQueryString) {
-            $arrQueryString = array_merge($netUrl->querystring, $arrQueryString);
+        if ($removeQueryString) {
+            $netUrl->querystring = array();
         }
-        $netUrl->querystring = array();
 
         SC_Response_Ex::sendRedirect($netUrl->getURL(), $arrQueryString);
     }

--- a/tests/class/SC_Response/SC_ResponseWithHeaderTest.php
+++ b/tests/class/SC_Response/SC_ResponseWithHeaderTest.php
@@ -1,0 +1,42 @@
+<?php
+
+class SC_ResponseWithHeaderTest extends Common_TestCase
+{
+    /** @var resource|bool */
+    private static $server;
+    const FIXTURES_DIR = '../fixtures/server';
+
+    public static function setUpBeforeClass()
+    {
+        $spec = [
+            1 => ['file', '/dev/null', 'w'],
+            2 => ['file', '/dev/null', 'w']
+        ];
+
+        if (!self::$server = @proc_open('exec php -S 127.0.0.1:8053', $spec, $pipes, __DIR__.'/'.self::FIXTURES_DIR)) {
+            self::markTestSkipped('PHP server unable to start.');
+        }
+        sleep(1);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        if (is_resource(self::$server)) {
+            proc_terminate(self::$server);
+            proc_close(self::$server);
+        }
+    }
+
+    public function testReload()
+    {
+        $context = stream_context_create(
+            [
+                'http' => [
+                    'follow_location' => false
+                ]
+            ]
+        );
+        $actual = file_get_contents('http://127.0.0.1:8053/sc_response_reload.php', false, $context);
+        self::assertStringEqualsFile(__DIR__.'/'.self::FIXTURES_DIR.'/sc_response_reload.expected', $actual);
+    }
+}

--- a/tests/class/fixtures/server/common.php
+++ b/tests/class/fixtures/server/common.php
@@ -1,0 +1,19 @@
+<?php
+
+putenv('HTTP_URL=http://127.0.0.1:8085/');
+
+require __DIR__.'/../../../require.php';
+
+error_reporting(-1);
+ini_set('display_errors', '1');
+
+header_remove('X-Powered-By');
+header('Content-Type: text/plain; charset=utf-8');
+
+register_shutdown_function(function () {
+    echo "\n";
+    session_write_close();
+    print_r(headers_list());
+    echo "shutdown\n";
+});
+ob_start();

--- a/tests/class/fixtures/server/sc_response_reload.expected
+++ b/tests/class/fixtures/server/sc_response_reload.expected
@@ -1,0 +1,7 @@
+
+Array
+(
+    [0] => Content-Type: text/plain; charset=utf-8
+    [1] => Location: http://127.0.0.1:8085/index.php?debug=%E3%83%86%E3%82%B9%E3%83%88&redirect=1&transactionid=aaaa
+)
+shutdown

--- a/tests/class/fixtures/server/sc_response_reload.php
+++ b/tests/class/fixtures/server/sc_response_reload.php
@@ -1,0 +1,8 @@
+<?php
+
+require __DIR__.'/common.php';
+
+$_SERVER['REQUEST_URI'] = HTTPS_URL.'index.php?debug='.urlencode('テスト');
+$_SESSION[TRANSACTION_ID_NAME] = 'aaaa';
+
+SC_Response_Ex::reload(['redirect' => 1]);


### PR DESCRIPTION
- #575 のテストケース追加

以下のテストケースのように、 built-in webserver を使用した header() 関数のテストを追加
https://github.com/EC-CUBE/ec-cube/blob/4.2/tests/Eccube/Tests/Session/Storage/Handler/SameSiteNoneCompatSessionHandlerTest.php