### PR TITLE
PHPバージョンごとに Docker イメージを作成する

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -1,17 +1,17 @@
 name: Testing dockerbuild
 on:
   push:
+    branches:
+      - '*'
+    tags:
+      - '*'
     paths:
-      - 'Dockerfile'
-      - 'dockerbuild/*'
-      - 'docker-compose*.yml'
-      - '.github/workflows/dockerbuild.yml'
+      - '**'
+      - '!*.md'
   pull_request:
     paths:
-      - 'Dockerfile'
-      - 'dockerbuild/*'
-      - 'docker-compose*.yml'
-      - '.github/workflows/dockerbuild.yml'
+      - '**'
+      - '!*.md'
   release:
     types: [ published ]
 env:
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: downcase REPO
         run: |
-          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}-php" >> ${GITHUB_ENV}
 
       - if: ${{ matrix.php == 5.4 }}
         run: |
@@ -78,9 +78,14 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=auto
-            suffix=-php-${{ matrix.php }}-apache
+          tags: |
+            # set latest tag for default branch
+            type=raw,value=${{ matrix.php }}-apache,prefix=,enable={{is_default_branch}}
+            type=ref,event=branch,prefix=${{ matrix.php }}-apache-
+            type=ref,event=tag,prefix=${{ matrix.php }}-apache-
+            type=ref,event=pr,prefix=${{ matrix.php }}-apache-pr-
+            type=match,prefix=${{ matrix.php }}-apache-,pattern=eccube-(.*),group=1
+            type=match,prefix=${{ matrix.php }}-apache-,pattern=eccube2-weekly-(.*),group=1
 
       - name: Build and export to Docker
         uses: docker/build-push-action@v3

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -1,14 +1,6 @@
 name: Testing dockerbuild
 on:
   push:
-    branches:
-      - '*'
-    tags:
-      - '*'
-    paths:
-      - '**'
-      - '!*.md'
-  pull_request:
     paths:
       - '**'
       - '!*.md'

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -1,0 +1,154 @@
+name: Testing dockerbuild
+on:
+  push:
+    paths:
+      - 'Dockerfile'
+      - 'dockerbuild/*'
+      - 'docker-compose*.yml'
+      - '.github/workflows/dockerbuild.yml'
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'dockerbuild/*'
+      - 'docker-compose*.yml'
+      - '.github/workflows/dockerbuild.yml'
+  release:
+    types: [ published ]
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  dockerbuild:
+    name: dockerbuild
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+
+    steps:
+      - name: downcase REPO
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+
+      - if: ${{ matrix.php == 5.4 }}
+        run: |
+          echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
+          echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql mbstring" >> ${GITHUB_ENV}
+          echo "APCU=apcu-4.0.11" >>  ${GITHUB_ENV}
+      - if: ${{ matrix.php == 5.5 || matrix.php == 5.6 }}
+        run: |
+          echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
+          echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
+          echo "APCU=apcu-4.0.11" >>  ${GITHUB_ENV}
+      - if: ${{ matrix.php >= 7.0 && matrix.php <= 7.3 }}
+        run: |
+          echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
+          echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
+          echo "APCU=apcu" >>  ${GITHUB_ENV}
+      - if: ${{ matrix.php >= 7.4 }}
+        run: |
+          echo "GD_OPTIONS=--with-freetype --with-jpeg" >> ${GITHUB_ENV}
+          echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
+          echo "APCU=apcu" >>  ${GITHUB_ENV}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+      ## Used when creating multi-platform images
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v2
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v2
+
+      - name: Setup environment
+        run: echo "COMPOSE_FILE=docker-compose.yml:docker-compose.pgsql.yml:docker-compose.owaspzap.yml:docker-compose.owaspzap.daemon.yml" >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=auto
+            suffix=-php-${{ matrix.php }}-apache
+
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PHP_VERSION_TAG=${{ matrix.php }}
+            GD_OPTIONS=${{ env.GD_OPTIONS }}
+            EXT_INSTALL_ARGS=${{ env.EXT_INSTALL_ARGS }}
+            APCU=${{ env.APCU }}
+
+      - name: Setup to EC-CUBE
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          TAG: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          HTTP_URL: https://127.0.0.1:8085/
+          HTTPS_URL: https://127.0.0.1:8085/
+        run: |
+          sudo chown -R 1001:1000 zap
+          sudo chmod -R g+w zap
+          docker-compose up -d
+
+      - run: sleep 1
+      - run: |
+          yarn install
+          yarn run playwright install --with-deps chromium
+          yarn playwright install-deps chromium
+
+      - name: Run to E2E testing
+        env:
+          GROUP: ${{ matrix.group }}
+          PATTERN: ${{ matrix.pattern }}
+          HTTPS_PROXY: 'localhost:8090'
+          HTTP_PROXY: 'localhost:8090'
+          CI: 1
+          FORCE_COLOR: 1
+        run: yarn test:e2e e2e-tests/test/front_guest
+
+      - run: git checkout composer.*
+      ## see https://docs.github.com/ja/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action
+      - name: Push Docker image
+        uses: docker/build-push-action@v3
+        if: success()
+        with:
+          context: .
+          push: true
+          # platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PHP_VERSION_TAG=${{ matrix.php }}
+            GD_OPTIONS=${{ env.GD_OPTIONS }}
+            EXT_INSTALL_ARGS=${{ env.EXT_INSTALL_ARGS }}
+            APCU=${{ env.APCU }}
+
+      - name: Upload evidence
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux-php${{ matrix.php }}-evidence
+          path: 'test-results/'
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux-php${{ matrix.php }}-logs
+          path: data/logs

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -90,12 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         db: [ 'pgsql', 'mysql' ]
-        tag:
-          - '5.6-apache'
-          - '7.1-apache'
-          - '7.2-apache'
-          - '7.3-apache'
-          - '7.4-apache'
+        php: [ '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
         include:
           - db: mysql
             dbport: '3306'
@@ -110,6 +105,28 @@ jobs:
             dbname: 'eccube_db'
             dbhost: 'postgres'
     steps:
+    ## TODO GitHub Container Registry が使えるようになったら workflow_run で書き直す
+    - if: ${{ matrix.php == 5.4 }}
+      run: |
+        echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
+        echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql mbstring" >> ${GITHUB_ENV}
+        echo "APCU=apcu-4.0.11" >>  ${GITHUB_ENV}
+    - if: ${{ matrix.php == 5.5 || matrix.php == 5.6 }}
+      run: |
+        echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
+        echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
+        echo "APCU=apcu-4.0.11" >>  ${GITHUB_ENV}
+    - if: ${{ matrix.php >= 7.0 && matrix.php <= 7.3 }}
+      run: |
+        echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
+        echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
+        echo "APCU=apcu" >>  ${GITHUB_ENV}
+    - if: ${{ matrix.php >= 7.4 }}
+      run: |
+        echo "GD_OPTIONS=--with-freetype --with-jpeg" >> ${GITHUB_ENV}
+        echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
+        echo "APCU=apcu" >>  ${GITHUB_ENV}
+
     - name: Checkout
       uses: actions/checkout@v3
 
@@ -121,13 +138,14 @@ jobs:
       env:
         HTTP_URL: https://127.0.0.1:8085/
         HTTPS_URL: https://127.0.0.1:8085/
-        TAG: ${{ matrix.tag }}
+        PHP_VERSION_TAG: ${{ matrix.php }}
       run: |
         sudo chown -R 1001:1000 zap
         sudo chmod -R g+w zap
         sh -c 'echo "<?php" >> data/config/config.php'
-        docker-compose build --build-arg TAG=${TAG} ec-cube
-        docker-compose up -d
+        docker build -t ec-cube2 --build-arg PHP_VERSION_TAG="${PHP_VERSION_TAG}" --build-arg GD_OPTIONS="${GD_OPTIONS}" --build-arg EXT_INSTALL_ARGS="${EXT_INSTALL_ARGS}" --build-arg APCU="${APCU}" .
+        docker tag ec-cube2 ghcr.io/ec-cube/ec-cube2:master-php-${PHP_VERSION_TAG}-apache
+        TAG=master-php-${PHP_VERSION_TAG}-apache docker-compose up -d
 
     - run: sleep 1
     - run: |
@@ -170,11 +188,11 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v3
       with:
-        name: linux-php${{ matrix.tag }}-${{ matrix.db }}-logs
+        name: linux-php${{ matrix.php }}-${{ matrix.db }}-logs
         path: html/install/temp/install.log*
     - name: Upload evidence
       if: failure()
       uses: actions/upload-artifact@v3
       with:
-        name: linux-php${{ matrix.tag }}-${{ matrix.db }}-evidence
+        name: linux-php${{ matrix.php }}-${{ matrix.db }}-evidence
         path: 'test-results/'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -42,13 +42,12 @@ jobs:
       run: cp -rp tests/class/fixtures/page_extends/* data/class_extends/page_extends
 
     - name: Setup to EC-CUBE
-      env:
-        HTTP_URL: https://127.0.0.1:8085/
-        HTTPS_URL: https://127.0.0.1:8085/
       run: |
         sudo chown -R 1001:1000 zap
         sudo chmod -R g+w zap
-        docker-compose up -d
+        docker build -t ec-cube2 --build-arg PHP_VERSION_TAG=7.4 .
+        docker tag ec-cube2 ghcr.io/ec-cube/ec-cube2-php:7.4-apache
+        TAG=7.4-apache docker-compose up -d
         docker-compose exec -T ec-cube composer install
         docker-compose exec -T ec-cube composer require ec-cube2/cli "dev-master@dev" --ignore-platform-req=php -W
         docker-compose exec -T ec-cube composer update 'symfony/*' --ignore-platform-req=php -W

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -144,8 +144,8 @@ jobs:
         sudo chmod -R g+w zap
         sh -c 'echo "<?php" >> data/config/config.php'
         docker build -t ec-cube2 --build-arg PHP_VERSION_TAG="${PHP_VERSION_TAG}" --build-arg GD_OPTIONS="${GD_OPTIONS}" --build-arg EXT_INSTALL_ARGS="${EXT_INSTALL_ARGS}" --build-arg APCU="${APCU}" .
-        docker tag ec-cube2 ghcr.io/ec-cube/ec-cube2:master-php-${PHP_VERSION_TAG}-apache
-        TAG=master-php-${PHP_VERSION_TAG}-apache docker-compose up -d
+        docker tag ec-cube2 ghcr.io/ec-cube/ec-cube2-php:${PHP_VERSION_TAG}-apache
+        TAG=${PHP_VERSION_TAG}-apache docker-compose up -d
 
     - run: sleep 1
     - run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,50 @@
-ARG TAG=7.4-apache
-FROM eccube2/php:${TAG}
+ARG PHP_VERSION_TAG=7.4
+ARG TAG=${PHP_VERSION_TAG}-apache
+FROM php:${TAG}
+
+ARG GD_OPTIONS="--with-freetype --with-jpeg"
+ARG EXT_INSTALL_ARGS="gd zip mysqli pgsql opcache"
+ARG APCU="apcu"
+# See https://github.com/debuerreotype/debuerreotype/issues/10
+RUN if [ ! -d /usr/share/man/man1 ]; then mkdir /usr/share/man/man1; fi
+RUN if [ ! -d /usr/share/man/man7 ]; then mkdir /usr/share/man/man7; fi
+
+# ext-gd: libfreetype6-dev libjpeg62-turbo-dev libpng-dev
+# ext-pgsql: libpq-dev
+# ext-zip: libzip-dev zlib1g-dev
+# ext-opcache: libpcre3-dev
+RUN apt-get update \
+    && apt-get install -y \
+        git unzip curl apt-transport-https gnupg wget ca-certificates bc \
+        libfreetype6-dev libjpeg62-turbo-dev libpng-dev \
+        libpq-dev \
+        libzip-dev zlib1g-dev \
+        libpcre3-dev \
+        ssl-cert \
+        mariadb-client postgresql-client \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-configure gd ${GD_OPTIONS} && docker-php-ext-install ${EXT_INSTALL_ARGS}
+RUN pecl install ${APCU} && docker-php-ext-enable apcu
+
+# composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php --2.2 --install-dir=/usr/local/bin --filename=composer \
+    && php -r "unlink('composer-setup.php');"
 
 ENV APACHE_DOCUMENT_ROOT /var/www/app/html
 ENV ECCUBE_PREFIX /var/www/app
-# See https://github.com/debuerreotype/debuerreotype/issues/10
-RUN mkdir /usr/share/man/man1
-RUN mkdir /usr/share/man/man7
-RUN apt-get update \
-  && apt-get install --no-install-recommends -y \
-    ssl-cert \
-    mariadb-client postgresql-client \
-    && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+ENV APACHE_RUN_DIR /var/run/apache2
+ENV APACHE_LOG_DIR /var/log/apache2
 
 RUN mkdir -p ${APACHE_DOCUMENT_ROOT} \
-  && sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
-  && sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf \
-  ;
+  && sed -ri -e "s!/var/www/html!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/sites-available/*.conf \
+  && sed -ri -e "s!/var/www/!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf \
+  && sed -ri -e "s!DocumentRoot.*!DocumentRoot ${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf \
+    ;
+
+COPY dockerbuild/docker-php-entrypoint /usr/local/bin/
 
 ## Enable SSL
 RUN a2enmod ssl rewrite headers
@@ -31,7 +59,6 @@ RUN chmod +x /wait-for-*.sh
 COPY composer.json ${ECCUBE_PREFIX}/composer.json
 COPY composer.lock ${ECCUBE_PREFIX}/composer.lock
 
-RUN composer selfupdate --2
 RUN composer install --no-scripts --no-autoloader --no-dev -d ${ECCUBE_PREFIX}
 
 COPY . ${ECCUBE_PREFIX}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
   ec-cube:
     ### ローカルでビルドする場合は以下のコマンドを使用します
     ## docker build -t ec-cube2 --no-cache --pull --build-arg TAG=8.1-apache .
-    ## docker tag ec-cube2 ghcr.io/ec-cube/ec-cube2:master-php-8.1-apache
-    image: ${REGISTRY:-ghcr.io}/${IMAGE_NAME:-ec-cube/ec-cube2}:${TAG:-master-php-8.1-apache}
+    ## docker tag ec-cube2 ghcr.io/ec-cube/ec-cube2-php:8.1-apache
+    image: ${REGISTRY:-ghcr.io}/${IMAGE_NAME:-ec-cube/ec-cube2-php}:${TAG:-8.1-apache}
     build:
       context: .
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
     ## docker build -t ec-cube2 --no-cache --pull --build-arg TAG=8.1-apache .
     ## docker tag ec-cube2 ghcr.io/ec-cube/ec-cube2-php:8.1-apache
     image: ${REGISTRY:-ghcr.io}/${IMAGE_NAME:-ec-cube/ec-cube2-php}:${TAG:-8.1-apache}
-    build:
-      context: .
     volumes:
       ### 同期対象からコストの重いフォルダを除外 #####################
       - "vendor:/var/www/app/data/vendor"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ volumes:
 
 services:
   ec-cube:
+    ### ローカルでビルドする場合は以下のコマンドを使用します
+    ## docker build -t ec-cube2 --no-cache --pull --build-arg TAG=8.1-apache .
+    ## docker tag ec-cube2 ghcr.io/ec-cube/ec-cube2:master-php-8.1-apache
+    image: ${REGISTRY:-ghcr.io}/${IMAGE_NAME:-ec-cube/ec-cube2}:${TAG:-master-php-8.1-apache}
     build:
       context: .
     volumes:


### PR DESCRIPTION
- https://github.com/EC-CUBE/ec-cube/pull/5801 を移植
- 個人リポジトリで正常にパッケージ作成されるのを確認(https://github.com/nanasess/ec-cube2/pkgs/container/ec-cube2-php)
- 以下のようなルールでタグを作成します

| Event           | Ref                           | Docker Tags                         |
|-----------------|-------------------------------|-------------------------------------|
| `pull_request`  | `refs/pull/2/merge`           | `<php-version>-apache-pr-2`                              |
| `push`          | `refs/heads/master`           | `<php-version>-apache`                            |
| `push tag`      | `refs/tags/eccube-2.17.3`            | `<php-version>-apache-2.17.3`           |
| `push tag`      | `refs/tags/eccube2-weekly-20221007`    | `<php-version>-apache-20221007`                   |

- 以下の設定が必要と思われる
https://docs.github.com/ja/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility#organization%E3%81%8C%E6%89%80%E6%9C%89%E3%81%99%E3%82%8B%E3%82%B3%E3%83%B3%E3%83%86%E3%83%8A%E3%82%A4%E3%83%A1%E3%83%BC%E3%82%B8%E3%81%B8%E3%81%AEgithub-actions%E3%81%AE%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9