### PR TITLE
受注編集画面で数値項目に空文字を入力された場合にシステムエラーになるのを修正

### DIFF
--- a/data/Smarty/templates/admin/order/edit.tpl
+++ b/data/Smarty/templates/admin/order/edit.tpl
@@ -415,12 +415,12 @@
                     <td class="center">
                         <!--{assign var=key value="price"}-->
                         <span class="attention"><!--{$arrErr[$key][$product_index]}--></span>
-                        <input type="text" name="<!--{$key}-->[<!--{$product_index}-->]" value="<!--{$arrForm[$key].value[$product_index]|h}-->" size="6" class="box6" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key][$product_index]|sfGetErrorColor}-->" id="<!--{$key}-->_<!--{$product_index}-->" /> 円
+                        <input type="number" name="<!--{$key}-->[<!--{$product_index}-->]" value="<!--{$arrForm[$key].value[$product_index]|h}-->" size="6" class="box6" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key][$product_index]|sfGetErrorColor}-->" id="<!--{$key}-->_<!--{$product_index}-->" /> 円
                     </td>
                     <td class="center">
                         <!--{assign var=key value="quantity"}-->
                         <span class="attention"><!--{$arrErr[$key][$product_index]}--></span>
-                        <input type="text" name="<!--{$key}-->[<!--{$product_index}-->]" value="<!--{$arrForm[$key].value[$product_index]|h}-->" size="3" class="box3" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key][$product_index]|sfGetErrorColor}-->" id="<!--{$key}-->_<!--{$product_index}-->"  onChange="quantityCopyForSingleShipping('<!--{$product_index}-->')" />
+                        <input type="number" name="<!--{$key}-->[<!--{$product_index}-->]" value="<!--{$arrForm[$key].value[$product_index]|h}-->" size="3" class="box3" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key][$product_index]|sfGetErrorColor}-->" id="<!--{$key}-->_<!--{$product_index}-->"  onChange="quantityCopyForSingleShipping('<!--{$product_index}-->')" />
                     </td>
                     <!--{assign var=price value="`$arrForm.price.value[$product_index]`"}-->
                     <!--{assign var=quantity value="`$arrForm.quantity.value[$product_index]`"}-->
@@ -432,7 +432,7 @@
                         <!--{$price|sfCalcIncTax:$tax_rate:$tax_rule|n2s}--> 円<br />
                         <!--{assign var=key value="tax_rate"}-->
                         <span class="attention"><!--{$arrErr[$key][$product_index]}--></span>
-                        税率<input type="text" name="<!--{$key}-->[<!--{$product_index}-->]" value="<!--{$arrForm[$key].value[$product_index]|h}-->" size="3" class="box3" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key][$product_index]|sfGetErrorColor}-->" id="<!--{$key}-->_<!--{$product_index}-->" />%
+                        税率<input type="number" name="<!--{$key}-->[<!--{$product_index}-->]" value="<!--{$arrForm[$key].value[$product_index]|h}-->" size="3" class="box3" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key][$product_index]|sfGetErrorColor}-->" id="<!--{$key}-->_<!--{$product_index}-->" />%
                     </td>
                     <td class="right"><!--{($price|sfCalcIncTax:$tax_rate:$tax_rule*$quantity)|n2s}-->円</td>
                 </tr>
@@ -446,7 +446,7 @@
                 <td class="right">
                     <!--{assign var=key value="discount"}-->
                     <span class="attention"><!--{$arrErr[$key]}--></span>
-                    <input type="text" name="<!--{$key}-->" value="<!--{$arrForm[$key].value|h}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" size="5" class="box6" />
+                    <input type="number" name="<!--{$key}-->" value="<!--{$arrForm[$key].value|h}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" size="5" class="box6" />
                     円
                 </td>
             </tr>
@@ -455,7 +455,7 @@
                 <td class="right">
                     <!--{assign var=key value="deliv_fee"}-->
                     <span class="attention"><!--{$arrErr[$key]}--></span>
-                    <input type="text" name="<!--{$key}-->" value="<!--{$arrForm[$key].value|h}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" size="5" class="box6" />
+                    <input type="number" name="<!--{$key}-->" value="<!--{$arrForm[$key].value|h}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" size="5" class="box6" />
                     円
                 </td>
             </tr>
@@ -464,7 +464,7 @@
                 <td class="right">
                     <!--{assign var=key value="charge"}-->
                     <span class="attention"><!--{$arrErr[$key]}--></span>
-                    <input type="text" name="<!--{$key}-->" value="<!--{$arrForm[$key].value|h}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" size="5" class="box6" />
+                    <input type="number" name="<!--{$key}-->" value="<!--{$arrForm[$key].value|h}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" size="5" class="box6" />
                     円
                 </td>
             </tr>
@@ -489,7 +489,7 @@
                     <td class="right">
                         <!--{assign var=key value="use_point"}-->
                         <span class="attention"><!--{$arrErr[$key]}--></span>
-                        <input type="text" name="<!--{$key}-->" value="<!--{$arrForm[$key].value|default:0|h}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" size="5" class="box6" />
+                        <input type="number" name="<!--{$key}-->" value="<!--{$arrForm[$key].value|default:0|h}-->" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key]|sfGetErrorColor}-->" size="5" class="box6" />
                         pt
                     </td>
                 </tr>

--- a/data/class/pages/admin/order/LC_Page_Admin_Order_Edit.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order_Edit.php
@@ -678,6 +678,18 @@ class LC_Page_Admin_Order_Edit extends LC_Page_Admin_Order_Ex
     {
         $objProduct = new SC_Product_Ex();
         $arrValues = $objFormParam->getHashArray();
+
+        // XXX 空文字が入ってくる場合があるので数値へキャストする
+        // きちんとエラーハンドリングすべきだが応急処置
+        foreach (['price', 'quantity', 'tax_rate'] as $key) {
+            foreach ($arrValues[$key] as &$val) {
+                $val = (int) $val;
+            }
+        }
+        foreach (['discount', 'charge', 'deliv_fee', 'use_point'] as $key) {
+            $arrValues[$key] = (int) $arrValues[$key];
+        }
+
         $arrErr = [];
         $arrErrTemp = $objFormParam->checkError();
         $arrErrDate = [];
@@ -1217,7 +1229,9 @@ class LC_Page_Admin_Order_Edit extends LC_Page_Admin_Order_Ex
             $arrUpdateQuantity = [];
             foreach ($arrShipmentsItems as $arritems) {
                 foreach ($arritems['shipment_product_class_id'] as $relation_index => $shipment_product_class_id) {
-                    $arrUpdateQuantity[$shipment_product_class_id] += $arritems['shipment_quantity'][$relation_index];
+                    // XXX 空文字が入ってくる場合があるので数値へキャストする
+                    // きちんとエラーハンドリングすべきだが応急処置
+                    $arrUpdateQuantity[$shipment_product_class_id] += (int) $arritems['shipment_quantity'][$relation_index];
                 }
             }
 


### PR DESCRIPTION
refs #829
とり急ぎ応急処置。数量及び税率が空文字の場合は0にキャストする。
根治対応は #836 で行う
