### PR TITLE
PHP 8 で PHPUnit が失敗する不具合を回避

### DIFF
--- a/tests/class/modifier/Modifier_ScriptEscapeTest.php
+++ b/tests/class/modifier/Modifier_ScriptEscapeTest.php
@@ -2,7 +2,11 @@
 require 'data/smarty_extends/modifier.script_escape.php';
 
 /**
+ * (省略。アノテーションを認識されるのに必要なようなので記述している。)
  *
+ * PHP 8.1 でグローバル変数が消失する不具合を回避するため、下で `backupGlobals` を指定している。本質的には PHPUnit が PHP8 に対応していないのが原因と考えられる。
+ *
+ * @backupGlobals disabled
  */
 class Modifier_ScriptEscapeTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
全体実行で一部が FAILURES となっていた。グローバル変数が消失(若しくは汚染)していたと考えられる。 PHP 8.1 で発現を確認。PHP 7.4 では発生しない。PHPUnit のバージョンが古いのが原因か。 https://xoops.ec-cube.net/modules/newbb/viewtopic.php?topic_id=28010&forum=4