### PR TITLE
setasign/fpdf の更新に伴う修正

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -630,16 +630,16 @@
         },
         {
             "name": "setasign/fpdf",
-            "version": "1.8.4",
+            "version": "1.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Setasign/FPDF.git",
-                "reference": "b0ddd9c5b98ced8230ef38534f6f3c17308a7974"
+                "reference": "f4104a04c9a3f95c4c26a0a0531abebcc980987a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Setasign/FPDF/zipball/b0ddd9c5b98ced8230ef38534f6f3c17308a7974",
-                "reference": "b0ddd9c5b98ced8230ef38534f6f3c17308a7974",
+                "url": "https://api.github.com/repos/Setasign/FPDF/zipball/f4104a04c9a3f95c4c26a0a0531abebcc980987a",
+                "reference": "f4104a04c9a3f95c4c26a0a0531abebcc980987a",
                 "shasum": ""
             },
             "require": {
@@ -670,9 +670,9 @@
                 "pdf"
             ],
             "support": {
-                "source": "https://github.com/Setasign/FPDF/tree/1.8.4"
+                "source": "https://github.com/Setasign/FPDF/tree/1.8.5"
             },
-            "time": "2021-08-30T07:50:06+00:00"
+            "time": "2022-11-18T07:02:00+00:00"
         },
         {
             "name": "setasign/fpdi",

--- a/data/class/helper/SC_Helper_FPDI.php
+++ b/data/class/helper/SC_Helper_FPDI.php
@@ -124,4 +124,17 @@ class SC_Helper_FPDI extends PDF_Japanese
 
         return $conv_str;
     }
+
+    public function _out($s)
+    {
+        // Add a line to the document
+        if($this->state==2)
+            $this->pages[$this->page] .= $s."\n";
+        elseif($this->state==1)
+            $this->_put($s);
+        elseif($this->state==0)
+            $this->Error('No page has been added yet');
+        elseif($this->state==3)
+            $this->Error('The document is closed');
+    }
 }


### PR DESCRIPTION
#638 において、 PDF 生成時にシステムエラーが発生していた。

fpdf-1.8.5 は fpdi-2.x を使用する必要があるが、システム要件が PHP5.6+となってしまう。
fpdf-1.8.4 の _out() メソッドを SC_Helper_FPDI クラスに移植することで、fpdi-1.6.2 にも対応する