### PR TITLE
存在しない郵便番号jsの読み込みを削除

### DIFF
--- a/data/Smarty/templates/default/site_frame.tpl
+++ b/data/Smarty/templates/default/site_frame.tpl
@@ -74,7 +74,6 @@
 <!--{/strip}-->
 
 <script type="text/javascript" src="https://ajaxzip3.github.io/ajaxzip3.js"></script>
-<script type="text/javascript" src="/js/plg_ajaxzip3.js"></script
 </head>
 
 <!-- ▼BODY部 スタート -->

--- a/data/Smarty/templates/default/site_frame.tpl
+++ b/data/Smarty/templates/default/site_frame.tpl
@@ -73,7 +73,6 @@
     <!--{* ▲Head COLUMN*}-->
 <!--{/strip}-->
 
-<script type="text/javascript" src="https://ajaxzip3.github.io/ajaxzip3.js"></script>
 </head>
 
 <!-- ▼BODY部 スタート -->


### PR DESCRIPTION
おそらくtypo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * 郵便番号入力補助に関連する不要な外部・ローカルスクリプトの読み込みを削除しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->