### PR TITLE
PHPStan のエラー修正

### DIFF
--- a/data/smarty_extends/function.html_checkboxes_ex.php
+++ b/data/smarty_extends/function.html_checkboxes_ex.php
@@ -52,6 +52,7 @@ function smarty_function_html_checkboxes_ex($params, &$smarty)
     $labels = true;
     $label_ids = true;
     $output = null;
+    $tags = [];
 
     $extra = '';
 

--- a/data/smarty_extends/function.html_radios_ex.php
+++ b/data/smarty_extends/function.html_radios_ex.php
@@ -53,6 +53,7 @@ function smarty_function_html_radios_ex($params, &$smarty)
     $label_ids = true;
     $output = null;
     $extra = '';
+    $tags = [];
 
     foreach ($params as $_key => $_val) {
         switch ($_key) {
@@ -123,7 +124,7 @@ function smarty_function_html_radios_ex($params, &$smarty)
     if (!empty($params['assign'])) {
         $smarty->assign($params['assign'], $_html_result);
     } else {
-        return implode("\n",$_html_result);
+        return implode("\n", $_html_result);
     }
 
     return '';

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -42,10 +42,5 @@ parameters:
         - data/smarty_extends/function.html_radios_ex.php
         - data/smarty_extends/function.html_checkboxes_ex.php
     -
-      message: "#^Undefined variable\\: \\$tags$#"
-      paths:
-        - data/smarty_extends/function.html_radios_ex.php
-        - data/smarty_extends/function.html_checkboxes_ex.php
-    -
       message: "#^Variable \\$SJIS_widths might not be defined\\.$#"
       path: data/class/helper/SC_Helper_FPDI.php


### PR DESCRIPTION
- Fix `Variable $tags might not be defined.`
- refs https://github.com/EC-CUBE/ec-cube2/pull/799/files#annotation_16450669942