### PR TITLE
Use MySQL8.4 with utf8mb4

### DIFF
--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -33,8 +33,8 @@ services:
       PASSWORD_HASH_ALGOS: sha256
 
   mysql:
-    image: mysql:8.0
-    command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci --default-time-zone=+09:00
+    image: mysql:8.4
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci --default-time-zone=+09:00
     ports:
       - '13306:3306'
     volumes:


### PR DESCRIPTION
This pull request includes an update to the MySQL service configuration in the `docker-compose.mysql.yml` file. The most important change is upgrading the MySQL version and adjusting the character set and collation settings.

MySQL service configuration update:

* [`docker-compose.mysql.yml`](diffhunk://#diff-ae3c263ba27f935006b36e116f6c62716c15a063f3a3a6696f3901a9377151c9L36-R37): Upgraded MySQL image from `mysql:8.0` to `mysql:8.4` and changed the character set to `utf8mb4` and collation to `utf8mb4_general_ci`.