### PR TITLE
dockerbuild workflow のみキャッシュを保存し、テスト実行時はキャッシュを保存しない

### DIFF
--- a/.github/actions/dockerbuild/action.yml
+++ b/.github/actions/dockerbuild/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Docker registry to push to'
     default: 'ghcr.io'
     required: true
+  cache-to:
+    description: 'Add the Docker build layer to the cache'
+    default: ~
+    required: false
 
 runs:
   using: "composite"
@@ -60,7 +64,7 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha,scope=php-${{ inputs.php-version }}
-        cache-to: type=gha,mode=max,scope=php-${{ inputs.php-version }}
+        cache-to: ${{ inputs.cache-to }}
         build-args: |
           PHP_VERSION_TAG=${{ inputs.php-version }}
           GD_OPTIONS=${{ env.GD_OPTIONS }}

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -29,3 +29,4 @@ jobs:
         uses: ./.github/actions/dockerbuild
         with:
           php-version: ${{ matrix.php }}
+          cache-to: type=gha,mode=max,scope=php-${{ matrix.php }}


### PR DESCRIPTION
最初に実行される dockerbuild workflow のみ docker build のキャッシュを保存し、後続の workflow ではキャッシュの取得のみ行う。

若干の高速化と、以下のようなキャッシュのエラーを防止できる
https://github.com/EC-CUBE/ec-cube2/actions/runs/8384754767/job/22962608070#step:3:2232