### PR TITLE
testlists商品一覧取得() が時折エラーとなるのを回避

### DIFF
--- a/tests/class/SC_Product/SC_Product_listsTest.php
+++ b/tests/class/SC_Product/SC_Product_listsTest.php
@@ -86,6 +86,7 @@ class SC_Product_listsTest extends SC_Product_TestBase
         // $this->assertNull($result);
 
         $this->objQuery->setWhere('product_id IN (?, ?)', [1001, 1002]);
+        $this->objQuery->setOrder('product_id');
         $this->actual = $this->objProducts->lists($this->objQuery);
 
         $this->verify('商品一覧');


### PR DESCRIPTION
1002, 1001 の順に出力された場合に失敗していたので、setOrder() で順序を固定した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テストケースの実行時における並び順の検証を強化しました。

**注:** このリリースにはエンドユーザー向けの新機能や改善は含まれていません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EC-CUBE/ec-cube2/pull/1400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->