### PR TITLE
Fix: installer testでDependabotの場合もMySQL/PostgreSQL両方をテストするように修正

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -144,7 +144,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        db: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && fromJSON('["mysql"]') || fromJSON('["pgsql", "mysql"]') }}
+        db: ['mysql', 'pgsql']
         php: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && fromJSON('["8.4"]') || fromJSON('["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]') }}
         include:
           - db: mysql


### PR DESCRIPTION
installer testでDependabotの判定を削除し、常にMySQL/PostgreSQL 両方をテストするように変更。

問題:
- DependabotのPRではmatrix.dbを["mysql"]のみに制限していたが、 includeに db: pgsql の定義があったため、PostgreSQLジョブが 追加で実行されていた
- PostgreSQLのジョブが必要な環境変数を取得できず失敗していた

修正:
- installer testのmatrix.dbを常に['mysql', 'pgsql']に変更
- Dependabotの場合でも両方のDBでテストを実行

結果:
- 通常のPR: MySQL, PostgreSQL × 7 PHP = 14ジョブ（変更なし）
- DependabotのPR: MySQL, PostgreSQL × PHP 8.4 = 2ジョブ（PostgreSQL追加）

理由:
- インストーラーはDB依存の処理が含まれるため、両DBでのテストが必要
- Dependabotの依存更新でもDB関連の問題を検出できる