### PR TITLE
入力が無い場合にも PREF_CHECK がエラー判定となってしまうのを修正

### DIFF
--- a/data/class/SC_CheckError.php
+++ b/data/class/SC_CheckError.php
@@ -1843,6 +1843,12 @@ class SC_CheckError
         $key = $value[1];
 
         $pref_id = $this->arrParam[$key];
+
+        // 未入力の場合はエラーにしない(EXIST_CHECKを使用すること)
+        if (strlen($pref_id ?? '') === 0) {
+            return;
+        }
+
         $objQuery = SC_Query_Ex::getSingletonInstance();
         $exists = $objQuery->exists('mtb_pref', 'id = ?', [$pref_id]);
         if (!$exists) {

--- a/tests/class/SC_CheckError/SC_CheckError_PREF_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_PREF_CHECKTest.php
@@ -47,7 +47,7 @@ class SC_CheckError_PREF_CHECKTest extends SC_CheckError_AbstractTestCase
     public function testPREFCHECKWithEmpty()
     {
         $this->arrForm = [self::FORM_NAME => ''];
-        $this->expected = '※ PREF_CHECKが不正な値です。<br />';
+        $this->expected = null;
 
         $this->scenario();
         $this->verify();
@@ -56,7 +56,7 @@ class SC_CheckError_PREF_CHECKTest extends SC_CheckError_AbstractTestCase
     public function testPREFCHECKWithNull()
     {
         $this->arrForm = [self::FORM_NAME => null];
-        $this->expected = '※ PREF_CHECKが不正な値です。<br />';
+        $this->expected = null;
 
         $this->scenario();
         $this->verify();


### PR DESCRIPTION
Fixes #744 

PREF_CHECK の挙動が変わるが、 PREF_CHECK は以下でのみ使用されており、 EXIST_CHECK と併用されているため問題ないと思われる

https://github.com/EC-CUBE/ec-cube2/blob/4d7ff5b7aa641e3c89d66ebafce1ad80a5c285be/data/class/helper/SC_Helper_Customer.php#L404