### PR TITLE
Issue #1378: DB_TYPE 条件分岐を DBFactory パターンに統一

### DIFF
--- a/data/class/db/SC_DB_DBFactory.php
+++ b/data/class/db/SC_DB_DBFactory.php
@@ -342,6 +342,19 @@ class SC_DB_DBFactory
     }
 
     /**
+     * 現在時刻から指定期間前の日時を表す SQL 式を返す.
+     *
+     * @param int    $value 期間の値
+     * @param string $unit  期間の単位 ('hour', 'day', 'minute' 等)
+     *
+     * @return string SQL 式
+     */
+    public function getDateTimeBeforeIntervalSql($value, $unit)
+    {
+        return null;
+    }
+
+    /**
      * 削除時に対象行が存在しない場合に削除をスキップする必要があるかを返す。
      *
      * @return bool

--- a/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
+++ b/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
@@ -400,6 +400,14 @@ class SC_DB_DBFactory_MYSQL extends SC_DB_DBFactory
         return $this->getTransactionIsolationLevel() >= static::ISOLATION_LEVEL_REPEATABLE_READ;
     }
 
+    public function getDateTimeBeforeIntervalSql($value, $unit)
+    {
+        $value = (int) $value;
+        $unit = strtoupper($unit);
+
+        return "NOW() - INTERVAL {$value} {$unit}";
+    }
+
     public function addLimitOffset($sql, $limit = null, $offset = null)
     {
         // MySQL は OFFSET のみの指定はできないため、LIMIT が指定されていない場合は最大値を指定する。

--- a/data/class/db/dbfactory/SC_DB_DBFactory_PGSQL.php
+++ b/data/class/db/dbfactory/SC_DB_DBFactory_PGSQL.php
@@ -266,6 +266,14 @@ class SC_DB_DBFactory_PGSQL extends SC_DB_DBFactory
         return [];
     }
 
+    public function getDateTimeBeforeIntervalSql($value, $unit)
+    {
+        $value = (int) $value;
+        $unit = strtolower($unit);
+
+        return "NOW() - INTERVAL '{$value} {$unit}'";
+    }
+
     /**
      * 擬似表を表すSQL文(FROM 句)を取得する
      *

--- a/data/class/db/dbfactory/SC_DB_DBFactory_SQLITE3.php
+++ b/data/class/db/dbfactory/SC_DB_DBFactory_SQLITE3.php
@@ -206,6 +206,14 @@ class SC_DB_DBFactory_SQLITE3 extends SC_DB_DBFactory
         return $sql;
     }
 
+    public function getDateTimeBeforeIntervalSql($value, $unit)
+    {
+        $value = (int) $value;
+        $unit = strtolower($unit);
+
+        return "datetime('now', 'localtime', '-{$value} {$unit}')";
+    }
+
     /**
      * 擬似表を表すSQL文(FROM 句)を取得する
      *

--- a/data/class/helper/SC_Helper_LoginRateLimit.php
+++ b/data/class/helper/SC_Helper_LoginRateLimit.php
@@ -56,15 +56,10 @@ class SC_Helper_LoginRateLimit
     {
         $objQuery = SC_Query_Ex::getSingletonInstance();
 
-        // データベースタイプに応じて1時間前の時刻を取得
-        if (DB_TYPE == 'pgsql') {
-            $interval_clause = "create_date > NOW() - INTERVAL '1 hour'";
-        } elseif (DB_TYPE == 'sqlite3') {
-            $interval_clause = "create_date > datetime('now', 'localtime', '-1 hour')";
-        } else {
-            // MySQL
-            $interval_clause = 'create_date > NOW() - INTERVAL 1 HOUR';
-        }
+        // DBFactory を使用して1時間前の時刻を取得
+        $objDBFactory = SC_DB_DBFactory::getInstance();
+        $interval_expr = $objDBFactory->getDateTimeBeforeIntervalSql(1, 'hour');
+        $interval_clause = "create_date > {$interval_expr}";
 
         // 同一メールアドレスの失敗回数をチェック
         $email_count = $objQuery->count(
@@ -166,15 +161,10 @@ class SC_Helper_LoginRateLimit
 
         $objQuery = SC_Query_Ex::getSingletonInstance();
 
-        // データベースタイプに応じて削除条件を設定
-        if (DB_TYPE == 'pgsql') {
-            $where = "create_date < NOW() - INTERVAL '{$days} days'";
-        } elseif (DB_TYPE == 'sqlite3') {
-            $where = "create_date < datetime('now', 'localtime', '-{$days} days')";
-        } else {
-            // MySQL
-            $where = "create_date < NOW() - INTERVAL {$days} DAY";
-        }
+        // DBFactory を使用して削除条件を設定
+        $objDBFactory = SC_DB_DBFactory::getInstance();
+        $interval_expr = $objDBFactory->getDateTimeBeforeIntervalSql($days, 'day');
+        $where = "create_date < {$interval_expr}";
 
         $count = $objQuery->delete(
             'dtb_login_attempt',


### PR DESCRIPTION
## Summary
- `SC_Helper_LoginRateLimit` 内の `DB_TYPE` による直接条件分岐を `SC_DB_DBFactory` パターンに統一
- `SC_DB_DBFactory` に汎用メソッド `getDateTimeBeforeIntervalSql($value, $unit)` を追加
- MySQL / PostgreSQL / SQLite3 の各 DBFactory クラスでオーバーライド実装
- `checkRateLimit()` と `cleanupOldAttempts()` の2箇所を修正

## 設計
- 既存の DBFactory パターンに準拠し、SQL フラグメントを返す設計
- `$value` を `(int)` キャストして SQL インジェクション防止
- `>` / `<` どちらの比較にも対応可能な汎用的な式を返却

Closes #1378

## Test plan
- [x] PHPUnit 全テスト通過（MySQL）- 既存のエラー/失敗のみ
- [ ] GitHub Actions CI 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * バックエンド基盤を改善し、複数のデータベースシステム間での処理の一貫性が向上しました。これに伴い、ログイン試行回数制限の内部実装も最適化されています。ユーザーインターフェースへの直接的な変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->