### PR TITLE
ci: codecov の GPG 署名検証失敗を PyPI 版 CLI で回避する

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -117,3 +117,6 @@ jobs:
         flags: tests
         # yml: ./codecov.yml
         fail_ci_if_error: true
+        # cli.codecov.io のバイナリは GPG 公開鍵を取得できず署名検証が
+        # "No public key" で失敗するため、PyPI 版 CLI を使い検証経路を回避する
+        use_pypi: true


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

cli.codecov.io のバイナリで GPG 公開鍵を取得できず署名検証が `"No public key"` で失敗し、coverage アップロードが落ちる問題に対応します。

- `.github/workflows/coverage.yml` の codecov-action に `use_pypi: true` を追加し、PyPI 版 CLI を使うことで署名検証経路を回避します。

## 方針(Policy)

本家 ec-cube の PR [EC-CUBE/ec-cube#6830](https://github.com/EC-CUBE/ec-cube/pull/6830) と同じ問題が ec-cube2 でも発生しているため、同じ対応を適用しました。

## 実装に関する補足(Appendix)

ec-cube2 で codecov-action を使用しているのは `coverage.yml` の `Upload coverage` ステップ 1 箇所のみです（`rg "codecov" .github/` で確認済み）。

## テスト（Test)

- [ ] CI の coverage ジョブで codecov アップロードが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions ワークフロー設定を改善し、CI/CD パイプラインの信頼性を向上させました。（ユーザー向けの変更はありません）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->