### PR TITLE
Add PHP8.4-rc

### DIFF
--- a/.github/actions/dockerbuild/action.yml
+++ b/.github/actions/dockerbuild/action.yml
@@ -22,8 +22,7 @@ runs:
       run: |
         echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}-php" >> ${GITHUB_ENV}
 
-    - if: ${{ inputs.php-version >= 7.4 }}
-      shell: 'bash'
+    - shell: 'bash'
       run: |
         echo "GD_OPTIONS=--with-freetype --with-jpeg" >> ${GITHUB_ENV}
         echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}

--- a/.github/workflows/dockerbuild-and-push.yml
+++ b/.github/workflows/dockerbuild-and-push.yml
@@ -21,15 +21,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4-rc' ]
 
     steps:
       - name: downcase REPO
         run: |
           echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}-php" >> ${GITHUB_ENV}
 
-      - if: ${{ matrix.php >= 7.4 }}
-        run: |
+      - run: |
           echo "GD_OPTIONS=--with-freetype --with-jpeg" >> ${GITHUB_ENV}
           echo "EXT_INSTALL_ARGS=gd zip mysqli pgsql opcache" >> ${GITHUB_ENV}
           echo "APCU=apcu" >>  ${GITHUB_ENV}

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4-rc' ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,7 +60,11 @@ jobs:
         echo "COMPOSE_FILE=docker-compose.yml:docker-compose.${DB}.yml:docker-compose.dev.yml" >> $GITHUB_ENV
         echo "IMAGE_NAME=${OWNER,,}/ec-cube2-php" >> $GITHUB_ENV
         if [ $EVENT_NAME = "pull_request" ]; then
-          echo "TAG=${PHP}-apache-${BASE_REF}" >> $GITHUB_ENV
+          if [ -n $DOCKER_METADATA_OUTPUT_VERSION ]; then
+            echo "TAG=${DOCKER_METADATA_OUTPUT_VERSION}" >> $GITHUB_ENV
+          else
+            echo "TAG=${PHP}-apache-${BASE_REF}" >> $GITHUB_ENV
+          fi
         else
           echo "TAG=${PHP}-apache-${REF_NAME}" >> $GITHUB_ENV
         fi
@@ -158,7 +162,11 @@ jobs:
         echo "COMPOSE_FILE=docker-compose.yml:docker-compose.${DB}.yml:docker-compose.dev.yml" >> $GITHUB_ENV
         echo "IMAGE_NAME=${OWNER,,}/ec-cube2-php" >> $GITHUB_ENV
         if [ $EVENT_NAME = "pull_request" ]; then
-          echo "TAG=${PHP}-apache-${BASE_REF}" >> $GITHUB_ENV
+          if [ -n $DOCKER_METADATA_OUTPUT_VERSION ]; then
+            echo "TAG=${DOCKER_METADATA_OUTPUT_VERSION}" >> $GITHUB_ENV
+          else
+            echo "TAG=${PHP}-apache-${BASE_REF}" >> $GITHUB_ENV
+          fi
         else
           echo "TAG=${PHP}-apache-${REF_NAME}" >> $GITHUB_ENV
         fi

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -30,7 +30,7 @@ jobs:
           - 'test/front_login'
           - 'test/front_guest'
           - 'test/admin'
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4-rc' ]
         db: [ mysql, pgsql ]
     steps:
     - name: Checkout
@@ -123,7 +123,7 @@ jobs:
       fail-fast: false
       matrix:
         db: [ 'pgsql', 'mysql' ]
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4-rc' ]
         include:
           - db: mysql
             dbport: '3306'

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -39,7 +39,11 @@ jobs:
         echo "COMPOSE_FILE=docker-compose.yml:docker-compose.pgsql.yml:docker-compose.dev.yml" >> $GITHUB_ENV
         echo "IMAGE_NAME=${OWNER,,}/ec-cube2-php" >> $GITHUB_ENV
         if [ $EVENT_NAME = "pull_request" ]; then
-          echo "TAG=8.3-apache-${BASE_REF}" >> $GITHUB_ENV
+          if [ -n $DOCKER_METADATA_OUTPUT_VERSION ]; then
+            echo "TAG=${DOCKER_METADATA_OUTPUT_VERSION}" >> $GITHUB_ENV
+          else
+            echo "TAG=8.3-apache-${BASE_REF}" >> $GITHUB_ENV
+          fi
         else
           echo "TAG=8.3-apache-${REF_NAME}" >> $GITHUB_ENV
         fi

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-22.04 ]
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4-rc' ]
         db: [ mysql, pgsql ]
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -53,7 +53,11 @@ jobs:
         echo "COMPOSE_FILE=docker-compose.yml:docker-compose.${DB}.yml:docker-compose.dev.yml" >> $GITHUB_ENV
         echo "IMAGE_NAME=${OWNER,,}/ec-cube2-php" >> $GITHUB_ENV
         if [ $EVENT_NAME = "pull_request" ]; then
-          echo "TAG=${PHP}-apache-${BASE_REF}" >> $GITHUB_ENV
+          if [ -n $DOCKER_METADATA_OUTPUT_VERSION ]; then
+            echo "TAG=${DOCKER_METADATA_OUTPUT_VERSION}" >> $GITHUB_ENV
+          else
+            echo "TAG=${PHP}-apache-${BASE_REF}" >> $GITHUB_ENV
+          fi
         else
           echo "TAG=${PHP}-apache-${REF_NAME}" >> $GITHUB_ENV
         fi

--- a/html/install/templates/step4.tpl
+++ b/html/install/templates/step4.tpl
@@ -30,7 +30,7 @@
     <input type="hidden" name="senddata_cube_ver" value="<!--{$tpl_cube_ver}-->" />
     <input type="hidden" name="senddata_php_ver" value="<!--{$tpl_php_ver}-->" />
     <input type="hidden" name="senddata_db_ver" value="<!--{$tpl_db_ver}-->" />
-    <input type="hidden" name="senddata_os_type" value="<!--{""|php_uname|h}--> <!--{$smarty.server.SERVER_SOFTWARE|h}-->" />
+    <input type="hidden" name="senddata_os_type" value="<!--{php_uname()|h}--> <!--{$smarty.server.SERVER_SOFTWARE|h}-->" />
     <!--{foreach key=key item=item from=$arrHidden}-->
         <input type="hidden" name="<!--{$key}-->" value="<!--{$item|h}-->" />
     <!--{/foreach}-->
@@ -48,7 +48,7 @@
                 <li><span class="bold">EC-CUBEバージョン：</span><!--{$tpl_cube_ver}--></li>
                 <li><span class="bold">PHP情報：</span><!--{$tpl_php_ver}--></li>
                 <li><span class="bold">DB情報：</span><!--{$tpl_db_ver}--></li>
-                <li><span class="bold">OS情報：</span><!--{""|php_uname|h}--> <!--{$smarty.server.SERVER_SOFTWARE|h}--></li>
+                <li><span class="bold">OS情報：</span><!--{php_uname()|h}--> <!--{$smarty.server.SERVER_SOFTWARE|h}--></li>
             </ul>
         </div>
         <div class="result-info02">

--- a/tests/class/fixtures/server/common.php
+++ b/tests/class/fixtures/server/common.php
@@ -4,7 +4,12 @@ putenv('HTTP_URL=http://127.0.0.1:8085/');
 
 require __DIR__.'/../../../require.php';
 
-error_reporting(-1);
+if (PHP_VERSION_ID >= 80400) {
+    // XXX PHP8.4.0+で MobileDetect 3.74.x が E_DEPRECATED を発生させるため
+    error_reporting(E_ALL & ~E_DEPRECATED);
+} else {
+    error_reporting(E_ALL);
+}
 ini_set('display_errors', '1');
 
 header_remove('X-Powered-By');


### PR DESCRIPTION
- MobileDetect が E_DEPRECATED を発生させているが、その他は問題なさそう
- Warning は別途対応していきたい
- Fixes #1019 


---
以下は Copilot actions が自動生成したコメントです

This pull request includes several updates to the GitHub Actions workflows and a few other files. The main changes involve adding support for PHP 8.4-rc, adjusting environment variable handling, and updating error reporting for compatibility with PHP 8.4. Below are the most important changes:

### GitHub Actions Workflows:

* Updated PHP matrix to include PHP 8.4-rc in `.github/workflows/dockerbuild-and-push.yml`, `.github/workflows/dockerbuild.yml`, `.github/workflows/e2e-tests.yml`, and `.github/workflows/unit-tests.yml`. [[1]](diffhunk://#diff-87d401317db1a884e0f35f355f7cd874106e13165b0a712aa533996884950377L24-R31) [[2]](diffhunk://#diff-3c398cbd519ae8533126a880455107af4985394a2d2c4d6970866eaac30b468aL22-R22) [[3]](diffhunk://#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3L33-R33) [[4]](diffhunk://#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3L126-R130) [[5]](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3L27-R27)
* Added conditional handling for `DOCKER_METADATA_OUTPUT_VERSION` when setting the `TAG` environment variable in `.github/workflows/e2e-tests.yml`, `.github/workflows/phpstan.yml`, and `.github/workflows/unit-tests.yml`. [[1]](diffhunk://#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3R63-R67) [[2]](diffhunk://#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3R165-R169) [[3]](diffhunk://#diff-73a1d6ddd0eabb7e1349cdb83b76ff10f29f9e4fe316c0cd29495174181f4546R42-R46) [[4]](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3R56-R60)
* Simplified the `if` condition for setting environment variables in `.github/actions/dockerbuild/action.yml` and `.github/workflows/dockerbuild-and-push.yml`. [[1]](diffhunk://#diff-7bdd16d4a84766c078f4ddba5eea36b5601c52c30e14f5c3fc5611797d34b75bL25-R25) [[2]](diffhunk://#diff-87d401317db1a884e0f35f355f7cd874106e13165b0a712aa533996884950377L24-R31)

### Template Files:

* Corrected the usage of `php_uname()` in `html/install/templates/step4.tpl` to ensure proper escaping and display of OS information. [[1]](diffhunk://#diff-de1f7817dd6924fee595a9813b7cc0d294ae045188bd0c4ad94ec0ea12575672L33-R33) [[2]](diffhunk://#diff-de1f7817dd6924fee595a9813b7cc0d294ae045188bd0c4ad94ec0ea12575672L51-R51)

### Test Files:

* Updated error reporting in `tests/class/fixtures/server/common.php` to handle deprecated warnings in PHP 8.4.