### PR TITLE
GitHub Actions で PostgreSQL がエラーになるのを修正

### DIFF
--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -7,7 +7,8 @@ services:
     command: apache2-foreground
     entrypoint: /wait-for-pgsql.sh
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     environment:
       TZ: Asia/Tokyo
       PHP_POST_MAX_SIZE: 10M
@@ -39,8 +40,9 @@ services:
       - POSTGRES_DB=eccube_db
       - POSTGRES_USER=eccube_db_user
       - POSTGRES_PASSWORD=password
-      - POSTGRES_HOST_AUTH_METHOD=md5
-      - POSTGRES_INITDB_ARGS=--auth-host=md5
+      # 古いクライアント用の設定
+      # - POSTGRES_HOST_AUTH_METHOD=md5
+      # - POSTGRES_INITDB_ARGS=--auth-host=md5
     ports:
       - 15432:5432
     volumes:

--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -34,7 +34,7 @@ services:
       PASSWORD_HASH_ALGOS: sha256
 
   postgres:
-    image: postgres
+    image: postgres:16
     environment:
       - TZ=Asia/Tokyo
       - POSTGRES_DB=eccube_db

--- a/dockerbuild/wait-for-pgsql.sh
+++ b/dockerbuild/wait-for-pgsql.sh
@@ -2,7 +2,7 @@
 set -e
 
 export PGPASSWORD=$DB_PASSWORD
-until psql -h "${DB_SERVER}" -U "${DB_USER}" -d "template1" -c '\l'; do
+until psql -h "${DB_SERVER}" -U "${DB_USER}" -d "template1" -c 'SELECT 1'; do
   >&2 echo "Postgres is unavailable - sleeping"
   printf "."
   sleep 1


### PR DESCRIPTION
PostgreSQL17 がリリースされたタイミングで GitHub Actions にエラーが発生している

PostgreSQL17 サーバーへ PostgreSQL17未満の psql で `\l` を実行すると以 下のエラーが発生する

```
psql --version
psql (PostgreSQL) 16.4
psql -h 127.0.0.1 -p 15432 -U eccube_db_user eccube_db
eccube_db=# \l
ERROR:  column d.daticulocale does not exist
行 8:   d.daticulocale as "ICU Locale",
        ^
HINT:  Perhaps you meant to reference the column "d.datlocale".
```

wait-for-pgsql.sh で `\l` を使用していたため、副作用の少ない `SELECT 1` に変更する.
また、 docker compose のヘルスチェックが有効になるよう `condition: service_healthy` を追加する