### PR TITLE
キャッシュコントロールの簡素化 #1273

### DIFF
--- a/data/class/pages/LC_Page.php
+++ b/data/class/pages/LC_Page.php
@@ -603,6 +603,8 @@ class LC_Page
      * @param  string $mode (nocache/private)
      *
      * @return void
+     *
+     * @deprecated EC-CUBE 本体では使用していない。https://github.com/EC-CUBE/ec-cube2/issues/1273
      */
     public function httpCacheControl($mode = '')
     {

--- a/data/class/pages/LC_Page_Sitemap.php
+++ b/data/class/pages/LC_Page_Sitemap.php
@@ -83,9 +83,6 @@ class LC_Page_Sitemap extends LC_Page_Ex
         // FIXME PCサイトのみに限定している。ある程度妥当だとは思うが、よりベターな方法はないだろうか。
         $this->arrPageList = $this->getPageData('device_type_id = ?', DEVICE_TYPE_PC);
 
-        // キャッシュしない(念のため)
-        header('Paragrama: no-cache');
-
         // XMLテキスト
         header('Content-type: application/xml; charset=utf-8');
 

--- a/data/class/pages/admin/LC_Page_Admin_Index.php
+++ b/data/class/pages/admin/LC_Page_Admin_Index.php
@@ -39,7 +39,6 @@ class LC_Page_Admin_Index extends LC_Page_Admin_Ex
     {
         parent::init();
         $this->tpl_mainpage = 'login.tpl';
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/admin/customer/LC_Page_Admin_Customer.php
+++ b/data/class/pages/admin/customer/LC_Page_Admin_Customer.php
@@ -76,8 +76,6 @@ class LC_Page_Admin_Customer extends LC_Page_Admin_Ex
         // カテゴリ一覧設定
         $objDb = new SC_Helper_DB_Ex();
         $this->arrCatList = $objDb->sfGetCategoryList();
-
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/admin/customer/LC_Page_Admin_Customer_SearchCustomer.php
+++ b/data/class/pages/admin/customer/LC_Page_Admin_Customer_SearchCustomer.php
@@ -43,7 +43,6 @@ class LC_Page_Admin_Customer_SearchCustomer extends LC_Page_Admin_Ex
         parent::init();
         $this->tpl_mainpage = 'customer/search_customer.tpl';
         $this->tpl_subtitle = '会員検索';
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/admin/mail/LC_Page_Admin_Mail.php
+++ b/data/class/pages/admin/mail/LC_Page_Admin_Mail.php
@@ -75,8 +75,6 @@ class LC_Page_Admin_Mail extends LC_Page_Admin_Ex
 
         // テンプレート一覧設定
         $this->arrTemplate = $this->lfGetMailTemplateList(SC_Helper_Mail_Ex::sfGetMailmagaTemplate());
-
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/admin/order/LC_Page_Admin_Order.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order.php
@@ -66,8 +66,6 @@ class LC_Page_Admin_Order extends LC_Page_Admin_Ex
 
         // 支払い方法の取得
         $this->arrPayments = SC_Helper_Payment_Ex::getIDValueList();
-
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/admin/order/LC_Page_Admin_Order_Edit.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order_Edit.php
@@ -131,8 +131,6 @@ class LC_Page_Admin_Order_Edit extends LC_Page_Admin_Order_Ex
 
         // 配送業者の取得
         $this->arrDeliv = SC_Helper_Delivery_Ex::getIDValueList();
-
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/admin/order/LC_Page_Admin_Order_Mail.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order_Mail.php
@@ -55,7 +55,6 @@ class LC_Page_Admin_Order_Mail extends LC_Page_Admin_Order_Ex
 
         $masterData = new SC_DB_MasterData_Ex();
         $this->arrMAILTEMPLATE = $masterData->getMasterData('mtb_mail_template');
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/admin/order/LC_Page_Admin_Order_MailView.php
+++ b/data/class/pages/admin/order/LC_Page_Admin_Order_MailView.php
@@ -40,7 +40,6 @@ class LC_Page_Admin_Order_MailView extends LC_Page_Admin_Ex
         parent::init();
         $this->tpl_mainpage = 'order/mail_view.tpl';
         $this->tpl_subtitle = '受注管理メール確認';
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/admin/ownersstore/LC_Page_Admin_OwnersStore_Settings.php
+++ b/data/class/pages/admin/ownersstore/LC_Page_Admin_OwnersStore_Settings.php
@@ -53,7 +53,6 @@ class LC_Page_Admin_OwnersStore_Settings extends LC_Page_Admin_Ex
         $this->tpl_subno = 'settings';
         $this->tpl_maintitle = 'オーナーズストア';
         $this->tpl_subtitle = '認証キー設定';
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/admin/system/LC_Page_Admin_System_Input.php
+++ b/data/class/pages/admin/system/LC_Page_Admin_System_Input.php
@@ -54,7 +54,6 @@ class LC_Page_Admin_System_Input extends LC_Page_Admin_Ex
         $this->arrWORK = $masterData->getMasterData('mtb_work');
 
         $this->tpl_subtitle = 'メンバー登録/編集';
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/contact/LC_Page_Contact.php
+++ b/data/class/pages/contact/LC_Page_Contact.php
@@ -43,7 +43,6 @@ class LC_Page_Contact extends LC_Page_Ex
         } else {
             $this->tpl_title = 'お問い合わせ(入力ページ)';
         }
-        $this->httpCacheControl('nocache');
 
         $masterData = new SC_DB_MasterData_Ex();
         $this->arrPref = $masterData->getMasterData('mtb_pref');

--- a/data/class/pages/contact/LC_Page_Contact_Complete.php
+++ b/data/class/pages/contact/LC_Page_Contact_Complete.php
@@ -40,7 +40,6 @@ class LC_Page_Contact_Complete extends LC_Page_Ex
         parent::init();
         $this->tpl_title = 'お問い合わせ(完了ページ)';
         $this->tpl_mainno = 'contact';
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/entry/LC_Page_Entry.php
+++ b/data/class/pages/entry/LC_Page_Entry.php
@@ -51,8 +51,6 @@ class LC_Page_Entry extends LC_Page_Ex
         $this->arrYear = $objDate->getYear('', START_BIRTH_YEAR, '');
         $this->arrMonth = $objDate->getMonth(true);
         $this->arrDay = $objDate->getDay(true);
-
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/entry/LC_Page_Entry_Complete.php
+++ b/data/class/pages/entry/LC_Page_Entry_Complete.php
@@ -41,7 +41,6 @@ class LC_Page_Entry_Complete extends LC_Page_Ex
     public function init()
     {
         parent::init();
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/forgot/LC_Page_Forgot.php
+++ b/data/class/pages/forgot/LC_Page_Forgot.php
@@ -57,7 +57,6 @@ class LC_Page_Forgot extends LC_Page_Ex
         $masterData = new SC_DB_MasterData_Ex();
         $this->arrReminder = $masterData->getMasterData('mtb_reminder');
         $this->device_type = SC_Display_Ex::detectDevice();
-        $this->httpCacheControl('nocache');
         // デフォルトログインアドレスロード
         $objCookie = new SC_Cookie_Ex();
         $this->tpl_login_email = $objCookie->getCookie('login_email');

--- a/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc_Login.php
+++ b/data/class/pages/frontparts/bloc/LC_Page_FrontParts_Bloc_Login.php
@@ -43,7 +43,6 @@ class LC_Page_FrontParts_Bloc_Login extends LC_Page_FrontParts_Bloc_Ex
         parent::init();
         $this->tpl_login = false;
         $this->tpl_disable_logout = false;
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/mypage/LC_Page_Mypage.php
+++ b/data/class/pages/mypage/LC_Page_Mypage.php
@@ -56,8 +56,6 @@ class LC_Page_Mypage extends LC_Page_AbstractMypage_Ex
         }
         $masterData = new SC_DB_MasterData_Ex();
         $this->arrCustomerOrderStatus = $masterData->getMasterData('mtb_customer_order_status');
-
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/mypage/LC_Page_Mypage_Change.php
+++ b/data/class/pages/mypage/LC_Page_Mypage_Change.php
@@ -48,7 +48,6 @@ class LC_Page_Mypage_Change extends LC_Page_AbstractMypage_Ex
         $this->arrJob = $masterData->getMasterData('mtb_job');
         $this->arrMAILMAGATYPE = $masterData->getMasterData('mtb_mail_magazine_type');
         $this->arrSex = $masterData->getMasterData('mtb_sex');
-        $this->httpCacheControl('nocache');
 
         // 生年月日選択肢の取得
         $objDate = new SC_Date_Ex(BIRTH_YEAR, date('Y'));

--- a/data/class/pages/mypage/LC_Page_Mypage_Delivery.php
+++ b/data/class/pages/mypage/LC_Page_Mypage_Delivery.php
@@ -46,7 +46,6 @@ class LC_Page_Mypage_Delivery extends LC_Page_AbstractMypage_Ex
         $masterData = new SC_DB_MasterData_Ex();
         $this->arrPref = $masterData->getMasterData('mtb_pref');
         $this->arrCountry = $masterData->getMasterData('mtb_country');
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/mypage/LC_Page_Mypage_DeliveryAddr.php
+++ b/data/class/pages/mypage/LC_Page_Mypage_DeliveryAddr.php
@@ -48,7 +48,6 @@ class LC_Page_Mypage_DeliveryAddr extends LC_Page_Ex
         $masterData = new SC_DB_MasterData_Ex();
         $this->arrPref = $masterData->getMasterData('mtb_pref');
         $this->arrCountry = $masterData->getMasterData('mtb_country');
-        $this->httpCacheControl('nocache');
         $this->validUrl = [
             MYPAGE_DELIVADDR_URLPATH,
             DELIV_URLPATH,

--- a/data/class/pages/mypage/LC_Page_Mypage_DownLoad.php
+++ b/data/class/pages/mypage/LC_Page_Mypage_DownLoad.php
@@ -52,7 +52,6 @@ class LC_Page_Mypage_DownLoad extends LC_Page_Ex
     {
         $this->skip_load_page_layout = true;
         parent::init();
-        $this->allowClientCache();
     }
 
     /**

--- a/data/class/pages/mypage/LC_Page_Mypage_History.php
+++ b/data/class/pages/mypage/LC_Page_Mypage_History.php
@@ -53,7 +53,6 @@ class LC_Page_Mypage_History extends LC_Page_AbstractMypage_Ex
         parent::init();
         $this->tpl_mypageno = 'index';
         $this->tpl_subtitle = '購入履歴詳細';
-        $this->httpCacheControl('nocache');
 
         $masterData = new SC_DB_MasterData_Ex();
         $this->arrMAILTEMPLATE = $masterData->getMasterData('mtb_mail_template');

--- a/data/class/pages/mypage/LC_Page_Mypage_Login.php
+++ b/data/class/pages/mypage/LC_Page_Mypage_Login.php
@@ -38,7 +38,6 @@ class LC_Page_Mypage_Login extends LC_Page_AbstractMypage_Ex
     public function init()
     {
         parent::init();
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/mypage/LC_Page_Mypage_MailView.php
+++ b/data/class/pages/mypage/LC_Page_Mypage_MailView.php
@@ -39,7 +39,6 @@ class LC_Page_Mypage_MailView extends LC_Page_AbstractMypage_Ex
     {
         $this->skip_load_page_layout = true;
         parent::init();
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/products/LC_Page_Products_Review.php
+++ b/data/class/pages/products/LC_Page_Products_Review.php
@@ -54,7 +54,6 @@ class LC_Page_Products_Review extends LC_Page_Ex
         $this->arrSex = $masterData->getMasterData('mtb_sex');
         $this->arrReviewDenyURL = $masterData->getMasterData('mtb_review_deny_url');
         $this->tpl_mainpage = 'products/review.tpl';
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/regist/LC_Page_Regist_Complete.php
+++ b/data/class/pages/regist/LC_Page_Regist_Complete.php
@@ -39,7 +39,6 @@ class LC_Page_Regist_Complete extends LC_Page_Ex
     {
         parent::init();
         $this->tpl_title = '会員登録(完了ページ)';
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/rss/LC_Page_Rss.php
+++ b/data/class/pages/rss/LC_Page_Rss.php
@@ -65,9 +65,6 @@ class LC_Page_Rss extends LC_Page_Ex
         // 新着情報を取得
         $arrNews = $this->lfGetNews();
 
-        // キャッシュしない(念のため)
-        header('pragma: no-cache');
-
         // XMLテキスト(これがないと正常にRSSとして認識してくれないツールがあるため)
         header('Content-type: application/xml');
 

--- a/data/class/pages/rss/LC_Page_Rss_Products.php
+++ b/data/class/pages/rss/LC_Page_Rss_Products.php
@@ -110,9 +110,6 @@ class LC_Page_Rss_Products extends LC_Page_Ex
         // セットしたデータをテンプレートファイルに出力
         $objView->assignobj($this);
 
-        // キャッシュしない(念のため)
-        header('Pragma: no-cache');
-
         // XMLテキスト(これがないと正常にRSSとして認識してくれないツールがあるため)
         header('Content-type: application/xml');
 

--- a/data/class/pages/shopping/LC_Page_Shopping.php
+++ b/data/class/pages/shopping/LC_Page_Shopping.php
@@ -53,8 +53,6 @@ class LC_Page_Shopping extends LC_Page_Ex
         $this->arrYear = $objDate->getYear('', START_BIRTH_YEAR, '');
         $this->arrMonth = $objDate->getMonth(true);
         $this->arrDay = $objDate->getDay(true);
-
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/shopping/LC_Page_Shopping_Complete.php
+++ b/data/class/pages/shopping/LC_Page_Shopping_Complete.php
@@ -39,7 +39,6 @@ class LC_Page_Shopping_Complete extends LC_Page_Ex
     {
         parent::init();
         $this->tpl_title = 'ご注文完了';
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/shopping/LC_Page_Shopping_Confirm.php
+++ b/data/class/pages/shopping/LC_Page_Shopping_Confirm.php
@@ -52,7 +52,6 @@ class LC_Page_Shopping_Confirm extends LC_Page_Ex
         $this->arrMAILMAGATYPE = $masterData->getMasterData('mtb_mail_magazine_type');
         $this->arrReminder = $masterData->getMasterData('mtb_reminder');
         $this->arrDeliv = SC_Helper_Delivery_Ex::getIDValueList('service_name');
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/shopping/LC_Page_Shopping_Deliv.php
+++ b/data/class/pages/shopping/LC_Page_Shopping_Deliv.php
@@ -45,7 +45,6 @@ class LC_Page_Shopping_Deliv extends LC_Page_Ex
         $this->arrPref = $masterData->getMasterData('mtb_pref');
         $this->arrCountry = $masterData->getMasterData('mtb_country');
         $this->tpl_title = 'お届け先の指定';
-        $this->httpCacheControl('nocache');
     }
 
     /**

--- a/data/class/pages/shopping/LC_Page_Shopping_Multiple.php
+++ b/data/class/pages/shopping/LC_Page_Shopping_Multiple.php
@@ -42,7 +42,6 @@ class LC_Page_Shopping_Multiple extends LC_Page_Ex
     {
         parent::init();
         $this->tpl_title = 'お届け先の複数指定';
-        $this->httpCacheControl('nocache');
     }
 
     /**


### PR DESCRIPTION
Resolves #1273

[data/class/pages/LC_Page_Sitemap.php](https://github.com/EC-CUBE/ec-cube2/pull/1293/files#diff-75271e5066f70209c5ac44621fb53a2237e995b728cc550fbc4e19f0fcb516f2) は、そもそも Typo だった。他同様に削除した。