### PR TITLE
Corepack を利用する

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
     "eslint": "^8.57.0",
     "eslint-config-jquery": "^3.0.2",
     "eslint-plugin-import": "^2.29.1",
-    "tar": "^7.1.0",
-    "typescript": "^5.4.5",
     "tar": "^7.4.0",
     "typescript": "^5.4.5",
     "webpack-cli": "^4.10.0",

--- a/package.json
+++ b/package.json
@@ -48,5 +48,6 @@
     "test:e2e": "playwright test --grep-invert '(@attack|@extends)'",
     "test:e2e-extends": "playwright test --grep @extends",
     "test:attack": "playwright test --grep-invert @extends"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Corepack を利用することで、 yarn のインストールされていない環境でも yarn コマンドを実行するだけで、 yarn をインストールすることができる
https://yarnpkg.com/corepack
https://zenn.dev/teppeis/articles/2021-05-corepack

- corepack は Node.js v14.19.0 以降では標準でバンドルされている
- 自前で yarn をインストールしている環境は従来どおり利用可能