### PR TITLE
tests 継承するクラスを Common_TestCase に統一

### DIFF
--- a/tests/class/SC_Query_Test.php
+++ b/tests/class/SC_Query_Test.php
@@ -30,7 +30,7 @@
  *
  * @version $Id$
  */
-class SC_Query_Test extends PHPUnit_Framework_TestCase
+class SC_Query_Test extends Common_TestCase
 {
     /**
      * MDB2 をグローバル変数のバックアップ対象から除外する。
@@ -63,11 +63,6 @@ class SC_Query_Test extends PHPUnit_Framework_TestCase
         $this->dropTestTable();
         $this->objQuery->rollback();
         $this->objQuery = null;
-    }
-
-    protected function verify()
-    {
-        $this->assertEquals($this->expected, $this->actual);
     }
 
     /**

--- a/tests/class/batch/SC_Batch_Update_parseDistInfoTest.php
+++ b/tests/class/batch/SC_Batch_Update_parseDistInfoTest.php
@@ -3,7 +3,7 @@
 /**
  * @backupGlobals disabled
  */
-class SC_Batch_Update_parseDistInfoTest extends PHPUnit_Framework_TestCase
+class SC_Batch_Update_parseDistInfoTest extends Common_TestCase
 {
     /** @var SC_Batch_Update */
     private $batch;

--- a/tests/class/modifier/Modifier_ScriptEscapeTest.php
+++ b/tests/class/modifier/Modifier_ScriptEscapeTest.php
@@ -1,13 +1,5 @@
 <?php
-
-/**
- * (省略。アノテーションを認識されるのに必要なようなので記述している。)
- *
- * PHP 8.1 でグローバル変数が消失する不具合を回避するため、下で `backupGlobals` を指定している。本質的には PHPUnit が PHP8 に対応していないのが原因と考えられる。
- *
- * @backupGlobals disabled
- */
-class Modifier_ScriptEscapeTest extends PHPUnit_Framework_TestCase
+class Modifier_ScriptEscapeTest extends Common_TestCase
 {
     public function scriptEscapeProvider()
     {

--- a/tests/class/module/HTTP/HTTP_Request_CompatibilityTest.php
+++ b/tests/class/module/HTTP/HTTP_Request_CompatibilityTest.php
@@ -10,7 +10,7 @@ require_once __DIR__.'/Request_Legacy.php';
  * Compares the new Guzzle-based implementation with the legacy implementation
  * to ensure backward compatibility of the API.
  */
-class HTTP_Request_CompatibilityTest extends \PHPUnit\Framework\TestCase
+class HTTP_Request_CompatibilityTest extends Common_TestCase
 {
     /**
      * Test constructor defaults are the same

--- a/tests/class/module/HTTP/HTTP_Request_GuzzleTest.php
+++ b/tests/class/module/HTTP/HTTP_Request_GuzzleTest.php
@@ -8,7 +8,7 @@ require_once $HOME.'/data/module/HTTP/Request.php';
  *
  * Tests to verify backward compatibility of the Guzzle-based HTTP_Request implementation.
  */
-class HTTP_Request_GuzzleTest extends \PHPUnit\Framework\TestCase
+class HTTP_Request_GuzzleTest extends Common_TestCase
 {
     /**
      * Test constants are defined

--- a/tests/class/module/Net/Net_URLTest.php
+++ b/tests/class/module/Net/Net_URLTest.php
@@ -8,7 +8,7 @@ require_once $HOME.'/data/module/Net/URL.php';
  *
  * Tests to verify backward compatibility of the Guzzle-based Net_URL implementation.
  */
-class Net_URLTest extends \PHPUnit\Framework\TestCase
+class Net_URLTest extends Common_TestCase
 {
     /**
      * Test basic URL parsing

--- a/tests/class/module/Net/Net_URL_CompatibilityTest.php
+++ b/tests/class/module/Net/Net_URL_CompatibilityTest.php
@@ -10,7 +10,7 @@ require_once __DIR__.'/URL_Legacy.php';
  * Compares the new Guzzle-based implementation with the legacy implementation
  * to ensure backward compatibility.
  */
-class Net_URL_CompatibilityTest extends \PHPUnit\Framework\TestCase
+class Net_URL_CompatibilityTest extends Common_TestCase
 {
     /**
      * URLs to test


### PR DESCRIPTION
fix #1401

https://github.com/EC-CUBE/ec-cube2/pull/1402#issuecomment-4550783320 の情報を基に、`extends \PHPUnit\Framework\TestCase` を `extends Common_TestCase` に置換した。

`class Common_TestCase extends \PHPUnit\Framework\TestCase` なので、おそらく問題ないと見込んでいる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * テスト基盤の継承先を統一し、テスト実行環境の一貫性を向上しました。
  * 一部テスト内の冗長なヘルパーを親側に移動・削除し、共通セットアップを活用するように整理しました。
  * これによりテストの保守性と実行の安定性が向上します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EC-CUBE/ec-cube2/pull/1403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->