### PR TITLE
PHP Warning 回避

### DIFF
--- a/data/class/helper/SC_Helper_Purchase.php
+++ b/data/class/helper/SC_Helper_Purchase.php
@@ -1490,24 +1490,25 @@ __EOS__;
 
     public function checkSessionPendingOrder()
     {
-        if (!SC_Utils_Ex::isBlank($_SESSION['order_id'])) {
-            $order_id = $_SESSION['order_id'];
-            unset($_SESSION['order_id']);
-            $objQuery = SC_Query_Ex::getSingletonInstance();
-            $objQuery->begin();
-            $arrOrder =  SC_Helper_Purchase_Ex::getOrder($order_id);
-            if ($arrOrder['status'] == ORDER_PENDING) {
-                $objCartSess = new SC_CartSession_Ex();
-                $cartKeys = $objCartSess->getKeys();
-                if (SC_Utils_Ex::isBlank($cartKeys)) {
-                    SC_Helper_Purchase_Ex::rollbackOrder($order_id, ORDER_CANCEL, true);
-                    GC_Utils_Ex::gfPrintLog('order rollback.(session pending) order_id=' . $order_id);
-                } else {
-                    SC_Helper_Purchase_Ex::cancelOrder($order_id, ORDER_CANCEL, true);
-                    GC_Utils_Ex::gfPrintLog('order rollback.(session pending and set card) order_id=' . $order_id);
-                }
+        if (!isset($_SESSION['order_id'])) return;
+        if (SC_Utils_Ex::isBlank($_SESSION['order_id'])) return;
+
+        $order_id = $_SESSION['order_id'];
+        unset($_SESSION['order_id']);
+        $objQuery = SC_Query_Ex::getSingletonInstance();
+        $objQuery->begin();
+        $arrOrder =  SC_Helper_Purchase_Ex::getOrder($order_id);
+        if ($arrOrder['status'] == ORDER_PENDING) {
+            $objCartSess = new SC_CartSession_Ex();
+            $cartKeys = $objCartSess->getKeys();
+            if (SC_Utils_Ex::isBlank($cartKeys)) {
+                SC_Helper_Purchase_Ex::rollbackOrder($order_id, ORDER_CANCEL, true);
+                GC_Utils_Ex::gfPrintLog('order rollback.(session pending) order_id=' . $order_id);
+            } else {
+                SC_Helper_Purchase_Ex::cancelOrder($order_id, ORDER_CANCEL, true);
+                GC_Utils_Ex::gfPrintLog('order rollback.(session pending and set card) order_id=' . $order_id);
             }
-            $objQuery->commit();
         }
+        $objQuery->commit();
     }
 }

--- a/data/class/pages/LC_Page.php
+++ b/data/class/pages/LC_Page.php
@@ -300,7 +300,7 @@ class LC_Page
         // 開始時刻を設定する。
         $this->timeStart = microtime(true);
 
-        $this->tpl_authority = $_SESSION['authority'];
+        $this->tpl_authority = $_SESSION['authority'] ?? null;
 
         // ディスプレイクラス生成
         $this->objDisplay = new SC_Display_Ex();

--- a/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc.php
+++ b/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc.php
@@ -46,7 +46,7 @@ class LC_Page_FrontParts_Bloc extends LC_Page_Ex
         // 開始時刻を設定する。
         $this->timeStart = microtime(true);
 
-        $this->tpl_authority = $_SESSION['authority'];
+        $this->tpl_authority = $_SESSION['authority'] ?? null;
 
         // ディスプレイクラス生成
         $this->objDisplay = new SC_Display_Ex();

--- a/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc_Category.php
+++ b/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc_Category.php
@@ -36,8 +36,6 @@ class LC_Page_FrontParts_Bloc_Category extends LC_Page_FrontParts_Bloc_Ex
     public $arrCat;
     /** @var array */
     public $arrTree;
-    /** @var int */
-    public $root_parent_id;
 
     /**
      * Page を初期化する.
@@ -127,7 +125,6 @@ class LC_Page_FrontParts_Bloc_Category extends LC_Page_FrontParts_Bloc_Ex
         foreach ($arrParentCategoryId as $category_id) {
             $arrParentID = $objCategory->getTreeTrail($category_id);
             $this->arrParentID = array_merge($this->arrParentID, $arrParentID);
-            $this->root_parent_id[] = $arrParentID[0];
         }
 
         return $arrTree;

--- a/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc_Recommend.php
+++ b/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc_Recommend.php
@@ -63,8 +63,7 @@ class LC_Page_FrontParts_Bloc_Recommend extends LC_Page_FrontParts_Bloc_Ex
     public function action()
     {
         // 基本情報を渡す
-        $objSiteInfo = SC_Helper_DB_Ex::sfGetBasisData();
-        $this->arrInfo = $objSiteInfo->data;
+        $this->arrInfo = SC_Helper_DB_Ex::sfGetBasisData();
 
         //おすすめ商品表示
         $this->arrBestProducts = $this->lfGetRanking();

--- a/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc_Recommend.php
+++ b/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc_Recommend.php
@@ -62,9 +62,6 @@ class LC_Page_FrontParts_Bloc_Recommend extends LC_Page_FrontParts_Bloc_Ex
      */
     public function action()
     {
-        // 基本情報を渡す
-        $this->arrInfo = SC_Helper_DB_Ex::sfGetBasisData();
-
         //おすすめ商品表示
         $this->arrBestProducts = $this->lfGetRanking();
     }


### PR DESCRIPTION
PHP 8.1 で見かけた Warning を回避する。

- LC_Page_FrontParts_Bloc_Category はプロパティ `root_parent_id` の配列要素追加の右辺値で Warning が発生していた。当該プロパティは2007年に追加されたが、2008年にはテンプレートから参照されなくなっているため、削除して良いと判断している。