### PR TITLE
入力が無い場合にも MIN_LENGTH_CHECK がエラー判定となってしまうのを修正

### DIFF
--- a/data/class/SC_CheckError.php
+++ b/data/class/SC_CheckError.php
@@ -446,7 +446,13 @@ class SC_CheckError
         $this->createParam($value);
 
         // 文字数の取得
-        if (mb_strlen($this->arrParam[$keyname]) < $min_str_len) {
+        $len = mb_strlen($this->arrParam[$keyname]);
+
+        // 未入力の場合はエラーにしない(EXIST_CHECKを使用すること)
+        if ($len === 0) {
+            return;
+        }
+        if ($len < $min_str_len) {
             $this->arrErr[$keyname] = sprintf(
                 '※ %sは%d字以上で入力してください。<br />',
                 $disp_name,

--- a/tests/class/SC_CheckError/SC_CheckError_MIN_LENGTH_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_MIN_LENGTH_CHECKTest.php
@@ -35,7 +35,7 @@ class SC_CheckError_MIN_LENGTH_CHECKTest extends SC_CheckError_AbstractTestCase
     {
         $this->minlength = 5;
         $this->arrForm = [self::FORM_NAME => ''];
-        $this->expected = '※ MIN_LENGTH_CHECKは5字以上で入力してください。<br />';
+        $this->expected = null;
 
         $this->scenario();
         $this->verify();
@@ -45,7 +45,7 @@ class SC_CheckError_MIN_LENGTH_CHECKTest extends SC_CheckError_AbstractTestCase
     {
         $this->minlength = 5;
         $this->arrForm = [self::FORM_NAME => null];
-        $this->expected = '※ MIN_LENGTH_CHECKは5字以上で入力してください。<br />';
+        $this->expected = null;
 
         $this->scenario();
         $this->verify();


### PR DESCRIPTION
Fixes #115 

MIN_LENGTH_CHECK は EC-CUBE本体では使用されていない模様