### PR TITLE
複数の配送方法を選択肢にした場合、無効な配送方法のエラーになるのを修正

### DIFF
--- a/data/class/pages/shopping/LC_Page_Shopping_Payment.php
+++ b/data/class/pages/shopping/LC_Page_Shopping_Payment.php
@@ -380,9 +380,9 @@ class LC_Page_Shopping_Payment extends LC_Page_Ex
 
         $objDelivery = new SC_Helper_Delivery();
         $validDelivery = array_filter($objDelivery->getList($this->cartKey), function ($delivery) use ($arrForm) {
-            return $arrForm['deliv_id'] != $delivery['deliv_id'];
+            return $arrForm['deliv_id'] == $delivery['deliv_id'];
         });
-        if (!empty($validDelivery)) {
+        if (empty($validDelivery)) {
             trigger_error('無効な配送方法: ' . var_export($arrForm['deliv_id'], true), E_USER_ERROR);
         }
 


### PR DESCRIPTION
refs #602 

添付画像のように、複数の配送方法を選択肢にした場合、無効な配送方法の E_USER_ERROR になってしまうのを修正
![image](https://github.com/EC-CUBE/ec-cube2/assets/815715/04fc53e6-636e-4077-b535-265b8f7aa338)

以下のPRを取り込むことでテストはすべて通ることを確認済
https://github.com/EC-CUBE/ec-cube2/pull/767
