### PR TITLE
fix(deps): zaproxy/axios 依存を除去し native fetch に置換

### DIFF
--- a/e2e-tests/utils/ZapClient.ts
+++ b/e2e-tests/utils/ZapClient.ts
@@ -1,4 +1,3 @@
-import ClientApi from 'zaproxy';
 import PlaywrightConfig from '../../playwright.config';
 
 /**
@@ -115,33 +114,41 @@ export class ZapClientError extends Error {
  */
 export class ZapClient {
 
-  /** APIキー. */
-  private apiKey: string | null;
-
-  /** プロキシサーバーのホスト名. */
+  /** プロキシサーバーのURL. */
   private proxy: string | undefined;
 
-  /** ClientApi のインスタンス. */
-  private readonly zaproxy;
+  /** ZAP REST API のベースURL. */
+  private baseUrl: string;
+
+  /** リクエストヘッダー. */
+  private headers: Record<string, string>;
 
   /**
    * コンストラクタ.
    */
   constructor (proxy?: string | null, apiKey?: string | null) {
     this.proxy = proxy ?? PlaywrightConfig.use?.proxy?.server;
-    this.apiKey = apiKey !== undefined ? apiKey : null;
-    const proxyConfig = this.proxy ? (() => {
-      const url = new URL(this.proxy);
-      return {
-        protocol: url.protocol.replace(':', ''),
-        host: url.hostname,
-        port: parseInt(url.port) || (url.protocol === 'https:' ? 443 : 80)
-      };
-    })() : undefined;
-    this.zaproxy = new ClientApi({
-      apiKey: this.apiKey,
-      proxy: proxyConfig
-    });
+    this.baseUrl = this.proxy ? `${this.proxy}/JSON` : 'http://localhost:8080/JSON';
+    this.headers = apiKey ? { 'X-ZAP-API-Key': apiKey } : {};
+  }
+
+  /**
+   * ZAP REST API にリクエストを送信します.
+   */
+  private async request (path: string, params?: Record<string, any>): Promise<any> {
+    const url = new URL(this.baseUrl + path);
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        if (value !== null && value !== undefined) {
+          url.searchParams.set(key, String(value));
+        }
+      }
+    }
+    const response = await fetch(url.toString(), { headers: this.headers });
+    if (!response.ok) {
+      throw new ZapClientError(`ZAP API error: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
   }
 
   /**
@@ -151,7 +158,7 @@ export class ZapClient {
    * @param mode 実行モードの列挙型.
    */
   public async setMode (mode: Mode): Promise<void> {
-    await this.zaproxy.core.setMode({ mode });
+    await this.request('/core/action/setMode/', { mode });
   }
 
   /**
@@ -162,7 +169,7 @@ export class ZapClient {
    * @param override セッションを上書きする場合 true
    */
   public async newSession (name: string, override: boolean): Promise<void> {
-    await this.zaproxy.core.newSession({ name, overwrite: override });
+    await this.request('/core/action/newSession/', { name, overwrite: override });
   }
 
   /**
@@ -172,7 +179,7 @@ export class ZapClient {
    * @param contextType ContextType の列挙型
    */
   public async importContext (contextType: ContextType): Promise<void> {
-    await this.zaproxy.context.importContext({ contextfile: '/zap/wrk/' + contextType });
+    await this.request('/context/action/importContext/', { contextFile: '/zap/wrk/' + contextType });
   }
 
   /**
@@ -182,7 +189,7 @@ export class ZapClient {
    * @returns Forced user mode が有効な場合 true
    */
   public async isForcedUserModeEnabled (): Promise<boolean> {
-    const result = await this.zaproxy.forcedUser.isForcedUserModeEnabled();
+    const result = await this.request('/forcedUser/view/isForcedUserModeEnabled/');
     return JSON.parse(result.forcedModeEnabled);
   }
 
@@ -193,7 +200,7 @@ export class ZapClient {
    * @param bool Forced user mode を有効にする場合 true
    */
   public async setForcedUserModeEnabled (bool?: boolean): Promise<void> {
-    await this.zaproxy.forcedUser.setForcedUserModeEnabled({ bool: bool ?? true });
+    await this.request('/forcedUser/action/setForcedUserModeEnabled/', { boolean: bool ?? true });
   }
 
   /**
@@ -205,7 +212,7 @@ export class ZapClient {
    * @returns リクエスト結果の {@link HttpMessage}
    */
   public async sendRequest (request: string, followRedirects?: boolean): Promise<HttpMessage> {
-    const result = await this.zaproxy.core.sendRequest({ request, followredirects: followRedirects ?? false });
+    const result = await this.request('/core/action/sendRequest/', { request, followRedirects: followRedirects ?? false });
     return result.sendRequest;
   }
 
@@ -217,7 +224,7 @@ export class ZapClient {
    * @returns 履歴の数
    */
   public async getNumberOfMessages (url: string): Promise<number> {
-    const result = await this.zaproxy.core.numberOfMessages({ baseurl: url });
+    const result = await this.request('/core/view/numberOfMessages/', { baseurl: url });
     return JSON.parse(result.numberOfMessages);
   }
 
@@ -231,7 +238,7 @@ export class ZapClient {
    * @returns 履歴({@link HttpMessage})の配列
    */
   public async getMessages (url: string, start?: number, count?: number): Promise<HttpMessage[]> {
-    const result = await this.zaproxy.core.messages({ baseurl: url, start, count });
+    const result = await this.request('/core/view/messages/', { baseurl: url, start, count });
     return result.messages;
   }
 
@@ -268,16 +275,15 @@ export class ZapClient {
    * @returns スキャンID
    */
   public async activeScanAsUser (url: string, contextId: number, userId: number, recurse?: boolean, scanPolicyName?: string | null, method?: 'GET' | 'POST' | 'PUT' | 'DELETE', postData?: string | null): Promise<number> {
-    const params = {
+    const result = await this.request('/ascan/action/scanAsUser/', {
       url,
-      contextid: contextId,
-      userid: userId,
+      contextId,
+      userId,
       recurse: recurse ?? false,
-      scanpolicyname: scanPolicyName ?? null,
+      scanPolicyName: scanPolicyName ?? null,
       method: method ?? 'GET',
-      postdata: postData ?? null,
-    };
-    const result = await this.zaproxy.ascan.scanAsUser(params);
+      postData: postData ?? null,
+    });
     return result.scan;
   }
 
@@ -297,16 +303,15 @@ export class ZapClient {
    * @returns スキャンID
    */
   public async activeScan (url: string, recurse?: boolean, inScopeOnly?: boolean, scanPolicyName?: string | null, method?: 'GET' | 'POST' | 'PUT' | 'DELETE', postData?: string | null, contextId?: number | null): Promise<number> {
-    const params = {
+    const result = await this.request('/ascan/action/scan/', {
       url,
       recurse: recurse ?? false,
-      inscopeonly: inScopeOnly ?? true,
-      scanpolicyname: scanPolicyName ?? null,
+      inScopeOnly: inScopeOnly ?? true,
+      scanPolicyName: scanPolicyName ?? null,
       method: method ?? 'GET',
-      postdata: postData ?? null,
-      contextid: contextId ?? null,
-    };
-    const result = await this.zaproxy.ascan.scan(params);
+      postData: postData ?? null,
+      contextId: contextId ?? null,
+    });
     return result.scan;
   }
 
@@ -317,7 +322,7 @@ export class ZapClient {
    * @returns スキャンステータス
    */
   public async getActiveScanStatus (scanId: number): Promise<number> {
-    const result = await this.zaproxy.ascan.status({ scanid: scanId });
+    const result = await this.request('/ascan/view/status/', { scanId });
     return result.status;
   }
 
@@ -326,7 +331,7 @@ export class ZapClient {
    * [coreActionSnapshotSession API](https://www.zaproxy.org/docs/api/#coreactionsnapshotsession) を実行します.
    */
   public async snapshotSession (): Promise<void> {
-    await this.zaproxy.core.snapshotSession({});
+    await this.request('/core/action/snapshotSession/');
   }
 
   /**
@@ -340,7 +345,7 @@ export class ZapClient {
    * @returns アラートの配列
    */
   public async getAlerts (url: string, start?: number, count?:number, riskid?: Risk): Promise<Alert[]> {
-    const result = await this.zaproxy.core.alerts({ baseurl: url, start, count, riskid });
+    const result = await this.request('/core/view/alerts/', { baseurl: url, start, count, riskId: riskid });
     return result.alerts;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,8 +44,7 @@
         "expose-loader": "^5.0.1",
         "tar": "^7.5.11",
         "typescript": "^5.8.3",
-        "webpack-cli": "^6.0.1",
-        "zaproxy": "^2.0.0-rc.7"
+        "webpack-cli": "^6.0.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2696,13 +2695,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2717,18 +2709,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-eslint": {
@@ -3092,20 +3072,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3269,19 +3235,6 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/commander": {
       "version": "12.1.0",
@@ -3613,16 +3566,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3683,34 +3626,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/dunder-proto/node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/easy-extender": {
@@ -4590,6 +4505,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -4607,87 +4523,6 @@
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/form-data/node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/form-data/node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/form-data/node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/fresh": {
@@ -4813,20 +4648,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-symbol-description": {
@@ -5878,16 +5699,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -6614,16 +6425,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/punycode": {
@@ -8547,18 +8348,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zaproxy": {
-      "version": "2.0.0-rc.7",
-      "resolved": "https://registry.npmjs.org/zaproxy/-/zaproxy-2.0.0-rc.7.tgz",
-      "integrity": "sha512-CThYnULF5D34N6+I/KPAyaHKmsA78QxCk78WquLwgrgYfzl1cOTAsKYBPnrXkqbU4cLxPexK27+dIAosdfLfcA==",
-      "dev": true,
-      "dependencies": {
-        "axios": "^1.3.3"
-      },
-      "engines": {
-        "node": ">=17.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "expose-loader": "^5.0.1",
     "tar": "^7.5.11",
     "typescript": "^5.8.3",
-    "webpack-cli": "^6.0.1",
-    "zaproxy": "^2.0.0-rc.7"
+    "webpack-cli": "^6.0.1"
   },
   "scripts": {
     "lint:javascript": "eslint --fix data/*.js",


### PR DESCRIPTION
## Summary
- `zaproxy` パッケージ (devDependencies) を削除し、axios の間接依存を完全に除去
- `ZapClient.ts` を native `fetch` による ZAP REST API 直接呼び出しに書き換え
- 公開インターフェース（型・enum・クラス）は不変のため、呼び出し側 14 ファイルの変更は不要

## Changes
- `e2e-tests/utils/ZapClient.ts`: `import ClientApi from 'zaproxy'` を削除し、`fetch` ベースの private `request()` メソッドで ZAP REST API を直接呼び出すように変更
- `package.json`: devDependencies から `zaproxy` を削除
- `package-lock.json`: `zaproxy` と `axios` のエントリが除去 (-215行)

## Motivation
axios に頻繁な緊急度の高い脆弱性が報告されており、Dependabot 対応が繰り返し発生していた。
zaproxy パッケージが行っていたのは ZAP REST API への単純な HTTP GET リクエストのみであり、Node.js の native `fetch` で完全に置き換え可能。

## Test plan
- [ ] E2E テスト通過 (CI: main.yml → e2e-tests.yml)
- [ ] Penetration テスト通過 (workflow_dispatch: penetration-tests.yml)
- [ ] `npm ls axios` で axios が依存ツリーに存在しないことを確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * テスト環境の内部実装を改善し、コード保守性を向上させました。

* **Chores**
  * 開発用依存パッケージの最適化を実施いたしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->