### PR TITLE
debian-stretch が archive へ移動したため sources.list を修正

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php: [ '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
 
     steps:
       - name: downcase REPO
@@ -32,26 +32,50 @@ jobs:
         run: |
           echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
           echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql mbstring" >> ${GITHUB_ENV}
-          echo "APCU=apcu-4.0.11" >>  ${GITHUB_ENV}
-          echo "FORCE_YES=--force-yes" >>  ${GITHUB_ENV}
-      - if: ${{ matrix.php == 5.5 || matrix.php == 5.6 }}
+          echo "APCU=apcu-4.0.11" >> ${GITHUB_ENV}
+          echo "FORCE_YES=--force-yes" >> ${GITHUB_ENV}
+          echo "APT_REPO=cloudfront.debian.net/debian-archive" >> ${GITHUB_ENV}
+          echo "APT_SECURITY_REPO=cloudfront.debian.net/debian-archive/debian-security" >> ${GITHUB_ENV}
+      - if: ${{ matrix.php == 5.5 }}
         run: |
           echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
           echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
-          echo "APCU=apcu-4.0.11" >>  ${GITHUB_ENV}
+          echo "APCU=" >>  ${GITHUB_ENV}
           echo "FORCE_YES=--force-yes" >>  ${GITHUB_ENV}
-      - if: ${{ matrix.php >= 7.0 && matrix.php <= 7.3 }}
+          echo "APT_REPO=cloudfront.debian.net/debian-archive" >> ${GITHUB_ENV}
+          echo "APT_SECURITY_REPO=cloudfront.debian.net/debian-archive/debian-security" >> ${GITHUB_ENV}
+      - if: ${{ matrix.php == 5.6 }}
+        run: |
+          echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
+          echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
+          echo "APCU=" >>  ${GITHUB_ENV}
+          echo "FORCE_YES=--force-yes" >>  ${GITHUB_ENV}
+          echo "APT_REPO=cloudfront.debian.net/debian-archive" >> ${GITHUB_ENV}
+          echo "APT_SECURITY_REPO=cloudfront.debian.net/debian-archive" >> ${GITHUB_ENV}
+      - if: ${{ matrix.php == 7.0 }}
         run: |
           echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
           echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
           echo "APCU=apcu" >>  ${GITHUB_ENV}
           echo "FORCE_YES=" >>  ${GITHUB_ENV}
+          echo "APT_REPO=cloudfront.debian.net/debian-archive" >> ${GITHUB_ENV}
+          echo "APT_SECURITY_REPO=cloudfront.debian.net/debian-archive" >> ${GITHUB_ENV}
+      - if: ${{ matrix.php >= 7.1 && matrix.php <= 7.3 }}
+        run: |
+          echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
+          echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
+          echo "APCU=apcu" >>  ${GITHUB_ENV}
+          echo "FORCE_YES=" >>  ${GITHUB_ENV}
+          echo "APT_REPO=deb.debian.org" >> ${GITHUB_ENV}
+          echo "APT_SECURITY_REPO=security.debian.org" >> ${GITHUB_ENV}
       - if: ${{ matrix.php >= 7.4 }}
         run: |
           echo "GD_OPTIONS=--with-freetype --with-jpeg" >> ${GITHUB_ENV}
           echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
           echo "APCU=apcu" >>  ${GITHUB_ENV}
           echo "FORCE_YES=" >>  ${GITHUB_ENV}
+          echo "APT_REPO=deb.debian.org" >> ${GITHUB_ENV}
+          echo "APT_SECURITY_REPO=security.debian.org" >> ${GITHUB_ENV}
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -97,6 +121,9 @@ jobs:
             GD_OPTIONS=${{ env.GD_OPTIONS }}
             EXT_INSTALL_ARGS=${{ env.EXT_INSTALL_ARGS }}
             APCU=${{ env.APCU }}
+            FORCE_YES=${{ env.FORCE_YES }}
+            APT_REPO=${{ env.APT_REPO }}
+            APT_SECURITY_REPO=${{ env.APT_SECURITY_REPO }}
 
       - name: Setup to EC-CUBE
         env:
@@ -142,6 +169,9 @@ jobs:
             GD_OPTIONS=${{ env.GD_OPTIONS }}
             EXT_INSTALL_ARGS=${{ env.EXT_INSTALL_ARGS }}
             APCU=${{ env.APCU }}
+            FORCE_YES=${{ env.FORCE_YES }}
+            APT_REPO=${{ env.APT_REPO }}
+            APT_SECURITY_REPO=${{ env.APT_SECURITY_REPO }}
 
       - name: Upload evidence
         if: failure()

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -170,7 +170,7 @@ jobs:
         sudo chown -R 1001:1000 zap
         sudo chmod -R g+w zap
         sh -c 'echo "<?php" >> data/config/config.php'
-        docker build -t ec-cube2 --build-arg PHP_VERSION_TAG="${PHP_VERSION_TAG}" --build-arg GD_OPTIONS="${GD_OPTIONS}" --build-arg EXT_INSTALL_ARGS="${EXT_INSTALL_ARGS}" --build-arg APCU="${APCU} --build-arg FORCE_YES="${FORCE_YES}" --build_arg APT_REPO="${APT_REPO} --build_arg APT_SECURITY_REPO=${APT_SECURITY_REPO}" .
+        docker build -t ec-cube2 --build-arg PHP_VERSION_TAG="${PHP_VERSION_TAG}" --build-arg GD_OPTIONS="${GD_OPTIONS}" --build-arg EXT_INSTALL_ARGS="${EXT_INSTALL_ARGS}" --build-arg APCU="${APCU}" --build-arg FORCE_YES="${FORCE_YES}" --build-arg APT_REPO="${APT_REPO}" --build-arg APT_SECURITY_REPO="${APT_SECURITY_REPO}" .
         docker tag ec-cube2 ghcr.io/ec-cube/ec-cube2-php:${PHP_VERSION_TAG}-apache
         TAG=${PHP_VERSION_TAG}-apache docker-compose up -d
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         db: [ 'pgsql', 'mysql' ]
-        php: [ '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php: [ '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
         include:
           - db: mysql
             dbport: '3306'
@@ -109,22 +109,50 @@ jobs:
       run: |
         echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
         echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql mbstring" >> ${GITHUB_ENV}
-        echo "APCU=apcu-4.0.11" >>  ${GITHUB_ENV}
-    - if: ${{ matrix.php == 5.5 || matrix.php == 5.6 }}
+        echo "APCU=apcu-4.0.11" >> ${GITHUB_ENV}
+        echo "FORCE_YES=--force-yes" >> ${GITHUB_ENV}
+        echo "APT_REPO=cloudfront.debian.net/debian-archive" >> ${GITHUB_ENV}
+        echo "APT_SECURITY_REPO=cloudfront.debian.net/debian-archive/debian-security" >> ${GITHUB_ENV}
+    - if: ${{ matrix.php == 5.5 }}
       run: |
         echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
         echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
-        echo "APCU=apcu-4.0.11" >>  ${GITHUB_ENV}
-    - if: ${{ matrix.php >= 7.0 && matrix.php <= 7.3 }}
+        echo "APCU=" >>  ${GITHUB_ENV}
+        echo "FORCE_YES=--force-yes" >>  ${GITHUB_ENV}
+        echo "APT_REPO=cloudfront.debian.net/debian-archive" >> ${GITHUB_ENV}
+        echo "APT_SECURITY_REPO=cloudfront.debian.net/debian-archive/debian-security" >> ${GITHUB_ENV}
+    - if: ${{ matrix.php == 5.6 }}
+      run: |
+        echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
+        echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
+        echo "APCU=" >>  ${GITHUB_ENV}
+        echo "FORCE_YES=--force-yes" >>  ${GITHUB_ENV}
+        echo "APT_REPO=cloudfront.debian.net/debian-archive" >> ${GITHUB_ENV}
+        echo "APT_SECURITY_REPO=cloudfront.debian.net/debian-archive" >> ${GITHUB_ENV}
+    - if: ${{ matrix.php == 7.0 }}
       run: |
         echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
         echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
         echo "APCU=apcu" >>  ${GITHUB_ENV}
+        echo "FORCE_YES=" >>  ${GITHUB_ENV}
+        echo "APT_REPO=cloudfront.debian.net/debian-archive" >> ${GITHUB_ENV}
+        echo "APT_SECURITY_REPO=cloudfront.debian.net/debian-archive" >> ${GITHUB_ENV}
+    - if: ${{ matrix.php >= 7.1 && matrix.php <= 7.3 }}
+      run: |
+        echo "GD_OPTIONS=--with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include" >> ${GITHUB_ENV}
+        echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
+        echo "APCU=apcu" >>  ${GITHUB_ENV}
+        echo "FORCE_YES=" >>  ${GITHUB_ENV}
+        echo "APT_REPO=deb.debian.org" >> ${GITHUB_ENV}
+        echo "APT_SECURITY_REPO=security.debian.org" >> ${GITHUB_ENV}
     - if: ${{ matrix.php >= 7.4 }}
       run: |
         echo "GD_OPTIONS=--with-freetype --with-jpeg" >> ${GITHUB_ENV}
         echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
         echo "APCU=apcu" >>  ${GITHUB_ENV}
+        echo "FORCE_YES=" >>  ${GITHUB_ENV}
+        echo "APT_REPO=deb.debian.org" >> ${GITHUB_ENV}
+        echo "APT_SECURITY_REPO=security.debian.org" >> ${GITHUB_ENV}
 
     - name: Checkout
       uses: actions/checkout@v3
@@ -142,7 +170,7 @@ jobs:
         sudo chown -R 1001:1000 zap
         sudo chmod -R g+w zap
         sh -c 'echo "<?php" >> data/config/config.php'
-        docker build -t ec-cube2 --build-arg PHP_VERSION_TAG="${PHP_VERSION_TAG}" --build-arg GD_OPTIONS="${GD_OPTIONS}" --build-arg EXT_INSTALL_ARGS="${EXT_INSTALL_ARGS}" --build-arg APCU="${APCU}" .
+        docker build -t ec-cube2 --build-arg PHP_VERSION_TAG="${PHP_VERSION_TAG}" --build-arg GD_OPTIONS="${GD_OPTIONS}" --build-arg EXT_INSTALL_ARGS="${EXT_INSTALL_ARGS}" --build-arg APCU="${APCU} --build-arg FORCE_YES="${FORCE_YES}" --build_arg APT_REPO="${APT_REPO} --build_arg APT_SECURITY_REPO=${APT_SECURITY_REPO}" .
         docker tag ec-cube2 ghcr.io/ec-cube/ec-cube2-php:${PHP_VERSION_TAG}-apache
         TAG=${PHP_VERSION_TAG}-apache docker-compose up -d
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,20 @@ FROM php:${TAG}
 ARG GD_OPTIONS="--with-freetype --with-jpeg"
 ARG EXT_INSTALL_ARGS="gd zip mysqli pgsql opcache"
 ARG APCU="apcu"
-ARG FORCE_YES="--force-yes"
+ARG FORCE_YES=""
+ARG APT_REPO="deb.debian.org"
+ARG APT_SECURITY_REPO="security.debian.org"
+
 # See https://github.com/debuerreotype/debuerreotype/issues/10
 RUN if [ ! -d /usr/share/man/man1 ]; then mkdir /usr/share/man/man1; fi
 RUN if [ ! -d /usr/share/man/man7 ]; then mkdir /usr/share/man/man7; fi
+
+RUN if [ ! -e /etc/apt/sources.list ]; then touch /etc/apt/sources.list; fi # for bookworm
+RUN sed -i s,deb.debian.org,${APT_REPO},g /etc/apt/sources.list;
+RUN sed -i s,security.debian.org,${APT_SECURITY_REPO},g /etc/apt/sources.list;
+RUN sed -i s,httpredir.debian.org,${APT_REPO},g /etc/apt/sources.list; # for jessie
+RUN sed -i '/stretch-updates/d' /etc/apt/sources.list # for stretch
+RUN sed -i '/jessie-updates/d' /etc/apt/sources.list # for jessie
 
 # ext-gd: libfreetype6-dev libjpeg62-turbo-dev libpng-dev
 # ext-pgsql: libpq-dev
@@ -27,7 +37,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN docker-php-ext-configure gd ${GD_OPTIONS} && docker-php-ext-install ${EXT_INSTALL_ARGS}
-RUN pecl install ${APCU} && docker-php-ext-enable apcu
+RUN if [[ ${APCU} ]]; then  pecl install ${APCU} && docker-php-ext-enable apcu; fi
 
 # composer
 COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer
@@ -64,4 +74,4 @@ COPY composer.lock ${ECCUBE_PREFIX}/composer.lock
 RUN composer install --no-scripts --no-autoloader --no-dev -d ${ECCUBE_PREFIX}
 
 COPY . ${ECCUBE_PREFIX}
-RUN composer dumpautoload -o --apcu
+RUN composer dumpautoload -o


### PR DESCRIPTION
archive.debian.org は遅いので cloudfront の mirror を使用する
see. https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html

PHP8.2を追加

以下でビルドに成功するのは確認済
https://github.com/nanasess/ec-cube2/actions/runs/6213876187

以下のPRを取り込むことでテストはすべて通ることを確認済
https://github.com/EC-CUBE/ec-cube2/pull/767