### PR TITLE
受注メール配信 確認画面の hidden 重複を削除

### DIFF
--- a/data/Smarty/templates/admin/order/mail_confirm.tpl
+++ b/data/Smarty/templates/admin/order/mail_confirm.tpl
@@ -35,15 +35,6 @@
             <input type="hidden" name="<!--{$key}-->" value="<!--{$item.value|h}-->" />
         <!--{/if}-->
     <!--{/foreach}-->
-    <!--{foreach key=key item=item from=$arrSearchHidden}-->
-        <!--{if is_array($item)}-->
-            <!--{foreach item=c_item from=$item}-->
-            <input type="hidden" name="<!--{$key|h}-->[]" value="<!--{$c_item|h}-->" />
-            <!--{/foreach}-->
-        <!--{else}-->
-            <input type="hidden" name="<!--{$key|h}-->" value="<!--{$item|h}-->" />
-        <!--{/if}-->
-    <!--{/foreach}-->
     <div id="order" class="contents-main">
         <h2>メール配信</h2>
 


### PR DESCRIPTION
$arrSearchHidden の内容が $arrForm にも含まれている。

当初、$arrForm から検索条件項目を外す方向を試みたが、変更量が多くなり、トータルそれが良いのか懐疑的となった。
変更量が少ない方法を採用した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * メール確認フォームで不要な隠し検索パラメータの送信を廃止しました。これにより、フォーム送信時のペイロードが最適化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->