### PR TITLE
GPG の Warning で docker build に失敗するのを修正

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -1,6 +1,8 @@
 name: Testing dockerbuild
 on:
   push:
+    branches:
+      - "master"
     paths:
       - '**'
       - '!*.md'

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -31,21 +31,25 @@ jobs:
           echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
           echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql mbstring" >> ${GITHUB_ENV}
           echo "APCU=apcu-4.0.11" >>  ${GITHUB_ENV}
+          echo "FORCE_YES=--force-yes" >>  ${GITHUB_ENV}
       - if: ${{ matrix.php == 5.5 || matrix.php == 5.6 }}
         run: |
           echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
           echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
           echo "APCU=apcu-4.0.11" >>  ${GITHUB_ENV}
+          echo "FORCE_YES=--force-yes" >>  ${GITHUB_ENV}
       - if: ${{ matrix.php >= 7.0 && matrix.php <= 7.3 }}
         run: |
           echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
           echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
           echo "APCU=apcu" >>  ${GITHUB_ENV}
+          echo "FORCE_YES=" >>  ${GITHUB_ENV}
       - if: ${{ matrix.php >= 7.4 }}
         run: |
           echo "GD_OPTIONS=--with-freetype --with-jpeg" >> ${GITHUB_ENV}
           echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
           echo "APCU=apcu" >>  ${GITHUB_ENV}
+          echo "FORCE_YES=" >>  ${GITHUB_ENV}
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM php:${TAG}
 ARG GD_OPTIONS="--with-freetype --with-jpeg"
 ARG EXT_INSTALL_ARGS="gd zip mysqli pgsql opcache"
 ARG APCU="apcu"
+ARG FORCE_YES="--force-yes"
 # See https://github.com/debuerreotype/debuerreotype/issues/10
 RUN if [ ! -d /usr/share/man/man1 ]; then mkdir /usr/share/man/man1; fi
 RUN if [ ! -d /usr/share/man/man7 ]; then mkdir /usr/share/man/man7; fi
@@ -14,7 +15,7 @@ RUN if [ ! -d /usr/share/man/man7 ]; then mkdir /usr/share/man/man7; fi
 # ext-zip: libzip-dev zlib1g-dev
 # ext-opcache: libpcre3-dev
 RUN apt-get update \
-    && apt-get install -y \
+    && apt-get install -y ${FORCE_YES} \
         git unzip curl apt-transport-https gnupg wget ca-certificates bc \
         libfreetype6-dev libjpeg62-turbo-dev libpng-dev \
         libpq-dev \


### PR DESCRIPTION
- PHP5.6以下は `apt-get install -y --force-yes` とする
- GitHub Actions のターゲットを `on.push.branches: master` に指定
   - dependabot でビルドされるイメージは不要なため
- 正常にビルドできるのは確認済み(https://github.com/nanasess/ec-cube2/actions/runs/3519410521)