### PR TITLE
mysql 5.7 でdeadlockが発生 #630

### DIFF
--- a/data/class/SC_Query.php
+++ b/data/class/SC_Query.php
@@ -829,13 +829,17 @@ class SC_Query
      * @param string $where       WHERE句
      * @param array  $arrWhereVal プレースホルダ
      *
-     * @return
+     * @return int|MDB2_Error 削除件数
      */
     public function delete($table, $where = '', $arrWhereVal = [])
     {
-        // 空deleteは実行しない
-        if ($this->count($table, $where, $arrWhereVal) == 0) {
-            return;
+        // デッドロックを生じ得る条件の場合、空 DELETE を避ける
+        if (
+            $this->dbFactory->isSkipDeleteIfNotExists()
+            && $this->inTransaction()
+            && !$this->exists($table, $where, $arrWhereVal)
+        ) {
+            return 0;
         }
 
         if (strlen($where) <= 0) {
@@ -908,7 +912,7 @@ class SC_Query
      * @param  mixed   $types        プレースホルダの型指定 デフォルトnull = string
      * @param  mixed   $result_types 返値の型指定またはDML実行(MDB2_PREPARE_MANIP)
      *
-     * @return array   SQL の実行結果の配列
+     * @return MDB2_Result|integer|MDB2_Error   SQL の実行結果
      */
     public function query($n, $arr = [], $ignore_err = false, $types = null, $result_types = MDB2_PREPARE_RESULT)
     {
@@ -1069,7 +1073,7 @@ class SC_Query
      * @param  mixed                 $types        プレースホルダの型指定 デフォルト null
      * @param  mixed                 $result_types 返値の型指定またはDML実行(MDB2_PREPARE_MANIP)、nullは指定無し
      *
-     * @return MDB2_Statement_Common プリペアドステートメントインスタンス
+     * @return MDB2_Statement_Common|MDB2_Error プリペアドステートメントインスタンス
      */
     public function prepare($sql, $types = null, $result_types = MDB2_PREPARE_RESULT)
     {
@@ -1088,7 +1092,7 @@ class SC_Query
      * @param MDB2_Statement_Common プリペアドステートメントインスタンス
      * @param  array       $arrVal プレースホルダに挿入する配列
      *
-     * @return MDB2_Result 結果セットのインスタンス
+     * @return MDB2_Result|integer|MDB2_Error MDB2_Result or integer (affected rows).
      */
     public function execute(&$sth, $arrVal = [])
     {

--- a/data/class/SC_Query.php
+++ b/data/class/SC_Query.php
@@ -912,7 +912,7 @@ class SC_Query
      * @param  mixed   $types        プレースホルダの型指定 デフォルトnull = string
      * @param  mixed   $result_types 返値の型指定またはDML実行(MDB2_PREPARE_MANIP)
      *
-     * @return MDB2_Result|integer|MDB2_Error   SQL の実行結果
+     * @return MDB2_Result|int|MDB2_Error   SQL の実行結果
      */
     public function query($n, $arr = [], $ignore_err = false, $types = null, $result_types = MDB2_PREPARE_RESULT)
     {
@@ -1092,7 +1092,7 @@ class SC_Query
      * @param MDB2_Statement_Common プリペアドステートメントインスタンス
      * @param  array       $arrVal プレースホルダに挿入する配列
      *
-     * @return MDB2_Result|integer|MDB2_Error MDB2_Result or integer (affected rows).
+     * @return MDB2_Result|int|MDB2_Error MDB2_Result or integer (affected rows).
      */
     public function execute(&$sth, $arrVal = [])
     {

--- a/data/class/db/SC_DB_DBFactory.php
+++ b/data/class/db/SC_DB_DBFactory.php
@@ -30,6 +30,11 @@
  */
 class SC_DB_DBFactory
 {
+    public const ISOLATION_LEVEL_READ_UNCOMMITTED = 10;
+    public const ISOLATION_LEVEL_READ_COMMITTED = 20;
+    public const ISOLATION_LEVEL_REPEATABLE_READ = 30;
+    public const ISOLATION_LEVEL_SERIALIZABLE = 40;
+
     /**
      * DB_TYPE に応じた DBFactory インスタンスを生成する.
      *
@@ -320,5 +325,27 @@ class SC_DB_DBFactory
 __EOS__;
 
         return $sql;
+    }
+
+    /**
+     * トランザクション分離レベルを取得する。
+     *
+     * @return int
+     */
+    public function getTransactionIsolationLevel()
+    {
+        // TODO: 一般的な DBMS のデフォルトを返している。実際のレベルを返すのが望ましい。しかし、毎回 `SHOW transaction_isolation` などを実行するのは避けたい。インストーラーで実行環境のレベルを退避して設定ファイルに記録したり、設定ファイルで別のレベルを設定できるよう改善できそう。
+        return static::ISOLATION_LEVEL_READ_COMMITTED;
+    }
+
+    /**
+     * 削除時に対象行が存在しない場合に削除をスキップする必要があるかを返す。
+     *
+     * @return bool
+     */
+
+    public function isSkipDeleteIfNotExists()
+    {
+        return false;
     }
 }

--- a/data/class/db/SC_DB_DBFactory.php
+++ b/data/class/db/SC_DB_DBFactory.php
@@ -343,7 +343,6 @@ __EOS__;
      *
      * @return bool
      */
-
     public function isSkipDeleteIfNotExists()
     {
         return false;

--- a/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
+++ b/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
@@ -396,8 +396,8 @@ __EOS__;
         return static::ISOLATION_LEVEL_REPEATABLE_READ;
     }
 
-     public function isSkipDeleteIfNotExists()
-     {
-         return $this->getTransactionIsolationLevel() >= static::ISOLATION_LEVEL_REPEATABLE_READ;
-     }
- }
+    public function isSkipDeleteIfNotExists()
+    {
+        return $this->getTransactionIsolationLevel() >= static::ISOLATION_LEVEL_REPEATABLE_READ;
+    }
+}

--- a/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
+++ b/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
@@ -389,4 +389,15 @@ __EOS__;
         }
         $objQuery->exec("SET SESSION sql_mode = 'ANSI'");
     }
-}
+
+    public function getTransactionIsolationLevel()
+    {
+        // TODO: デフォルトを返している。実際のレベルを返すのが望ましい。しかし、毎回 `SELECT @@session.transaction_isolation` などを実行するのは避けたい。
+        return static::ISOLATION_LEVEL_REPEATABLE_READ;
+    }
+
+     public function isSkipDeleteIfNotExists()
+     {
+         return $this->getTransactionIsolationLevel() >= static::ISOLATION_LEVEL_REPEATABLE_READ;
+     }
+ }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,7 +31,6 @@
         <directory>./data/class/pages/</directory>
         <directory>./data/class/graph/</directory>
         <directory>./data/class/batch/</directory>
-        <directory>./data/class/db/dbfactory/</directory>
       </exclude>
     </coverage>
 </phpunit>

--- a/tests/class/db/SC_DB_DBFactoryTest.php
+++ b/tests/class/db/SC_DB_DBFactoryTest.php
@@ -1,0 +1,79 @@
+<?php
+
+class SC_DB_DBFactoryTest extends Common_TestCase
+{
+    /**
+     * @var SC_DB_DBFactory_PGSQL
+     */
+    protected $dbFactoryPgsql;
+
+    /**
+     * @var SC_DB_DBFactory_MYSQL
+     */
+    protected $dbFactoryMysql;
+
+    /**
+     * @var SC_DB_DBFactory_MYSQL
+     */
+    protected $dbFactoryMysqli;
+
+    /**
+     * @var SC_DB_DBFactory
+     */
+    protected $dbFactory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dbFactoryPgsql = SC_DB_DBFactory_Ex::getInstance('pgsql');
+        $this->dbFactoryMysql = SC_DB_DBFactory_Ex::getInstance('mysql');
+        $this->dbFactoryMysqli = SC_DB_DBFactory_Ex::getInstance('mysqli');
+        $this->dbFactory = SC_DB_DBFactory_Ex::getInstance('uknown');
+        // TODO: SC_DB_DBFactory_Ex::getInstance() 引数なしのパターンを追加する、DB_TYPE に依存するテストとなる。
+    }
+
+    public function testGetInstance_pgsql()
+    {
+        $this->assertInstanceOf('SC_DB_DBFactory', $this->dbFactoryPgsql);
+        $this->assertInstanceOf('SC_DB_DBFactory_Ex', $this->dbFactoryPgsql);
+        $this->assertInstanceOf('SC_DB_DBFactory_PGSQL', $this->dbFactoryPgsql);
+        $this->assertInstanceOf('SC_DB_DBFactory_PGSQL_Ex', $this->dbFactoryPgsql);
+        $this->assertNotInstanceOf('SC_DB_DBFactory_MYSQL', $this->dbFactoryPgsql);
+        $this->assertNotInstanceOf('SC_DB_DBFactory_MYSQL_Ex', $this->dbFactoryPgsql);
+    }
+
+    public function testGetInstance_mysql()
+    {
+        $this->assertInstanceOf('SC_DB_DBFactory', $this->dbFactoryMysql);
+        $this->assertInstanceOf('SC_DB_DBFactory_Ex', $this->dbFactoryMysql);
+        $this->assertInstanceOf('SC_DB_DBFactory_MYSQL', $this->dbFactoryMysql);
+        $this->assertInstanceOf('SC_DB_DBFactory_MYSQL_Ex', $this->dbFactoryMysql);
+        $this->assertNotInstanceOf('SC_DB_DBFactory_PGSQL', $this->dbFactoryMysql);
+        $this->assertNotInstanceOf('SC_DB_DBFactory_PGSQL_Ex', $this->dbFactoryMysql);
+    }
+
+    public function testGetInstance_mysqli()
+    {
+        $this->assertSame(get_class($this->dbFactoryMysql), get_class($this->dbFactoryMysqli));
+    }
+
+    public function testGetInstance_uknown()
+    {
+        $this->assertInstanceOf('SC_DB_DBFactory', $this->dbFactory);
+        $this->assertInstanceOf('SC_DB_DBFactory_Ex', $this->dbFactory);
+        $this->assertNotInstanceOf('SC_DB_DBFactory_MYSQL', $this->dbFactory);
+        $this->assertNotInstanceOf('SC_DB_DBFactory_MYSQL_Ex', $this->dbFactory);
+        $this->assertNotInstanceOf('SC_DB_DBFactory_PGSQL', $this->dbFactory);
+        $this->assertNotInstanceOf('SC_DB_DBFactory_PGSQL_Ex', $this->dbFactory);
+    }
+
+    public function testGetTransactionIsolationLevel()
+    {
+        $this->assertEquals(SC_DB_DBFactory_Ex::ISOLATION_LEVEL_READ_COMMITTED, $this->dbFactory->getTransactionIsolationLevel());
+    }
+
+    public function testIsSkipDeleteIfNotExists()
+    {
+        $this->assertEquals(false, $this->dbFactory->isSkipDeleteIfNotExists());
+    }
+}

--- a/tests/class/db/SC_DB_DBFactoryTest.php
+++ b/tests/class/db/SC_DB_DBFactoryTest.php
@@ -32,7 +32,7 @@ class SC_DB_DBFactoryTest extends Common_TestCase
         // TODO: SC_DB_DBFactory_Ex::getInstance() 引数なしのパターンを追加する、DB_TYPE に依存するテストとなる。
     }
 
-    public function testGetInstance_pgsql()
+    public function testGetInstancePgsql()
     {
         $this->assertInstanceOf('SC_DB_DBFactory', $this->dbFactoryPgsql);
         $this->assertInstanceOf('SC_DB_DBFactory_Ex', $this->dbFactoryPgsql);
@@ -42,7 +42,7 @@ class SC_DB_DBFactoryTest extends Common_TestCase
         $this->assertNotInstanceOf('SC_DB_DBFactory_MYSQL_Ex', $this->dbFactoryPgsql);
     }
 
-    public function testGetInstance_mysql()
+    public function testGetInstanceMysql()
     {
         $this->assertInstanceOf('SC_DB_DBFactory', $this->dbFactoryMysql);
         $this->assertInstanceOf('SC_DB_DBFactory_Ex', $this->dbFactoryMysql);
@@ -52,12 +52,12 @@ class SC_DB_DBFactoryTest extends Common_TestCase
         $this->assertNotInstanceOf('SC_DB_DBFactory_PGSQL_Ex', $this->dbFactoryMysql);
     }
 
-    public function testGetInstance_mysqli()
+    public function testGetInstanceMysqli()
     {
         $this->assertSame(get_class($this->dbFactoryMysql), get_class($this->dbFactoryMysqli));
     }
 
-    public function testGetInstance_uknown()
+    public function testGetInstanceUknown()
     {
         $this->assertInstanceOf('SC_DB_DBFactory', $this->dbFactory);
         $this->assertInstanceOf('SC_DB_DBFactory_Ex', $this->dbFactory);
@@ -74,6 +74,6 @@ class SC_DB_DBFactoryTest extends Common_TestCase
 
     public function testIsSkipDeleteIfNotExists()
     {
-        $this->assertEquals(false, $this->dbFactory->isSkipDeleteIfNotExists());
+        $this->assertFalse($this->dbFactory->isSkipDeleteIfNotExists());
     }
 }

--- a/tests/class/db/dbfactory/SC_DB_DBFactory_MYSQLTest.php
+++ b/tests/class/db/dbfactory/SC_DB_DBFactory_MYSQLTest.php
@@ -10,7 +10,7 @@ class SC_DB_DBFactory_MYSQLTest extends Common_TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->dbFactory = new SC_DB_DBFactory_MYSQL_Ex;
+        $this->dbFactory = new SC_DB_DBFactory_MYSQL_Ex();
     }
 
     public function testGetInstance()
@@ -25,6 +25,6 @@ class SC_DB_DBFactory_MYSQLTest extends Common_TestCase
 
     public function testIsSkipDeleteIfNotExists()
     {
-        $this->assertEquals(true, $this->dbFactory->isSkipDeleteIfNotExists());
+        $this->assertTrue($this->dbFactory->isSkipDeleteIfNotExists());
     }
 }

--- a/tests/class/db/dbfactory/SC_DB_DBFactory_MYSQLTest.php
+++ b/tests/class/db/dbfactory/SC_DB_DBFactory_MYSQLTest.php
@@ -1,0 +1,30 @@
+<?php
+
+class SC_DB_DBFactory_MYSQLTest extends Common_TestCase
+{
+    /**
+     * @var SC_DB_DBFactory_MYSQL
+     */
+    protected $dbFactory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dbFactory = new SC_DB_DBFactory_MYSQL_Ex;
+    }
+
+    public function testGetInstance()
+    {
+        $this->assertInstanceOf('SC_DB_DBFactory_MYSQL_Ex', $this->dbFactory);
+    }
+
+    public function testGetTransactionIsolationLevel()
+    {
+        $this->assertEquals(SC_DB_DBFactory_Ex::ISOLATION_LEVEL_REPEATABLE_READ, $this->dbFactory->getTransactionIsolationLevel());
+    }
+
+    public function testIsSkipDeleteIfNotExists()
+    {
+        $this->assertEquals(true, $this->dbFactory->isSkipDeleteIfNotExists());
+    }
+}

--- a/tests/class/db/dbfactory/SC_DB_DBFactory_PGSQLTest.php
+++ b/tests/class/db/dbfactory/SC_DB_DBFactory_PGSQLTest.php
@@ -1,0 +1,30 @@
+<?php
+
+class SC_DB_DBFactory_PGSQLTest extends Common_TestCase
+{
+    /**
+     * @var SC_DB_DBFactory_PGSQL
+     */
+    protected $dbFactory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dbFactory = new SC_DB_DBFactory_PGSQL_Ex;
+    }
+
+    public function testGetInstance()
+    {
+        $this->assertInstanceOf('SC_DB_DBFactory_PGSQL_Ex', $this->dbFactory);
+    }
+
+    public function testGetTransactionIsolationLevel()
+    {
+        $this->assertEquals(SC_DB_DBFactory_Ex::ISOLATION_LEVEL_READ_COMMITTED, $this->dbFactory->getTransactionIsolationLevel());
+    }
+
+    public function testIsSkipDeleteIfNotExists()
+    {
+        $this->assertEquals(false, $this->dbFactory->isSkipDeleteIfNotExists());
+    }
+}

--- a/tests/class/db/dbfactory/SC_DB_DBFactory_PGSQLTest.php
+++ b/tests/class/db/dbfactory/SC_DB_DBFactory_PGSQLTest.php
@@ -10,7 +10,7 @@ class SC_DB_DBFactory_PGSQLTest extends Common_TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->dbFactory = new SC_DB_DBFactory_PGSQL_Ex;
+        $this->dbFactory = new SC_DB_DBFactory_PGSQL_Ex();
     }
 
     public function testGetInstance()
@@ -25,6 +25,6 @@ class SC_DB_DBFactory_PGSQLTest extends Common_TestCase
 
     public function testIsSkipDeleteIfNotExists()
     {
-        $this->assertEquals(false, $this->dbFactory->isSkipDeleteIfNotExists());
+        $this->assertFalse($this->dbFactory->isSkipDeleteIfNotExists());
     }
 }


### PR DESCRIPTION
- トランザクション分離レベルを意識して、無駄な SQL 実行を避ける。https://github.com/EC-CUBE/ec-cube2/issues/630#issuecomment-2561370770
- 実行コストが幾らか低い傾向の exists() を使う。https://github.com/EC-CUBE/ec-cube2/issues/630#issuecomment-2562061376
- SC_DB_DBFactory のテストが無さそうなので、今回追加したメソッドの他、ごく基本的な部分を実装する。
- 削除件数を返さない不具合を修正。
- アノテーションを補完。