### PR TITLE
phpstan 調整

### DIFF
--- a/data/class/pages/forgot/LC_Page_Forgot.php
+++ b/data/class/pages/forgot/LC_Page_Forgot.php
@@ -277,7 +277,7 @@ class LC_Page_Forgot extends LC_Page_Ex
     public function lfSendMail(&$CONF, $email, $customer_name, $new_password)
     {
         // パスワード変更お知らせメール送信
-        $objMailText = new SC_SiteView_Ex(false);
+        $objMailText = new SC_SiteView_Ex();
         $objMailText->setPage($this);
         $objMailText->assign('customer_name', $customer_name);
         $objMailText->assign('new_password', $new_password);

--- a/data/class/pages/rss/LC_Page_Rss.php
+++ b/data/class/pages/rss/LC_Page_Rss.php
@@ -60,7 +60,7 @@ class LC_Page_Rss extends LC_Page_Ex
      */
     public function process()
     {
-        $objView = new SC_SiteView_Ex(false);
+        $objView = new SC_SiteView_Ex();
 
         //新着情報を取得
         $arrNews = $this->lfGetNews();

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,17 +2,18 @@ parameters:
   level: 1
   bootstrapFiles:
     - tests/require.php
-    - data/vendor/smarty/smarty/libs/plugins/function.html_radios.php
   excludePaths:
-    - data/Smarty/templates_c/*
-    - data/module/SOAP/*
-    - data/vendor/*
-    - data/downloads/*
-    - data/module/Calendar/Engine/PearDate.php
-    - data/class/helper/SC_Helper_Mobile.php
-    - data/class/SC_MobileEmoji.php
-    - data/class/SC_MobileImage.php
-    - data/**/flycheck_*.php
+    analyse:
+      - data/module/SOAP/*
+      - data/vendor/*
+      - data/downloads/*
+      - data/module/Calendar/Engine/PearDate.php
+      - data/class/helper/SC_Helper_Mobile.php
+      - data/class/SC_MobileEmoji.php
+      - data/class/SC_MobileImage.php
+      - data/**/flycheck_*.php
+    analyseAndScan:
+      - *.tpl.php
   ignoreErrors:
     -
       message: "#^Call to an undefined static method PEAR\\:\\:raiseError\\(\\)\\.$#"
@@ -34,9 +35,6 @@ parameters:
     # -
     #   message: "#^Constant SMARTY_PLUGINS_DIR not found\\.$#"
     #   path: data/smarty_extends/*
-    -
-      message: "#^Function smarty_function_escape_special_chars not found\\.$#"
-      path: data/smarty_extends/*
     -
       message: "#^Variable \\$SJIS_widths might not be defined\\.$#"
       path: data/class/helper/SC_Helper_FPDI.php


### PR DESCRIPTION
- excludePaths の指定を (暗黙の analyseAndScan ではなく) analyse に限定する。
  - 若干メモリー消費が多くなると思われる。支障があれば、analyseAndScan で良いと思うが後項のような検出漏れを生じるかも。
  - 前項の変更に伴い新たに検出された、エラー `Class SC_SiteView constructor invoked with 1 parameter, 0 required.` を回避する。c893462a51a996a873a2f508766a3472271a1680 で削除されている引数が指定されていたもの。
  - 前項の変更に伴い新たに検出されなくなった、エラーを ignoreErrors から削除する。
- excludePaths/analyseAndScan で、Smarty キャッシュは拡張子で指定する。インストラーのキャッシュも除外される。
- 1973616c6cf6eaaca01bd8ca298aad26e0b0b691 で追記した bootstrapFiles の定義が不要となった様子なので削除する。