### PR TITLE
feat(docker): docker compose で別バージョンタグをビルド可能にする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,18 @@ volumes:
 
 services:
   ec-cube:
-    ### ローカルでビルドする場合は以下のコマンドを使用します
-    ## docker build -t ec-cube2 --no-cache --pull --build-arg TAG=8.1-apache .
-    ## docker tag ec-cube2 ghcr.io/ec-cube/ec-cube2-php:8.1-apache
+    ### 通常は image をレジストリから pull します。
+    ### 別バージョンタグをローカルでビルドする場合は TAG を指定して build を実行します:
+    ##   TAG=8.3-apache docker compose build
+    ##   TAG=8.3-apache docker compose build --no-cache   # キャッシュを使わず再ビルド
+    ##   TAG=8.3-apache docker compose up -d --build       # ビルドして起動
     image: ${REGISTRY:-ghcr.io}/${IMAGE_NAME:-ec-cube/ec-cube2-php}:${TAG:-8.1-apache}
+    pull_policy: missing       # ローカルに無ければ build ではなく pull する
+    build:
+      context: .
+      args:
+        TAG: ${TAG:-8.1-apache}
+      pull: true
     volumes:
       ### 同期対象からコストの重いフォルダを除外 #####################
       - "vendor:/var/www/app/data/vendor"


### PR DESCRIPTION
## Summary

- `docker-compose.yml` の `ec-cube` サービスに `build:` セクションを追加し、`TAG` を指定するだけで `docker compose build` から別 PHP バージョンのイメージをビルドできるようにしました。
- これまで別バージョンタグをビルドする際は `docker compose` の枠外で `docker build` + `docker tag` を手動実行していましたが、`image:` と `build:` を併記することで `docker compose build` の 1 コマンドに集約され、`TAG` を変更するだけでイメージ名と build arg (`TAG`) が同期します。
- `pull_policy: missing` を明示し、**通常の `up` ではこれまで通りレジストリ (ghcr.io) から pull する従来の挙動を維持**しています。ローカルビルドは明示的に `build` を実行したときのみ行われます。

## Changes

- `ec-cube` サービスに以下を追加:
  - `pull_policy: missing` — ローカルに無ければ build ではなく pull する
  - `build:` セクション（`context: .`、`args.TAG`、`pull: true`）
- 旧来の `docker build` / `docker tag` 手順を案内するコメントを、新しい `docker compose build` ベースの手順に更新。

## 新しい運用

```bash
# 通常起動 — ローカルに無ければ ghcr.io から pull（build しない）
docker compose up -d --wait

# 別バージョンをローカルビルド（image タグも自動付与 / docker tag 不要）
TAG=8.3-apache docker compose build
TAG=8.3-apache docker compose build --no-cache   # キャッシュなし
TAG=8.3-apache docker compose up -d --build       # ビルドして起動
```

## Test plan

検証環境: Docker Compose v5.1.4 / Docker Engine 29.4.3

- [x] `docker compose config` — 設定が妥当で `pull_policy: missing` が反映される
- [x] `TAG=8.3-apache docker compose config` — `image:` タグと build arg `TAG` の両方に伝播
- [x] `TAG=8.2-apache docker compose up --dry-run` — ローカル未取得時に **build ではなく pull** される（従来挙動を維持）
- [x] `TAG=8.2-apache docker compose build --dry-run` — 明示 build 時に Building → `ghcr.io/ec-cube/ec-cube2-php:8.2-apache` へ自動タグ付け
- [x] dry-run による network/volume/container の副作用なし

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Docker設定を更新し、ローカル環境でのイメージビルド機能を強化しました。カスタマイズ可能なパラメータにより、構築と起動プロセスがより柔軟になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->