### PR TITLE
Fix: Docker Buildx timeout by using docker driver

### DIFF
--- a/.github/actions/dockerbuild/action.yml
+++ b/.github/actions/dockerbuild/action.yml
@@ -68,6 +68,8 @@ runs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker
     - name: Build and export to Docker
       uses: docker/build-push-action@v5
       with:


### PR DESCRIPTION
## 概要

DependabotのPRでDocker Buildxのセットアップ時にタイムアウトエラーが発生する問題を修正しました。

## 問題

`docker/setup-buildx-action@v3` がdocker-containerドライバーでビルダーコンテナを作成後、docker inspect時にタイムアウト:

```
Error: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/containers/buildx_buildkit_builder-.../json": context deadline exceeded
```

## 原因

- GitHub Actionsランナーの負荷やDocker APIの応答遅延により、ビルダーコンテナのステータス確認がタイムアウト
- docker-containerドライバーは別のコンテナを作成するため、Docker APIの呼び出しが増える

## 修正内容

`.github/actions/dockerbuild/action.yml`:
- `driver: docker` を設定し、別コンテナを作成せずに既存のDockerデーモンを直接使用
- これによりdocker inspectのタイムアウトを回避

## 影響

- docker-containerドライバーの高度な機能（マルチプラットフォームビルドなど）は使えなくなりますが、基本的なビルドとキャッシュは正常に動作します
- 既存のワークフローには影響なし

## テスト

Dependabot PRでのCI実行で確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)