### PR TITLE
fix: 管理画面の会員一覧で LIMIT が適用されない不具合を修正 (#1398)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -92,7 +92,7 @@ jobs:
             sleep 1
         done
         docker compose exec -T ec-cube composer dumpautoload
-        docker compose exec -T ec-cube php data/vendor/bin/eccube eccube:fixtures:generate --products=5 --customers=1 --orders=5
+        docker compose exec -T ec-cube php data/vendor/bin/eccube eccube:fixtures:generate --products=5 --customers=30 --orders=5
 
     - if: ${{ matrix.db == 'pgsql' }}
       run: |

--- a/data/class/helper/SC_Helper_Customer.php
+++ b/data/class/helper/SC_Helper_Customer.php
@@ -692,10 +692,11 @@ class SC_Helper_Customer
             $disp_pageno = 1;
         }
         $offset = (int) $page_max * ((int) $disp_pageno - 1);
+        $sql = $objSelect->getList();
         if ($limitMode == '') {
-            $objQuery->setLimitOffset($page_max, $offset);
+            $sql = $objQuery->dbFactory->addLimitOffset($sql, $page_max, $offset);
         }
-        $arrData = $objQuery->getAll($objSelect->getList(), $objSelect->arrVal);
+        $arrData = $objQuery->getAll($sql, $objSelect->arrVal);
 
         // 該当全体件数の取得
         $objQuery = SC_Query_Ex::getSingletonInstance();

--- a/e2e-tests/test/admin/customer/list_pagination.test.ts
+++ b/e2e-tests/test/admin/customer/list_pagination.test.ts
@@ -15,7 +15,7 @@ test.describe('会員一覧のページネーション (Issue #1398)', () => {
   /**
    * 会員レコードの先頭行 (rowspan="2" を持つ td を含む tr) から customer_id を取得.
    */
-  async function collectCustomerIds(page: Page): Promise<string[]> {
+  async function collectCustomerIds (page: Page): Promise<string[]> {
     const ids = await page
       .locator('#customer-search-result tr:has(td[rowspan="2"]) td:nth-child(2)')
       .allTextContents();

--- a/e2e-tests/test/admin/customer/list_pagination.test.ts
+++ b/e2e-tests/test/admin/customer/list_pagination.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '../../../fixtures/admin/admin_login.fixture';
+import { Page } from '@playwright/test';
+import { ADMIN_DIR } from '../../../config/default.config';
+
+const url = `/${ADMIN_DIR}customer/`;
+
+/**
+ * Issue #1398: 管理画面の会員一覧で LIMIT が SQL に反映されず
+ * 全件取得される回帰 (PR #1116 起因) の E2E 回帰テスト.
+ *
+ * 前提: CI/ローカル環境で `--customers=30` 以上の会員フィクスチャが投入されていること.
+ */
+test.describe('会員一覧のページネーション (Issue #1398)', () => {
+
+  /**
+   * 会員レコードの先頭行 (rowspan="2" を持つ td を含む tr) から customer_id を取得.
+   */
+  async function collectCustomerIds(page: Page): Promise<string[]> {
+    const ids = await page
+      .locator('#customer-search-result tr:has(td[rowspan="2"]) td:nth-child(2)')
+      .allTextContents();
+    return ids.map((s) => s.trim()).filter((s) => s.length > 0);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+  test('表示件数を指定したとき LIMIT が反映され, ページャで異なる会員が表示されること', async ({ adminLoginPage, page }) => {
+    await page.goto(url);
+
+    await page.selectOption('select[name=search_page_max]', '10');
+    await page.click('text=この条件で検索する');
+
+    await expect(page.locator('#customer-search-result')).toBeVisible();
+    await expect(page.locator('.pager')).toBeVisible();
+
+    const page1Ids = await collectCustomerIds(page);
+    expect(page1Ids.length).toBe(10);
+
+    await page.click('.pager ul li:nth-child(2) a');
+    await expect(page.locator('.pager .on')).toContainText('2');
+
+    const page2Ids = await collectCustomerIds(page);
+    expect(page2Ids.length).toBeGreaterThan(0);
+
+    const duplicates = page1Ids.filter((id) => page2Ids.includes(id));
+    expect(duplicates).toEqual([]);
+  });
+});

--- a/tests/class/helper/SC_Helper_Customer/SC_Helper_Customer_sfGetSearchDataTest.php
+++ b/tests/class/helper/SC_Helper_Customer/SC_Helper_Customer_sfGetSearchDataTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * SC_Helper_Customer::sfGetSearchData() のテスト.
+ *
+ * Issue #1398: 管理画面の会員一覧で LIMIT が SQL に反映されず
+ * 全件取得される回帰 (PR #1116 起因) の再現テスト.
+ */
+class SC_Helper_Customer_sfGetSearchDataTest extends Common_TestCase
+{
+    /** @var string 投入する会員を識別するための email prefix */
+    private $emailPrefix;
+
+    /** @var int 投入する会員件数 (page_max を超える件数にすること) */
+    private $totalCount = 30;
+
+    /** @var int 1 ページあたりの最大表示件数 */
+    private $pageMax = 10;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->emailPrefix = 'issue1398-'.uniqid().'-';
+        for ($i = 0; $i < $this->totalCount; $i++) {
+            $this->objGenerator->createCustomer(
+                sprintf('%s%02d@example.com', $this->emailPrefix, $i)
+            );
+        }
+    }
+
+    /**
+     * @param array $overrides 任意の上書きパラメータ
+     *
+     * @return array sfGetSearchData() に渡す検索パラメータ
+     */
+    private function buildSearchParam(array $overrides = [])
+    {
+        return array_merge([
+            'search_page_max' => (string) $this->pageMax,
+            'search_pageno' => '1',
+            'search_email' => $this->emailPrefix,
+        ], $overrides);
+    }
+
+    /**
+     * page_max を指定したとき, 結果の件数が page_max と一致すること.
+     * (修正前は LIMIT が SQL に反映されず, 投入件数全件が返る)
+     */
+    public function testSfGetSearchDataRespectsLimit()
+    {
+        [, $arrData] = SC_Helper_Customer_Ex::sfGetSearchData(
+            $this->buildSearchParam()
+        );
+
+        $this->expected = $this->pageMax;
+        $this->actual = count($arrData);
+        $this->verify('LIMIT が SQL に反映され, page_max 件数で返却されること');
+    }
+
+    /**
+     * 総件数 (linemax) は LIMIT の影響を受けず全件数を返すこと.
+     */
+    public function testSfGetSearchDataLineMaxReturnsTotalCount()
+    {
+        [$linemax] = SC_Helper_Customer_Ex::sfGetSearchData(
+            $this->buildSearchParam()
+        );
+
+        $this->expected = $this->totalCount;
+        $this->actual = (int) $linemax;
+        $this->verify('総件数は LIMIT の影響を受けず全件数を返すこと');
+    }
+
+    /**
+     * ページ遷移時に異なる customer_id が返ること (OFFSET の検証).
+     */
+    public function testSfGetSearchDataPaginationReturnsDifferentRows()
+    {
+        [, $arrPage1] = SC_Helper_Customer_Ex::sfGetSearchData(
+            $this->buildSearchParam(['search_pageno' => '1'])
+        );
+        [, $arrPage2] = SC_Helper_Customer_Ex::sfGetSearchData(
+            $this->buildSearchParam(['search_pageno' => '2'])
+        );
+
+        $ids1 = array_column($arrPage1, 'customer_id');
+        $ids2 = array_column($arrPage2, 'customer_id');
+
+        $this->expected = [];
+        $this->actual = array_values(array_intersect($ids1, $ids2));
+        $this->verify('OFFSET により 1 ページ目と 2 ページ目で重複が無いこと');
+    }
+
+    /**
+     * $limitMode が空文字以外のとき, LIMIT を付与せず全件返ること (既存挙動の維持).
+     */
+    public function testSfGetSearchDataLimitModeBypassesLimit()
+    {
+        [, $arrData] = SC_Helper_Customer_Ex::sfGetSearchData(
+            $this->buildSearchParam(),
+            'all'
+        );
+
+        $this->expected = $this->totalCount;
+        $this->actual = count($arrData);
+        $this->verify('limitMode 指定時は LIMIT を付けず全件返却すること');
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1398

PR #1116 ([5559b6a0](https://github.com/EC-CUBE/ec-cube2/commit/5559b6a00d1e9befacc9a2bfc4c33b36ec48e31c), 2025-01-10) で `SC_Query::setLimitOffset()` が MDB2 connection への即時反映から `\$this->limit` / `\$this->offset` への保存のみに変更された結果, `\$objQuery->getAll()` に生 SQL を直接渡す `SC_Helper_Customer::sfGetSearchData()` では LIMIT/OFFSET が一切付与されず, 管理画面の会員一覧 (`/admin/customer/`) で `dtb_customer` の全件が取得・表示される回帰が発生していました。

### 修正方針 (Issue 修正案 A: 局所修正)

呼び出し側で `\$objQuery->dbFactory->addLimitOffset()` を直接適用し, `SC_Query::setLimitOffset()` の内部実装に依存せず確実に LIMIT/OFFSET を SQL へ注入します。

- `SC_Query::getSql()` が内部で行っている処理と同等
- 既存に同パターン (`LC_Page_Admin_Home::page()`, `SC_Product::getProductsClassFullByProductId()`, `ItemSearch`) の先例あり
- 他の `setLimitOffset()` 呼び出し箇所は `SC_Query::select()` / `getOne()` 等の `getSql()` 経由メソッドで結果を受けているため LIMIT が SQL に反映されており, 本件の影響は受けない

### コミット

1. `test:` 回帰防止用の PHPUnit / E2E テストを追加
2. `fix:` 本体修正 (`SC_Helper_Customer::sfGetSearchData()`)

## Test plan

- [x] PHPUnit (sqlite3): `tests/class/helper/SC_Helper_Customer/` 4 テスト pass
  - 修正前: `testSfGetSearchDataRespectsLimit` / `testSfGetSearchDataPaginationReturnsDifferentRows` が fail (LIMIT/OFFSET 未適用を検知)
  - 修正後: 4 テスト pass
- [x] PHPUnit 全体 (sqlite3): 1772 tests, 2670 assertions OK (skipped 19, incomplete 2 はいずれも既存)
- [x] E2E (sqlite3, ローカル, 31 件フィクスチャ): `e2e-tests/test/admin/customer/list_pagination.test.ts` pass
  - 修正前: Expected 10 / Received 31 で fail (回帰再現を E2E でも確認)
  - 修正後: pass
- [x] CI: MySQL / PostgreSQL / SQLite3 × PHP 7.4-8.5 のマトリクス全 green を確認

## 補足

`.github/workflows/e2e-tests.yml` の `--customers=1` を `--customers=30` に変更しています。これは追加した E2E (ページネーション動作確認) に 10 件以上の会員データが必要なためです。他の E2E は `MAX(customer_id)` 等で最新会員を取得しており, フィクスチャ件数の増加による影響はありません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 会員一覧のページング処理を修正し、検索時のLIMIT/オフセットが正しく反映されるようにしました。

* **Tests**
  * 管理画面の会員一覧ページング回帰テストを追加しました。
  * 会員検索の単体テストを追加し、LIMIT・ページング・全件取得モードの動作を検証します。

* **Chores**
  * テスト用データ生成数を増やし（顧客数を30件に拡大）テストの再現性を高めました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EC-CUBE/ec-cube2/pull/1399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->