### PR TITLE
ソース整形 配列末尾のカンマと閉じ括弧を改行する #1017

### DIFF
--- a/data/class/api/SC_Api_Operation.php
+++ b/data/class/api/SC_Api_Operation.php
@@ -415,11 +415,17 @@ class SC_Api_Operation
     protected static function getOperationRequestEcho($arrParam, $start_time)
     {
         $arrRet = [
-                'HTTPHeaders' => ['Header' => ['_attributes' => ['Name' => 'UserAgent',
-                                                                                'Value' => htmlspecialchars($_SERVER['HTTP_USER_AGENT']), ]]],
-                'RequestId' => $start_time,
-                'Arguments' => [],
-                ];
+            'HTTPHeaders' => [
+                'Header' => [
+                    '_attributes' => [
+                        'Name' => 'UserAgent',
+                        'Value' => htmlspecialchars($_SERVER['HTTP_USER_AGENT']),
+                    ],
+                ],
+            ],
+            'RequestId' => $start_time,
+            'Arguments' => [],
+        ];
         foreach ($arrParam as $key => $val) {
             $arrRet['Arguments'][] = ['_attributes' => ['Name' => htmlentities($key, ENT_NOQUOTES, 'UTF-8'), 'Value' => htmlentities($val, ENT_NOQUOTES, 'UTF-8')]];
         }

--- a/data/class/api/SC_Api_Utils.php
+++ b/data/class/api/SC_Api_Utils.php
@@ -234,8 +234,10 @@ class SC_Api_Utils
             'addDecl' => true,
             'encoding' => 'UTF-8',
             'rootName' => $response_outer_name,
-            'rootAttributes' => ['xmlns' => self::API_XMLNS.ECCUBE_VERSION,
-                                        'xml:lang' => self::API_XML_LANG, ],
+            'rootAttributes' => [
+                'xmlns' => self::API_XMLNS.ECCUBE_VERSION,
+                'xml:lang' => self::API_XML_LANG,
+            ],
             'defaultTagName' => 'Response',
             'attributesArray' => '_attributes',
         ];

--- a/data/class/api/operations/CartAdd.php
+++ b/data/class/api/operations/CartAdd.php
@@ -40,7 +40,8 @@ class API_CartAdd extends SC_Api_Abstract_Ex
     public function doAction($arrParam)
     {
         $this->arrResponse = [
-            'Version' => ECCUBE_VERSION, ];
+            'Version' => ECCUBE_VERSION,
+        ];
 
         return true;
     }

--- a/data/class/api/operations/CartClear.php
+++ b/data/class/api/operations/CartClear.php
@@ -40,7 +40,8 @@ class API_CartClear extends SC_Api_Abstract_Ex
     public function doAction($arrParam)
     {
         $this->arrResponse = [
-            'Version' => ECCUBE_VERSION, ];
+            'Version' => ECCUBE_VERSION,
+        ];
 
         return true;
     }

--- a/data/class/api/operations/CartCreate.php
+++ b/data/class/api/operations/CartCreate.php
@@ -40,7 +40,8 @@ class API_CartCreate extends SC_Api_Abstract_Ex
     public function doAction($arrParam)
     {
         $this->arrResponse = [
-            'Version' => ECCUBE_VERSION, ];
+            'Version' => ECCUBE_VERSION,
+        ];
 
         return true;
     }

--- a/data/class/api/operations/CartGet.php
+++ b/data/class/api/operations/CartGet.php
@@ -40,7 +40,8 @@ class API_CartGet extends SC_Api_Abstract_Ex
     public function doAction($arrParam)
     {
         $this->arrResponse = [
-            'Version' => ECCUBE_VERSION, ];
+            'Version' => ECCUBE_VERSION,
+        ];
 
         return true;
     }

--- a/data/class/api/operations/CartModify.php
+++ b/data/class/api/operations/CartModify.php
@@ -40,7 +40,8 @@ class API_CartModify extends SC_Api_Abstract_Ex
     public function doAction($arrParam)
     {
         $this->arrResponse = [
-            'Version' => ECCUBE_VERSION, ];
+            'Version' => ECCUBE_VERSION,
+        ];
 
         return true;
     }

--- a/data/class/api/operations/GetVersion.php
+++ b/data/class/api/operations/GetVersion.php
@@ -40,7 +40,8 @@ class API_GetVersion extends SC_Api_Abstract_Ex
     public function doAction($arrParam)
     {
         $this->arrResponse = [
-            'Version' => ECCUBE_VERSION, ];
+            'Version' => ECCUBE_VERSION,
+        ];
 
         return true;
     }

--- a/data/class/db/SC_DB_MasterData.php
+++ b/data/class/db/SC_DB_MasterData.php
@@ -108,9 +108,11 @@ class SC_DB_MasterData
         }
         $i = 0;
         foreach ($masterData as $key => $val) {
-            $sqlVal = [$columns[0] => (string) $key,
-                            $columns[1] => (string) $val,
-                            $columns[2] => (string) $i, ];
+            $sqlVal = [
+                $columns[0] => (string) $key,
+                $columns[1] => (string) $val,
+                $columns[2] => (string) $i,
+            ];
             $this->objQuery->insert($name, $sqlVal);
             $i++;
         }

--- a/data/class/helper/SC_Helper_DB.php
+++ b/data/class/helper/SC_Helper_DB.php
@@ -683,8 +683,10 @@ class SC_Helper_DB
     {
         $objQuery = SC_Query_Ex::getSingletonInstance();
 
-        $sqlval = ['category_id' => $category_id,
-                        'product_id' => $product_id, ];
+        $sqlval = [
+            'category_id' => $category_id,
+            'product_id' => $product_id,
+        ];
 
         $arrSql = [];
         $arrSql['rank'] = '(SELECT COALESCE(MAX(rank), 0) FROM dtb_product_categories sub WHERE category_id = ?) + 1';
@@ -706,8 +708,10 @@ class SC_Helper_DB
      */
     public function addProductAfterCategories($category_id, $product_id)
     {
-        $sqlval = ['category_id' => $category_id,
-                        'product_id' => $product_id, ];
+        $sqlval = [
+            'category_id' => $category_id,
+            'product_id' => $product_id,
+        ];
 
         $objQuery = SC_Query_Ex::getSingletonInstance();
 

--- a/data/class/helper/SC_Helper_TaxRule.php
+++ b/data/class/helper/SC_Helper_TaxRule.php
@@ -243,10 +243,12 @@ class SC_Helper_TaxRule
 
             $arrRet = [];
             // リクエストの配列化
-            $arrRequest = ['product_id' => $product_id,
-                            'product_class_id' => $product_class_id,
-                            'pref_id' => $pref_id,
-                            'country_id' => $country_id, ];
+            $arrRequest = [
+                'product_id' => $product_id,
+                'product_class_id' => $product_class_id,
+                'pref_id' => $pref_id,
+                'country_id' => $country_id,
+            ];
 
             // 地域設定を優先するが、システムパラメーターなどに設定を持っていくか
             // 後に書いてあるほど優先される、詳細後述MEMO参照

--- a/data/class/pages/admin/design/LC_Page_Admin_Design_MainEdit.php
+++ b/data/class/pages/admin/design/LC_Page_Admin_Design_MainEdit.php
@@ -87,8 +87,11 @@ class LC_Page_Admin_Design_MainEdit extends LC_Page_Admin_Ex
                     if ($objLayout->isEditablePage($this->device_type_id, $this->page_id)) {
                         $objLayout->lfDelPageData($this->page_id, $this->device_type_id);
 
-                        SC_Response_Ex::reload(['device_type_id' => $this->device_type_id,
-                                                     'msg' => 'on', ], true);
+                        $arrQueryString = [
+                            'device_type_id' => $this->device_type_id,
+                            'msg' => 'on',
+                        ];
+                        SC_Response_Ex::reload($arrQueryString, true);
                         SC_Response_Ex::actionExit();
                     }
                 }

--- a/data/class/pages/admin/design/LC_Page_Admin_Design_UpDown.php
+++ b/data/class/pages/admin/design/LC_Page_Admin_Design_UpDown.php
@@ -148,10 +148,12 @@ class LC_Page_Admin_Design_UpDown extends LC_Page_Admin_Ex
         }
 
         // 登録不可の文字列チェック
-        $arrIgnoreCode = ['admin',
-                               MOBILE_DEFAULT_TEMPLATE_NAME,
-                               SMARTPHONE_DEFAULT_TEMPLATE_NAME,
-                               DEFAULT_TEMPLATE_NAME, ];
+        $arrIgnoreCode = [
+            'admin',
+            MOBILE_DEFAULT_TEMPLATE_NAME,
+            SMARTPHONE_DEFAULT_TEMPLATE_NAME,
+            DEFAULT_TEMPLATE_NAME,
+        ];
         if (in_array($template_code, $arrIgnoreCode)) {
             $arrErr['template_code'] = '※ このテンプレートコードは使用できません。<br/>';
         }

--- a/data/class/pages/admin/order/LC_Page_Admin_Order_Edit.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order_Edit.php
@@ -501,14 +501,16 @@ class LC_Page_Admin_Order_Edit extends LC_Page_Admin_Order_Ex
      */
     public function setMultipleItemTo(&$objFormParam)
     {
-        $arrMultipleKey = ['multiple_shipping_id',
-                'multiple_product_class_id',
-                'multiple_product_name',
-                'multiple_product_code',
-                'multiple_classcategory_name1',
-                'multiple_classcategory_name2',
-                'multiple_price',
-                'multiple_quantity', ];
+        $arrMultipleKey = [
+            'multiple_shipping_id',
+            'multiple_product_class_id',
+            'multiple_product_name',
+            'multiple_product_code',
+            'multiple_classcategory_name1',
+            'multiple_classcategory_name2',
+            'multiple_price',
+            'multiple_quantity',
+        ];
         $arrMultipleParams = $objFormParam->getSwapArray($arrMultipleKey);
 
         /*
@@ -682,9 +684,11 @@ class LC_Page_Admin_Order_Edit extends LC_Page_Admin_Order_Ex
         foreach ($arrValues['shipping_date_year'] as $key_index => $year) {
             $month = $arrValues['shipping_date_month'][$key_index];
             $day = $arrValues['shipping_date_day'][$key_index];
-            $objError = new SC_CheckError_Ex(['shipping_date_year' => $year,
+            $objError = new SC_CheckError_Ex([
+                'shipping_date_year' => $year,
                 'shipping_date_month' => $month,
-                'shipping_date_day' => $day, ]);
+                'shipping_date_day' => $day,
+            ]);
             $objError->doFunc(['お届け日', 'shipping_date_year', 'shipping_date_month', 'shipping_date_day'], ['CHECK_DATE']);
             $arrErrDate['shipping_date_year'][$key_index] = $objError->arrErr['shipping_date_year'];
         }
@@ -694,9 +698,11 @@ class LC_Page_Admin_Order_Edit extends LC_Page_Admin_Order_Ex
         $year = $arrValues['order_birth_year'];
         $month = $arrValues['order_birth_month'];
         $day = $arrValues['order_birth_day'];
-        $objError = new SC_CheckError_Ex(['order_birth_year' => $year,
-                                               'order_birth_month' => $month,
-                                               'order_birth_day' => $day, ]);
+        $objError = new SC_CheckError_Ex([
+            'order_birth_year' => $year,
+            'order_birth_month' => $month,
+            'order_birth_day' => $day,
+        ]);
         $objError->doFunc(['生年月日', 'order_birth_year', 'order_birth_month', 'order_birth_day'],
             ['CHECK_BIRTHDAY']);
         $arrErrTemp['order_birth_year'] = $objError->arrErr['order_birth_year'];

--- a/data/class/pages/admin/products/LC_Page_Admin_Products_Product.php
+++ b/data/class/pages/admin/products/LC_Page_Admin_Products_Product.php
@@ -1049,11 +1049,7 @@ __EOF__;
         $objDb = new SC_Helper_DB_Ex();
 
         // 配列の添字を定義
-        $checkArray = ['name', 'status',
-                            'main_list_comment', 'main_comment',
-                            'deliv_fee', 'comment1', 'comment2', 'comment3',
-                            'comment4', 'comment5', 'comment6',
-                            'sale_limit', 'deliv_date_id', 'maker_id', 'note', ];
+        $checkArray = ['name', 'status', 'main_list_comment', 'main_comment', 'deliv_fee', 'comment1', 'comment2', 'comment3', 'comment4', 'comment5', 'comment6', 'sale_limit', 'deliv_date_id', 'maker_id', 'note'];
         $arrList = SC_Utils_Ex::arrayDefineIndexes($arrList, $checkArray);
 
         // INSERTする値を作成する。


### PR DESCRIPTION
- 手打ちで改行を追加。
- VSCode で整形。
- 関数呼び出しで、複数の引数の一部で可読性が悪い箇所は、一旦変数に収めた。
- 一次元配列はケツカンマを削除して1行に収めた。
- php-cs-fixer 実行。

fixed #1017