### PR TITLE
feat(docker): PostgreSQL 18対応

### DIFF
--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -34,12 +34,15 @@ services:
       PASSWORD_HASH_ALGOS: sha256
 
   postgres:
-    image: postgres:latest
+    image: postgres:18
     environment:
       - TZ=Asia/Tokyo
       - POSTGRES_DB=eccube_db
       - POSTGRES_USER=eccube_db_user
       - POSTGRES_PASSWORD=password
+      # PostgreSQL 18+では /var/lib/postgresql/data が非推奨のため明示的に指定
+      # 参考: https://github.com/docker-library/postgres/pull/1259
+      - PGDATA=/var/lib/postgresql/data
       # 古いクライアント用の設定
       # - POSTGRES_HOST_AUTH_METHOD=md5
       # - POSTGRES_INITDB_ARGS=--auth-host=md5


### PR DESCRIPTION
## 概要

PostgreSQL 18のデータディレクトリ構造変更に対応し、`postgres:18`イメージで正常に起動できるようにしました。

## 背景

PostgreSQL 18では、データディレクトリの構造が変更され、デフォルトで`/var/lib/postgresql/MAJOR/docker`が使用されるようになりました。これにより、従来の`/var/lib/postgresql/data`へのマウントでは起動に失敗する問題が発生していました。

参考: https://github.com/docker-library/postgres/pull/1259

## 変更内容

- `postgres:latest` → `postgres:18` に変更
- `PGDATA`環境変数を明示的に`/var/lib/postgresql/data`に設定
  - PostgreSQL 18+の新しいデータディレクトリ構造に対応しつつ、従来の構造を維持

### 修正ファイル

- `docker-compose.pgsql.yml`

## 動作確認

- ✅ PostgreSQL 18.1での起動成功
- ✅ 全テーブルの正常な作成を確認
- ✅ データベース接続とクエリ実行が正常に動作

## テスト計画

- [x] ローカル環境でPostgreSQL 18での起動確認
- [ ] CI/CDでのテスト実行確認
- [ ] PostgreSQL 15, 16, 17での互換性確認（既存環境への影響なし）

## 関連Issue

Closes #1284

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)