### PR TITLE
ADMIN_DIRを変更するとパスが*/adminのままになる

### DIFF
--- a/data/class/SC_AdminView.php
+++ b/data/class/SC_AdminView.php
@@ -31,6 +31,6 @@ class SC_AdminView extends SC_View_Ex
         $this->_smarty->setCompileDir(realpath(COMPILE_ADMIN_REALDIR));
         $this->assign('TPL_URLPATH_PC', ROOT_URLPATH.USER_DIR.USER_PACKAGE_DIR.TEMPLATE_NAME.'/');
         $this->assign('TPL_URLPATH_DEFAULT', ROOT_URLPATH.USER_DIR.USER_PACKAGE_DIR.DEFAULT_TEMPLATE_NAME.'/');
-        $this->assign('TPL_URLPATH', ROOT_URLPATH.USER_DIR.USER_PACKAGE_DIR.'admin/');
+        $this->assign('TPL_URLPATH', ROOT_URLPATH.USER_DIR.USER_PACKAGE_DIR.ADMIN_DIR);
     }
 }


### PR DESCRIPTION
https://github.com/EC-CUBE/ec-cube2/blob/f52f6e2d55c988b1cb572877fb6518880ffe17f0/data/class/SC_AdminView.php#L34

TPL_URLPATHのパスがハードコーディングされているため、特定の環境や変更により、パスが正しく読み込まれない箇所が発生する可能性があります。