### PR TITLE
Revert "ubuntu-22.04 で PHP のビルドに失敗するため一旦20.04に変更"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ ubuntu-20.04 ]
+        operating-system: [ ubuntu-22.04 ]
         php: [ '5.4', '5.5', '5.6', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
         db: [ mysql, pgsql ]
         include:


### PR DESCRIPTION
This reverts commit 91dce9a7ef31ea5463e0f1c1434f3a449827e84e.

PHP8.3に対応したため、 Ubuntu22.04に戻す
https://github.com/nanasess/setup-php/releases/tag/v4.0.1