### PR TITLE
PHP8.4で非会員の受注を再計算した場合にシステムエラーになるのを修正

### DIFF
--- a/data/class/pages/admin/order/LC_Page_Admin_Order_Edit.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order_Edit.php
@@ -774,7 +774,7 @@ class LC_Page_Admin_Order_Edit extends LC_Page_Admin_Order_Ex
         $arrValues['add_point'] = SC_Helper_DB_Ex::sfGetAddPoint($totalpoint, $arrValues['use_point']) + $arrValues['birth_point'];
 
         // 最終保持ポイント
-        $arrValues['total_point'] = $objFormParam->getValue('point') - $arrValues['use_point'];
+        $arrValues['total_point'] = ((int) $objFormParam->getValue('point')) - $arrValues['use_point'];
 
         if ($arrValues['total'] < 0) {
             $arrErr['total'] = '合計額がマイナス表示にならないように調整して下さい。<br />';


### PR DESCRIPTION
非会員の場合は `$objFormParam->getValue('point')` が空文字列になるため int にキャストする