### PR TITLE
build(Dockerfile): replace libpcre3-dev with libpcre2-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
         libfreetype6-dev libjpeg62-turbo-dev libpng-dev \
         libpq-dev \
         libzip-dev zlib1g-dev \
-        libpcre3-dev \
+        libpcre2-dev \
         ssl-cert \
         mariadb-client postgresql-client \
     && apt-get clean \


### PR DESCRIPTION
Debien Bookworm 以降では libpcre3-dev パッケージが削除されたため、 docker build に失敗するのを修正