### PR TITLE
Github Actions にcheckoutを追加（※Auto Merge）

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,6 +17,10 @@ jobs:
       PR_URL: ${{github.event.pull_request.html_url}}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Checkout repository with preceding commits
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Approve PR
         run: gh pr review "$PR_URL" --approve
       ## いきなりマージするのが怖いので、一旦自動承認（↑）だけにする
@@ -30,7 +34,7 @@ jobs:
     steps:
       - name: failed
         # 失敗したときにデバッグ用に情報を出力しておく
-        run:  |
+        run: |
           echo 'Haven't met the conditions to merge yet'
           echo '${{ toJSON(github.event.workflow_run) }}'
           exit 1


### PR DESCRIPTION
以前、申請したPRである #827 において、
`failed to run git: fatal: not a git repository (or any of the parent directories): .git`
というエラーが発生。リポジトリのチェックアウトが必要なのにできていないというミスがあったので、追加で対応を行いました。

具体的には、承認処理が行われる前にチェックアウトのstepを追加しています。