### PR TITLE
user_data 配下が削除される課題の追加修正

### DIFF
--- a/data/class/pages/admin/contents/LC_Page_Admin_Contents_FileManager.php
+++ b/data/class/pages/admin/contents/LC_Page_Admin_Contents_FileManager.php
@@ -129,7 +129,7 @@ class LC_Page_Admin_Contents_FileManager extends LC_Page_Admin_Ex
                 $objFormParam->convParam();
                 $this->arrErr = $objFormParam->checkError();
                 $select_file = SC_Helper_FileManager_Ex::convertToAbsolutePath($objFormParam->getValue('select_file'));
-                if ($select_file === realpath(USER_REALDIR)) {
+                if (realpath($select_file) === realpath(USER_REALDIR)) {
                     GC_Utils_Ex::gfPrintLog($select_file.' は削除できません.');
                     $tpl_onload = "alert('user_dataは削除できません');";
                     $this->setTplOnLoad($tpl_onload);


### PR DESCRIPTION
https://github.com/EC-CUBE/ec-cube2/issues/682 の対応が不十分だったため、追加修正
`SC_Helper_FileManager_Ex::convertToAbsolutePath('/')` は `/path/to/user_data/` (末尾に / が付与される) ため、`realpath(USER_REALDIR)` と一致しなくなってしまう