### PR TITLE
docker-php-ext-install に `-j$(nproc)` を付与してパラレルビルドする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN docker-php-ext-configure gd ${GD_OPTIONS} && docker-php-ext-install ${EXT_INSTALL_ARGS}
+RUN docker-php-ext-configure gd ${GD_OPTIONS} && docker-php-ext-install -j$(nproc) ${EXT_INSTALL_ARGS}
 RUN if [[ ${APCU} ]]; then  pecl install ${APCU} && docker-php-ext-enable apcu; fi
 
 # composer


### PR DESCRIPTION
see https://github.com/docker-library/docs/tree/master/php#php-core-extensions

手元の環境では50%程度高速化した