### PR TITLE
smarty_modifier_script_escape が複雑になったため、高負荷がかかるのを抑制

### DIFF
--- a/data/Smarty/templates/default/site_frame.tpl
+++ b/data/Smarty/templates/default/site_frame.tpl
@@ -52,7 +52,7 @@
 <script src="<!--{$smarty.const.ROOT_URLPATH}-->js/eccube.js"></script>
 
 <script type="text/javascript">//<![CDATA[
-    <!--{$tpl_javascript}-->
+    <!--{$tpl_javascript nofilter}-->
     $(function(){
         <!--{$tpl_onload}-->
     });

--- a/data/Smarty/templates/sphone/site_frame.tpl
+++ b/data/Smarty/templates/sphone/site_frame.tpl
@@ -69,7 +69,7 @@
         <link rel="apple-touch-icon" href="<!--{$TPL_URLPATH}-->img/common/apple-touch-icon.png" />
 
         <script type="text/javascript">//<![CDATA[
-            <!--{$tpl_javascript}-->
+            <!--{$tpl_javascript nofilter}-->
             $(function(){
                 <!--{$tpl_onload}-->
             });


### PR DESCRIPTION
`$tpl_javascript` はエスケープ不要なので `nofilter` を付与

以下のPRを取り込むことでテストはすべて通ることを確認済
https://github.com/EC-CUBE/ec-cube2/pull/767