### PR TITLE
script_escape パフォーマンス改善

### DIFF
--- a/data/smarty_extends/modifier.script_escape.php
+++ b/data/smarty_extends/modifier.script_escape.php
@@ -7,38 +7,45 @@
  */
 function smarty_modifier_script_escape($value)
 {
-    if (is_array($value)) return $value;
+    // パフォーマンス低下を軽減するため文字列以外は処理しない。
+    // TODO: Stringable なオブジェクトも対象とするのが安全かもしれない。しかし、この modifier は、default_modifiers に設定しているため、影響が見通せない (文字列として返して良いのか不確か)。
+    if (!is_string($value)) return $value;
 
-    $pattern = "<script.*?>|<\/script>|javascript:|<svg.*(onload|onerror).*?>|<img.*(onload|onerror).*?>|<body.*onload.*?>|<iframe.*?>|<object.*?>|<embed.*?>|";
+    static $pattern;
+    if (is_null($pattern)) {
+        $pattern = "<script.*?>|<\/script>|javascript:|<svg.*(onload|onerror).*?>|<img.*(onload|onerror).*?>|<body.*onload.*?>|<iframe.*?>|<object.*?>|<embed.*?>|";
 
-    // 追加でサニタイズするイベント一覧
-    $escapeEvents = array(
-        'onmouse',
-        'onclick',
-        'onblur',
-        'onfocus',
-        'onresize',
-        'onscroll',
-        'ondblclick',
-        'onchange',
-        'onselect',
-        'onsubmit',
-        'onkey',
-    );
+        // 追加でサニタイズするイベント一覧
+        $escapeEvents = array(
+            'onmouse',
+            'onclick',
+            'onblur',
+            'onfocus',
+            'onresize',
+            'onscroll',
+            'ondblclick',
+            'onchange',
+            'onselect',
+            'onsubmit',
+            'onkey',
+        );
 
-    // イベント毎の正規表現を生成
-    $generateHtmlTagPatterns = array_map(function($str) {
-        return "<(\w+)([^>]*\s)?\/?".$str."[^>]*>";
-    }, $escapeEvents);
-    $pattern .= implode("|", $generateHtmlTagPatterns)."|";
-    $pattern .= "(\"|').*(onerror|onload|".implode("|", $escapeEvents).").*=.*(\"|').*";
-
-    // 正規表現をまとめる
-    $attributesPattern = "/${pattern}/i";
-
-    // 置き換える文字列
-    $convert = '#script tag escaped#';
+        // イベント毎の正規表現を生成
+        $generateHtmlTagPatterns = array_map(function($str) {
+            return "<(\w+)([^>]*\s)?\/?".$str."[^>]*>";
+        }, $escapeEvents);
+        $pattern .= implode("|", $generateHtmlTagPatterns)."|";
+        $pattern .= "(\"|').*(onerror|onload|".implode("|", $escapeEvents).").*=.*(\"|').*";
+        $pattern = "/{$pattern}/i";
+    }
 
     // マッチしたら文字列を置き換える
-    return preg_replace($attributesPattern, $convert, $value);
+    // - preg_replace は、(たとえ置換が発生しなくても) preg_match より重い。置換が発生する頻度は極めて低いはずなので、preg_match で事前判定する。
+    if (preg_match($pattern, $value)) {
+        // 置き換える文字列
+        $convert = '#script escaped#';
+        $value = preg_replace($pattern, $convert, $value);
+    }
+
+    return $value;
 }

--- a/tests/class/modifier/Modifier_ScriptEscapeTest.php
+++ b/tests/class/modifier/Modifier_ScriptEscapeTest.php
@@ -62,7 +62,7 @@ class Modifier_ScriptEscapeTest extends PHPUnit_Framework_TestCase
     public function testメールテンプレート_エスケープされる($value)
     {
         $ret = smarty_modifier_script_escape($value);
-        $pattern = "/#script tag escaped#/";
+        $pattern = "/#script escaped#/";
         $this->assertRegExp($pattern, $ret);
     }
 
@@ -72,7 +72,7 @@ class Modifier_ScriptEscapeTest extends PHPUnit_Framework_TestCase
     public function testメールテンプレート_エスケープされない($value)
     {
         $ret = smarty_modifier_script_escape($value);
-        $pattern = "/#script tag escaped#/";
+        $pattern = "/#script escaped#/";
         $this->assertNotRegExp($pattern, $ret);
     }
 }


### PR DESCRIPTION
ざっくり十数倍速くなったようです。

(参考) 検証コードと結果
```php
require_once 'modifier.script_escape.php';
$arr = [];
for ($i = 1; $i <= 1000000; $i ++) {
    $arr[] = uniqid();
}
$start = microtime(true);
foreach ($arr as $str) {
    smarty_modifier_script_escape($str);
}
echo microtime(true) - $start . PHP_EOL;
```

```
$ git restore --source=ofc/master data/smarty_extends/modifier.script_escape.php
$ php data/smarty_extends/modifier.script_escape_test.php
6.0050699710846
$ git restore --source=seasoft-script_escape data/smarty_extends/modifier.script_escape.php
$ php data/smarty_extends/modifier.script_escape_test.php
0.41585803031921
```