### PR TITLE
テンプレート設定 登録時の致命的エラーを修正

### DIFF
--- a/data/class/pages/admin/design/LC_Page_Admin_Design_Template.php
+++ b/data/class/pages/admin/design/LC_Page_Admin_Design_Template.php
@@ -279,7 +279,7 @@ class LC_Page_Admin_Design_Template extends LC_Page_Admin_Ex
         $this->doUpdateMasterData($template_code, $device_type_id);
         // コンパイルファイルのクリア処理
         $objView = new SC_AdminView_Ex();
-        $objView->_smarty->clear_compiled_tpl();
+        $objView->_smarty->clearCompiledTemplate();
 
         return true;
     }


### PR DESCRIPTION
Smartyのメソッド名が変更されているため、登録時に致命的エラーとなります。