### PR TITLE
デバッグメッセージの出力方法を変更

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -33,8 +33,10 @@ jobs:
       github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: failed
+        env:
+          WORKFLOW_RUN_CONTEXT: ${{ toJson(github.event.workflow_run) }}
         # 失敗したときにデバッグ用に情報を出力しておく
         run: |
-          echo 'Haven't met the conditions to merge yet'
-          echo '${{ toJSON(github.event.workflow_run) }}'
+          echo "Haven't met the conditions to merge yet"
+          echo "$WORKFLOW_RUN_CONTEXT"
           exit 1


### PR DESCRIPTION
自動マージができなかった時のデバッグ出力で、JSONがエスケープできていなかったため、出力方法を変更。
