### PR TITLE
refactor: パラメータ設定値の検証を token_get_all による構文解析に変更

### DIFF
--- a/data/class/SC_CheckError.php
+++ b/data/class/SC_CheckError.php
@@ -1795,28 +1795,39 @@ class SC_CheckError
         }
 
         // スカラ定数式に限定する。
-        // 数値 / クオート文字列 / 定数名 (true, false, null を含む) / 空白 / 開始タグ のみ許可。
-        static $allowedTypes = [
-            T_OPEN_TAG,
+        // 値となるトークンは 数値 / クオート文字列 / 定数名 (true, false, null を含む) のみ許可。
+        static $valueTypes = [
             T_LNUMBER,
             T_DNUMBER,
             T_CONSTANT_ENCAPSED_STRING,
             T_STRING,
-            T_WHITESPACE,
         ];
-        foreach ($tokens as $token) {
+        $lastIndex = count($tokens) - 1;
+        $hasValueToken = false;
+        foreach ($tokens as $index => $token) {
             if (is_array($token)) {
-                if (!in_array($token[0], $allowedTypes, true)) {
+                // 開始タグ・空白は読み飛ばす。
+                if ($token[0] === T_OPEN_TAG || $token[0] === T_WHITESPACE) {
+                    continue;
+                }
+                if (!in_array($token[0], $valueTypes, true)) {
                     return false;
                 }
-            } elseif (!in_array($token, ['.', '+', '-', ';'], true)) {
-                // 単一文字トークンは 連結 . と符号 +- と末尾 ; のみ許可。
-                // 関数呼び出しの () や文の連結はスカラ定数式ではないため除外する。
+                $hasValueToken = true;
+            } elseif ($token === ';') {
+                // 末尾 (構文解析用に付与した区切り) 以外の ; は許可しない。
+                // これにより '1;' のような複数の文や、';' 単体を排除する。
+                if ($index !== $lastIndex) {
+                    return false;
+                }
+            } elseif (!in_array($token, ['.', '+', '-'], true)) {
+                // 連結 . と符号 +- のみ許可。関数呼び出しの () 等は除外する。
                 return false;
             }
         }
 
-        return true;
+        // 値となるトークンが 1 つも無い場合 (空白のみ等) は不可。
+        return $hasValueToken;
     }
 
     /**

--- a/data/class/SC_CheckError.php
+++ b/data/class/SC_CheckError.php
@@ -1771,10 +1771,11 @@ class SC_CheckError
     /**
      * パラメーターとして適切な文字列かチェックする.(サブルーチン)
      *
+     * 値は mtb_constants.php へ define('KEY', <値>); の形で出力されるため、
+     * <値> が「スカラ定数式」(リテラル・定数・それらの連結) であることを確認する。
      * 下記を満たす場合を真とする。
-     * ・PHPコードとして評価可能であること。
-     * ・評価した結果がスカラデータ(定数に指定できる値)であること。
-     * 本メソッドの利用や改訂にあたっては、eval 関数の危険性を意識する必要がある。
+     * ・PHP として構文的に正しいこと。
+     * ・関数呼び出しや文などを含まず、スカラ定数式であること。
      *
      * @param string $value 評価する文字列
      *
@@ -1786,12 +1787,36 @@ class SC_CheckError
             return true;
         }
 
+        // 値を 1 文として構文解析する。構文エラーがあれば ParseError が送出される。
         try {
-            return (bool) @eval('return is_scalar('.$value.');');
-        } catch (\Throwable $e) {
-            // eval の構文エラーや実行時エラーは例外として扱い、バリデーション失敗とする
+            $tokens = token_get_all('<?php '.$value.';', TOKEN_PARSE);
+        } catch (\ParseError $e) {
             return false;
         }
+
+        // スカラ定数式に限定する。
+        // 数値 / クオート文字列 / 定数名 (true, false, null を含む) / 空白 / 開始タグ のみ許可。
+        static $allowedTypes = [
+            T_OPEN_TAG,
+            T_LNUMBER,
+            T_DNUMBER,
+            T_CONSTANT_ENCAPSED_STRING,
+            T_STRING,
+            T_WHITESPACE,
+        ];
+        foreach ($tokens as $token) {
+            if (is_array($token)) {
+                if (!in_array($token[0], $allowedTypes, true)) {
+                    return false;
+                }
+            } elseif (!in_array($token, ['.', '+', '-', ';'], true)) {
+                // 単一文字トークンは 連結 . と符号 +- と末尾 ; のみ許可。
+                // 関数呼び出しの () や文の連結はスカラ定数式ではないため除外する。
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/tests/class/SC_CheckError/SC_CheckError_EVAL_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_EVAL_CHECKTest.php
@@ -79,6 +79,9 @@ class SC_CheckError_EVAL_CHECKTest extends SC_CheckError_AbstractTestCase
             'バッククォート式' => ['`whoami`'],
             '変数参照' => ['$_SERVER'],
             'カンマ区切り' => ['1,2'],
+            'セミコロンのみ' => [';'],
+            '値の後のセミコロン' => ['1;'],
+            '空白のみ' => ['   '],
         ];
     }
 

--- a/tests/class/SC_CheckError/SC_CheckError_EVAL_CHECKTest.php
+++ b/tests/class/SC_CheckError/SC_CheckError_EVAL_CHECKTest.php
@@ -11,7 +11,7 @@ class SC_CheckError_EVAL_CHECKTest extends SC_CheckError_AbstractTestCase
     public function testEVALCHECK()
     {
         $this->arrForm = [
-            self::FORM_NAME => "define('AAA', 'BBB')",
+            self::FORM_NAME => '"BBB"',
         ];
         $this->expected = '';
 
@@ -19,18 +19,67 @@ class SC_CheckError_EVAL_CHECKTest extends SC_CheckError_AbstractTestCase
         $this->verify();
     }
 
-    public function testEVALCHECKWithInvalid()
+    /**
+     * スカラ定数として妥当な各種の値が許可されること.
+     *
+     * mtb_constants の実値は リテラル / 定数 / それらの連結式 のいずれかで、
+     * シングルクォート文字列も含まれる (#ffffdf 等).
+     *
+     * @dataProvider validValueProvider
+     */
+    public function testEVALCHECKWithValidValues($value)
     {
-        $this->arrForm = [
-            self::FORM_NAME => "define('AAA')",
+        $this->arrForm = [self::FORM_NAME => $value];
+        $this->expected = '';
+
+        $this->scenario();
+        $this->verify("値 [{$value}] は許可されるべき");
+    }
+
+    public function validValueProvider()
+    {
+        return [
+            'ダブルクォート文字列' => ['"BBB"'],
+            'シングルクォート文字列' => ["'BBB'"],
+            'カラーコード(シングルクォート)' => ["'#ffffdf'"],
+            '整数' => ['7200'],
+            '負の整数' => ['-1'],
+            '真偽値' => ['false'],
+            '定数参照' => ['SMTEXT_LEN'],
+            '定数の連結式' => ['HTML_REALDIR . USER_DIR'],
+            '文字列と定数の連結' => ['DATA_REALDIR . "cache/"'],
         ];
-        if (PHP_VERSION_ID >= 80000) {
-            $this->markTestSkipped('ArgumentCountError in PHP8');
-        }
+    }
+
+    /**
+     * 関数呼び出し・文の連結・変数等を含む値が拒否されること.
+     *
+     * mtb_constants の値はスカラ定数式 (リテラル / 定数 / それらの連結) に限られるため、
+     * 関数呼び出しや複数の文を含む値はバリデーションエラーとなる.
+     *
+     * @dataProvider invalidValueProvider
+     */
+    public function testEVALCHECKWithInvalidValues($value)
+    {
+        $this->arrForm = [self::FORM_NAME => $value];
         $this->expected = '※ form の形式が不正です。<br />';
 
         $this->scenario();
-        $this->verify();
+        $this->verify("値 [{$value}] は拒否されるべき");
+    }
+
+    public function invalidValueProvider()
+    {
+        return [
+            '関数呼び出し(define)' => ["define('AAA', 'BBB')"],
+            '引数不足のdefine' => ["define('AAA')"],
+            '括弧の不整合と文の連結' => ['0) || system($_GET[c]); //'],
+            '複数の文' => ['1; phpinfo()'],
+            '関数の呼び出し' => ["system('id')"],
+            'バッククォート式' => ['`whoami`'],
+            '変数参照' => ['$_SERVER'],
+            'カンマ区切り' => ['1,2'],
+        ];
     }
 
     public function testEVALCHECKWithEmpty()


### PR DESCRIPTION
## Summary

システム設定 > パラメーター設定 (`LC_Page_Admin_System_Parameter`) の値検証を担う `SC_CheckError::evalCheck()` を、`eval()` による評価から `token_get_all(..., TOKEN_PARSE)` を用いた構文解析に変更します。

パラメーター値は `data/cache/mtb_constants.php` へ `define('KEY', <値>);` の形で出力され、各リクエストで読み込まれます。そのため `<値>` が **スカラ定数式**(リテラル / 定数 / それらの連結式)として成立することを、値を実行せずに確認します。

### 変更点

- `evalCheck()` を `eval('return is_scalar(...)')` から、`token_get_all(TOKEN_PARSE)` による構文解析 + トークンの許可リストに変更
  - 数値 / クオート文字列 / 定数名 (`true`/`false`/`null` 含む) / 連結 (`.`) / 符号 (`+`/`-`) のみ許可
  - 関数呼び出し・複数の文・変数などスカラ定数式でない値は許可しない
- `mtb_constants_init.php` の既定値 245 件、およびシングル / ダブルクォート文字列はいずれも従来どおり許可されます
- `SC_CheckError_EVAL_CHECKTest` にスカラ定数式・非スカラ式のデータプロバイダを追加

### 補足

`define('AAA', 'BBB')` のような関数呼び出しは、旧実装では `is_scalar()` の評価結果が `true` になるため許可されていましたが、スカラ定数式ではないため本変更では許可しません。`mtb_constants` の実値に該当するものはありません。

## Test plan

- [x] `tests/class/SC_CheckError/SC_CheckError_EVAL_CHECKTest.php` (24 tests) 通過
- [x] `tests/class/pages/admin/system/LC_Page_Admin_System_ParameterTest.php` 通過
- [x] PHPUnit 全テスト通過 (MySQL, 1814 tests OK)
- [ ] PHPUnit 全テスト通過 (PostgreSQL)
- [ ] 管理画面のパラメーター設定で各種の値が保存でき、不正な値はバリデーションエラーになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 定数値検証の判定基準を見直し、出力される定数が「スカラ定数式」（許可されたリテラル・定数・連結のみ）であることを厳密に確認するよう改善しました。構文エラー時は安全に誤判定しない挙動に変更しました。

* **Tests**
  * 有効／無効のパターンをデータ駆動で網羅するテストを追加・拡充し、入力変更に合わせて検証シナリオを整理しました。旧実装の条件付きテストは整理・削除し、エラー期待値を統一しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->