### PR TITLE
メール関連の PHPUnit 修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       SMTP_PORT: 1025
       SMTP_USER: ~
       SMTP_PASSWORD: ~
+      TEST_MAILCATCHER_URL: "http://mailcatcher:1080"
     networks:
       - backend
 

--- a/eccube_install.sh
+++ b/eccube_install.sh
@@ -210,6 +210,7 @@ defined('SMTP_HOST') or define('SMTP_HOST', '${SMTP_HOST}');
 defined('SMTP_PORT') or define('SMTP_PORT', '${SMTP_PORT}');
 defined('SMTP_USER') or define('SMTP_USER', '${SMTP_USER}');
 defined('SMTP_PASSWORD') or define('SMTP_PASSWORD', '${SMTP_PASSWORD}');
+defined('TEST_MAILCATCHER_URL') or define('TEST_MAILCATCHER_URL', '${TEST_MAILCATCHER_URL-"http://127.0.0.1:1080"}');
 
 __EOF__
 

--- a/tests/class/SC_SendMailTest.php
+++ b/tests/class/SC_SendMailTest.php
@@ -167,8 +167,8 @@ class SC_SendMailTest extends Common_TestCase
         $this->verify();
 
         $this->expected = [
-            'host' => '127.0.0.1',
-            'port' => '1025'
+            'host' => SMTP_HOST,
+            'port' => SMTP_PORT,
         ];
         $this->actual = $this->objSendMail->getBackendParams('smtp');
         $this->verify();

--- a/tests/class/SC_SendMailTest.php
+++ b/tests/class/SC_SendMailTest.php
@@ -172,12 +172,5 @@ class SC_SendMailTest extends Common_TestCase
         ];
         $this->actual = $this->objSendMail->getBackendParams('smtp');
         $this->verify();
-
-        $this->expected = [
-            'host' => '127.0.0.1',
-            'port' => '1025'
-        ];
-        $this->actual = $this->objSendMail->getBackendParams('smtp');
-        $this->verify();
     }
 }


### PR DESCRIPTION
- Docker Compose 構成でも PHPUnit のメール関連のテストを実行する。
    適用前後のテスト結果抜粋:
    ``` diff
    -Tests: 1218, Assertions: 1433, Skipped: 17, Incomplete: 4.
    +Tests: 1218, Assertions: 1447, Skipped: 9, Incomplete: 4.
    ```
- fixed #997
    - 繰り返しを削除した。
