### PR TITLE
iOS で「会員登録をせずに購入」ボタンの文字が表示されないのを修正

### DIFF
--- a/html/user_data/packages/sphone/css/popup.css
+++ b/html/user_data/packages/sphone/css/popup.css
@@ -133,6 +133,7 @@ input[type="submit"].nav_nonmember {
     border: none;
     display: block;
     text-align: left;
+    color: #000;
 }
 .navBox li:last-child {
     border-bottom: none;


### PR DESCRIPTION
iOS のデフォルトでは `input[type=submit].color: #fff` となっているため、添付画像のように  **会員登録をせずに購入**  ボタンが表示されない
![image](https://github.com/EC-CUBE/ec-cube2/assets/815715/9757cd9c-ec1f-4798-b2fd-ff337317836d)

`input[type=submit].color: #000`  とすることで対応

以下のPRを取り込むことでテストはすべて通ることを確認済
https://github.com/EC-CUBE/ec-cube2/pull/767