### PR TITLE
Fix: CI/CDワークフローの依存関係を修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
     uses: ./.github/workflows/e2e-tests.yml
   success:
     needs:
+      - php-cs-fixer
       - phpstan
       - unit-tests
       - e2e-tests

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -19,7 +19,6 @@ on:
 jobs:
   php-cs-fixer:
     name: php-cs-fixer
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -19,7 +19,6 @@ on:
 jobs:
   phpstan:
     name: PHPStan
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout"


### PR DESCRIPTION
## 概要

PR #1304の修正PRです。Dependabot PRでテストが実行されなくなった問題を修正し、ワークフローの依存関係を整理しました。

## 問題

PR #1304で以下の問題が発生：

1. **php-cs-fixer**と**phpstan**にDependabotスキップ条件（`if: github.actor != 'dependabot[bot]'`）を追加
2. **unit-tests**と**e2e-tests**が**php-cs-fixer**に依存しているため、Dependabot PRではphp-cs-fixerがスキップされ、その後のテストも実行されない
3. **success**ジョブに**php-cs-fixer**が含まれていない

参考: https://github.com/EC-CUBE/ec-cube2/actions/runs/21159426408

## 修正内容

### 1. Dependabotスキップ条件を削除

- `php-cs-fixer.yml`: `if: github.actor != 'dependabot[bot]'` を削除
- `phpstan.yml`: `if: github.actor != 'dependabot[bot]'` を削除

**理由**: php-cs-fixerとphpstanは静的解析であり、依存関係の更新でも実行すべき

### 2. successジョブにphp-cs-fixerを追加

- `main.yml`: `success`ジョブの`needs`に`php-cs-fixer`を追加

## 依存関係

```
dockerbuild
  ↓
php-cs-fixer + phpstan（並列、両方必須実行）
  ↓
unit-tests（両方OKなら実行）
  ↓
e2e-tests（unit-testsがOKなら実行、内部でinstaller実行）
  ↓
success（全てOKなら成功）
```

### e2e-tests内の構造

e2e-tests.ymlは内部で以下のジョブを実行：

1. **run-on-linux**: E2Eテスト実行
2. **installer**: インストーラーテスト（run-on-linuxに依存）

main.ymlからは`e2e-tests`ワークフローを呼ぶだけで、両方のジョブが順次実行されます。

## 期待される効果

### 1. Dependabot PRでもテストが実行される

- php-cs-fixerとphpstanが常に実行される
- unit-testsとe2e-testsも依存関係通りに実行される
- Dependabot PRでもマトリックスは縮小（PHP 8.4 + MySQL のみ）

### 2. 依存関係が明確化

- 静的解析 → ユニットテスト → E2Eテスト → インストーラの順序
- 各ステップが失敗したら、後続のステップは実行されない
- successジョブで全てのステップが成功したことを確認

### 3. CI/CD実行時間の最適化

- PR #1304で追加したキャッシュ機能は維持
- 並列実行の最適化も維持
- Dependabot PRではマトリックス縮小により高速化

## 変更ファイル

- `.github/workflows/main.yml` - successジョブにphp-cs-fixerを追加
- `.github/workflows/php-cs-fixer.yml` - Dependabotスキップ条件を削除
- `.github/workflows/phpstan.yml` - Dependabotスキップ条件を削除

## テスト

- [ ] Dependabot PRでCIが正常に実行されることを確認
- [ ] 通常のPRでCIが正常に実行されることを確認
- [ ] 依存関係の順序が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)