### PR TITLE
fix: PHPUnit でテスト後半が `could not find MDB2 instance`

### DIFF
--- a/tests/class/Common_TestCase.php
+++ b/tests/class/Common_TestCase.php
@@ -41,6 +41,12 @@ class Common_TestCase extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
+        // https://github.com/EC-CUBE/ec-cube2/issues/1401 の対処
+        $key_str = serialize('');
+        if (empty($GLOBALS['_MDB2_databases']) && isset(SC_Query_Ex::$arrPoolInstance[$key_str])) {
+            unset(SC_Query_Ex::$arrPoolInstance[$key_str]);
+        }
+
         $this->objQuery = SC_Query_Ex::getSingletonInstance();
         $this->objQuery->begin();
         $this->objGenerator = new \Eccube2\Tests\Fixture\Generator($this->objQuery);


### PR DESCRIPTION
fix #1401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * テスト初期化処理を改善し、データベースプール管理に関する条件付きクリーンアップロジックを追加しました。これにより、テスト実行間での不要な状態保持を防止できます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EC-CUBE/ec-cube2/pull/1402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->