### PR TITLE
テンプレートの上の乗算を直感的に。sfMultiply ではなく演算子で行う。

### DIFF
--- a/data/Smarty/templates/admin/order/disp.tpl
+++ b/data/Smarty/templates/admin/order/disp.tpl
@@ -184,7 +184,7 @@
                 <!--{assign var=tax_rate value="`$arrForm.tax_rate.value[$product_index]`"}-->
                 <!--{assign var=tax_rule value="`$arrForm.tax_rule.value[$product_index]`"}-->
             <td class="right"><!--{$price|sfCalcIncTax:$tax_rate:$tax_rule|n2s}--> 円<br />(税率<!--{$tax_rate|n2s}-->%)</td>
-            <td class="right"><!--{$price|sfCalcIncTax:$tax_rate:$tax_rule|sfMultiply:$quantity|n2s}-->円</td>
+            <td class="right"><!--{($price|sfCalcIncTax:$tax_rate:$tax_rule*$quantity)|n2s}-->円</td>
         </tr>
         <!--{/section}-->
         <tr>

--- a/data/Smarty/templates/admin/order/edit.tpl
+++ b/data/Smarty/templates/admin/order/edit.tpl
@@ -434,7 +434,7 @@
                         <span class="attention"><!--{$arrErr[$key][$product_index]}--></span>
                         税率<input type="text" name="<!--{$key}-->[<!--{$product_index}-->]" value="<!--{$arrForm[$key].value[$product_index]|h}-->" size="3" class="box3" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key][$product_index]|sfGetErrorColor}-->" id="<!--{$key}-->_<!--{$product_index}-->" />%
                     </td>
-                    <td class="right"><!--{$price|sfCalcIncTax:$tax_rate:$tax_rule|sfMultiply:$quantity|n2s}-->円</td>
+                    <td class="right"><!--{($price|sfCalcIncTax:$tax_rate:$tax_rule*$quantity)|n2s}-->円</td>
                 </tr>
             <!--{/section}-->
             <tr>

--- a/data/Smarty/templates/default/mypage/history.tpl
+++ b/data/Smarty/templates/default/mypage/history.tpl
@@ -101,7 +101,7 @@
                     <!--{/if}-->
                     </td>
                     <td class="alignR"><!--{$orderDetail.quantity|h}--></td>
-                    <td class="alignR"><!--{$orderDetail.price_inctax|sfMultiply:$orderDetail.quantity|n2s}-->円</td>
+                    <td class="alignR"><!--{($orderDetail.price_inctax*$orderDetail.quantity)|n2s}-->円</td>
                 </tr>
             <!--{/foreach}-->
             <tr>

--- a/data/Smarty/templates/mobile/mypage/history.tpl
+++ b/data/Smarty/templates/mobile/mypage/history.tpl
@@ -65,7 +65,7 @@
         <!--{assign var=tax_rule value="`$orderDetail.tax_rule`"}-->
         <!--{$price|sfCalcIncTax:$tax_rate:$tax_rule|n2s|h}-->円<br>
         数量：<!--{$quantity|h}--><br>
-        小計：<!--{$price|sfCalcIncTax:$tax_rate:$tax_rule|sfMultiply:$quantity|n2s}-->円<br>
+        小計：<!--{($price|sfCalcIncTax:$tax_rate:$tax_rule*$quantity)|n2s}-->円<br>
     <!--{/foreach}-->
     <hr>
     小計：<!--{$tpl_arrOrderData.subtotal|n2s}-->円<br>

--- a/data/Smarty/templates/sphone/mypage/history.tpl
+++ b/data/Smarty/templates/sphone/mypage/history.tpl
@@ -125,7 +125,7 @@
                             <!--{assign var=tax_rule value="`$orderDetail.tax_rule`"}-->
                             <ul>
                                 <li><span class="mini">数量：</span><!--{$quantity|h}--></li>
-                                <li class="result"><span class="mini">小計：</span><!--{$price|sfCalcIncTax:$tax_rate:$tax_rule|sfMultiply:$quantity|n2s}-->円</li>
+                                <li class="result"><span class="mini">小計：</span><!--{($price|sfCalcIncTax:$tax_rate:$tax_rule*$quantity)|n2s}-->円</li>
                             </ul>
                         </div>
                     </div>

--- a/data/class/util/SC_Utils.php
+++ b/data/class/util/SC_Utils.php
@@ -906,7 +906,11 @@ class SC_Utils
         return $array;
     }
 
-    /* かけ算をする（Smarty用) */
+    /**
+     * かけ算をする（Smarty用)
+     *
+     * @deprecated 本体で使用されていないため非推奨
+     */
     public static function sfMultiply($num1, $num2)
     {
         return $num1 * $num2;


### PR DESCRIPTION
実装当時は、変数出力タグ内での演算に関して制約が厳しく、sfMultiply を使ってしのいでいたと理解している。