### PR TITLE
自動マージの仕組みを導入

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,36 @@
+name: Auto-merge
+
+on:
+  workflow_run:
+    workflows: [E2E testing for EC-CUBE]
+    types: [completed]
+
+jobs:
+  check-and-merge:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+      contents: write
+    env:
+      PR_URL: ${{github.event.pull_request.html_url}}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Approve PR
+        run: gh pr review "$PR_URL" --approve
+      ## いきなりマージするのが怖いので、一旦自動承認（↑）だけにする
+      #- name: Enable auto-merge
+      #  run: gh pr merge --merge --auto "$PR_URL"
+
+  failed:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: failed
+        # 失敗したときにデバッグ用に情報を出力しておく
+        run:  |
+          echo 'Haven't met the conditions to merge yet'
+          echo '${{ toJSON(github.event.workflow_run) }}'
+          exit 1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,21 +1,17 @@
 name: E2E testing for EC-CUBE
+run-name: E2E testing for EC-CUBE
+
 on:
-  push:
-    branches:
-      - '*'
-    tags:
-      - '*'
-    paths:
-      - '**'
-      - '!*.md'
-  pull_request:
-    paths:
-      - '**'
-      - '!*.md'
+  workflow_run:
+    workflows: [CI/CD for EC-CUBE]
+    types: [completed]
+
 jobs:
   run-on-linux:
     name: Run on Linux
     runs-on: ubuntu-22.04
+    if: |
+      github.event.workflow_run.conclusion == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -85,6 +81,8 @@ jobs:
   installer:
     name: Installer test
     runs-on: ubuntu-22.04
+    if: |
+      github.event.workflow_run.conclusion == 'success'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,21 +1,17 @@
 name: CI/CD for EC-CUBE
+run-name: CI/CD for EC-CUBE
+
 on:
-  push:
-    branches:
-      - '*'
-    tags:
-      - '*'
-    paths:
-      - '**'
-      - '!*.md'
-  pull_request:
-    paths:
-      - '**'
-      - '!*.md'
+  workflow_run:
+    workflows: [PHPStan]
+    types: [completed]
+
 jobs:
   run-on-linux:
     name: Run on Linux
     runs-on: ${{ matrix.operating-system }}
+    if: |
+      github.event.workflow_run.conclusion == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -150,6 +146,8 @@ jobs:
   run-on-windows:
     name: Run on Windows
     runs-on: ${{ matrix.operating-system }}
+    if: |
+      github.event.workflow_run.conclusion == 'success'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,4 +1,6 @@
 name: PHPStan
+run-name: PHPStan
+
 on:
   push:
     branches:
@@ -12,6 +14,8 @@ on:
     paths:
       - '**'
       - '!*.md'
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   phpstan:


### PR DESCRIPTION
PRの円滑なマージを推奨するために、試験的に自動マージのGithubActionを導入してみる。

## 従来との変更点
現在、ワークフローはpushされると自動で並列に走行するようになっている。
それを一部直列実行に変更。

1. PHP Stan
2. Unit Test
3. E2E Test
4. Auto Merge

の順番で実行していく。次のワークフローが完了かつ、成功した場合に次のワークフローを実行する。
つまり、E2E Testまでが完了すると、マージを行う想定。

現時点ではまず、いきなりマージの事故を防ぐために「自動承認（Approve）」を実装している。
自動承認される状況に問題がなければ、自動マージの処理もコメントアウトを解除する予定。

また、最初に動く「PHP Stan」のワークフローはPush時のみならず、**承認を行った際にも駆動するように変更**している

## 注意点

このワークフローを動かすためには、リポジトリの設定変更が必須となる。
- Setting > Actions > Generalの設定を開く
-  「Workflow permissions」のところまで移動する
- Read and write permissions にラジオボタンを変更
- Allow GitHub Actions to create and approve pull requests にチェックを入れる
 
<img width="1329" alt="スクリーンショット 2024-01-25 17 38 00" src="https://github.com/EC-CUBE/ec-cube2/assets/8691817/203ca3fd-5156-4a3b-bac1-96303a04ea1f">

<img width="809" alt="スクリーンショット 2024-01-25 17 38 08" src="https://github.com/EC-CUBE/ec-cube2/assets/8691817/7590daa9-6f98-4e62-8759-35a08c6e063a">

## 最後に

試行錯誤を重ねながらする前提で構築しているので、運用してみて適さない場合は随時やり方を検討していく。
よろしくお願いします。