### PR TITLE
DEFAULT_PASSWORD の文字数を PASSWORD_MIN_LEN に合わせる

### DIFF
--- a/data/mtb_constants_init.php
+++ b/data/mtb_constants_init.php
@@ -68,7 +68,7 @@ define('OPTION_RECOMMEND', 1);
 /** 商品規格登録(有効:1 無効:0) */
 define('OPTION_CLASS_REGIST', 1);
 /** 会員登録変更(マイページ)パスワード用 */
-define('DEFAULT_PASSWORD', "******");
+define('DEFAULT_PASSWORD', "********");
 /** 別のお届け先最大登録数 */
 define('DELIV_ADDR_MAX', 20);
 /** 対応状況管理画面の一覧表示件数 */

--- a/html/install/sql/insert_data.sql
+++ b/html/install/sql/insert_data.sql
@@ -1076,7 +1076,7 @@ INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('OPTION_PRODUCT_DELI
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('OPTION_DELIV_FEE', '1', 60, '配送業者ごとの配送料を加算する(有効:1 無効:0)');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('OPTION_RECOMMEND', '1', 61, 'おすすめ商品登録(有効:1 無効:0)');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('OPTION_CLASS_REGIST', '1', 62, '商品規格登録(有効:1 無効:0)');
-INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('DEFAULT_PASSWORD', '"******"', 66, '会員登録変更(マイページ)パスワード用');
+INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('DEFAULT_PASSWORD', '"********"', 66, '会員登録変更(マイページ)パスワード用');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('DELIV_ADDR_MAX', '20', 67, '別のお届け先最大登録数');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('ORDER_STATUS_MAX', '50', 70, '対応状況管理画面の一覧表示件数');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('REVIEW_REGIST_MAX', '5', 71, 'フロントレビュー書き込み最大数');


### PR DESCRIPTION
メンバー登録時に `PASSWORD_MIN_LEN ` より少ないエラーとなるため