### PR TITLE
fix: 値引按分の丸め誤差を既定税率へ正しく寄せる

### DIFF
--- a/data/class/helper/SC_Helper_TaxRule.php
+++ b/data/class/helper/SC_Helper_TaxRule.php
@@ -81,19 +81,14 @@ class SC_Helper_TaxRule
      */
     public static function getTaxPerTaxRate(array $arrTaxInclusiveTotalByRate, $discount_total = 0)
     {
-        /**
-         * @var array このメソッドの戻り値
-         */
-        $arrReturn = [];
-
         if (empty($arrTaxInclusiveTotalByRate)) {
-            goto do_return;
+            return [];
         }
 
         // 端数処理方法(calc_rule)と既定の税率(tax_rate)は用途が異なるため別変数に分ける
         [
             'calc_rule' => $default_calc_rule,
-            'tax_rate'  => $default_tax_rate,
+            'tax_rate' => $default_tax_rate,
         ] = static::getTaxRule();
 
         ksort($arrTaxInclusiveTotalByRate, SORT_NUMERIC);
@@ -105,9 +100,13 @@ class SC_Helper_TaxRule
 
         // 按分後の値引額の合計（8%対象商品の按分後の値引額 ＋ 10%対象商品の按分後の値引額）が実際の値引額より＋－1円となる事への対処
         // ①按分した値引き額を四捨五入で丸める
-        $total = array_sum($arrTaxInclusiveTotalByRate);
+        // round() は float を返すため、int にキャストしてから合算する
+        // (float のままだと後続の $diff が float 化し、$diff !== 0 が常に true になる)
+        $total_all = array_sum($arrTaxInclusiveTotalByRate);
         foreach ($arrTaxInclusiveTotalByRate as $rate => $total_by_rate) {
-            $arrDividedDiscount[$rate] = ($total == 0) ? 0 : round($discount_total * $total_by_rate / $total, 0);
+            $arrDividedDiscount[$rate] = ($total_all === 0)
+                ? 0
+                : (int) round($discount_total * $total_by_rate / $total_all, 0);
         }
         // ②四捨五入したとしても、四捨五入前の値引額がそれぞれ 16.5 + 75.5 の場合 →(四捨五入端数処理)→ 17 + 76 両方繰り上がる事への対処
         $diff = $discount_total - array_sum($arrDividedDiscount);
@@ -120,18 +119,21 @@ class SC_Helper_TaxRule
             $arrDividedDiscount[$adjust_rate] += $diff;
         }
 
+        /**
+         * @var array このメソッドの戻り値
+         */
+        $arrReturn = [];
+
         // 戻り値をセットする。
         foreach ($arrTaxInclusiveTotalByRate as $rate => $total_by_rate) {
             $discounted_total_by_rate = $total_by_rate - $arrDividedDiscount[$rate];
             $tax = $discounted_total_by_rate * ($rate / (100 + $rate));
             $arrReturn[$rate] = [
-                'discount' => (int) $arrDividedDiscount[$rate],
+                'discount' => $arrDividedDiscount[$rate],
                 'total' => (int) $discounted_total_by_rate,
                 'tax' => (int) static::roundByCalcRule($tax, $default_calc_rule),
             ];
         }
-
-        do_return:
 
         return $arrReturn;
     }
@@ -141,14 +143,14 @@ class SC_Helper_TaxRule
      *
      * 複数の税率がある場合は改行で区切る.
      *
-     * @param array{8?:int, 10?:int} $arrTaxableTotal 税率ごとのお支払い合計金額
+     * @param array{8?:int, 10?:int} $arrTaxInclusiveTotalByRate 税率ごとの税込み合計金額
      * @param int $discount_total 値引額合計
      *
      * @return string (<税率>%対象: <値引後税込合計>円 内消費税: <値引後税額>円)
      */
-    public static function getTaxDetail(array $arrTaxableTotal, $discount_total = 0)
+    public static function getTaxDetail(array $arrTaxInclusiveTotalByRate, $discount_total = 0)
     {
-        $arrTaxPerTaxRate = static::getTaxPerTaxRate($arrTaxableTotal, $discount_total);
+        $arrTaxPerTaxRate = static::getTaxPerTaxRate($arrTaxInclusiveTotalByRate, $discount_total);
         $result = '';
         foreach ($arrTaxPerTaxRate as $rate => $item) {
             $result .= '('.$rate.'%対象: '.number_format($item['total']).'円 内消費税: '.number_format($item['tax']).'円)'.PHP_EOL;

--- a/data/class/helper/SC_Helper_TaxRule.php
+++ b/data/class/helper/SC_Helper_TaxRule.php
@@ -31,6 +31,19 @@
 class SC_Helper_TaxRule
 {
     /**
+     * 税率設定のキャッシュ.
+     *
+     * getTaxRule() は複数回呼び出されるためキャッシュする.
+     * dtb_tax_rule を更新するメソッドから clearTaxRuleCache() でクリアする.
+     *
+     * @var array
+     *
+     * @see SC_Helper_TaxRule::getTaxRule()
+     * @see SC_Helper_TaxRule::clearTaxRuleCache()
+     */
+    private static $arrTaxRuleCache = [];
+
+    /**
      * 設定情報に基づいて税金付与した金額を返す
      *
      * @param int $price 計算対象の金額
@@ -224,9 +237,6 @@ class SC_Helper_TaxRule
      */
     public static function getTaxRule($product_id = 0, $product_class_id = 0, $pref_id = 0, $country_id = 0, $option_product_tax_rule = OPTION_PRODUCT_TAX_RULE)
     {
-        // 複数回呼出があるのでキャッシュ化
-        static $data_c = [];
-
         // 初期化
         $product_id = $product_id > 0 ? $product_id : 0;
         $product_class_id = $product_class_id > 0 ? $product_class_id : 0;
@@ -240,7 +250,8 @@ class SC_Helper_TaxRule
             $cache_key = "$pref_id,$country_id";
         }
 
-        if (empty($data_c[$cache_key])) {
+        // 複数回呼出があるのでキャッシュ化
+        if (empty(self::$arrTaxRuleCache[$cache_key])) {
             // ログイン済み会員で国と地域指定が無い場合は、会員情報をデフォルトで利用。管理画面では利用しない
             if (!(defined('ADMIN_FUNCTION') && ADMIN_FUNCTION == true)) {
                 $objCustomer = new SC_Customer_Ex();
@@ -322,10 +333,25 @@ class SC_Helper_TaxRule
             }
             // XXXX: 互換性のためtax_ruleにもcalc_ruleを設定
             $arrRet['tax_rule'] = $arrRet['calc_rule'];
-            $data_c[$cache_key] = $arrRet;
+            self::$arrTaxRuleCache[$cache_key] = $arrRet;
         }
 
-        return $data_c[$cache_key];
+        return self::$arrTaxRuleCache[$cache_key];
+    }
+
+    /**
+     * 税率設定のキャッシュをクリアする.
+     *
+     * dtb_tax_rule を更新した後に呼び出し、getTaxRule() が更新後の設定を
+     * 返すようにする.
+     *
+     * @return void
+     *
+     * @see SC_Helper_TaxRule::getTaxRule()
+     */
+    public static function clearTaxRuleCache()
+    {
+        self::$arrTaxRuleCache = [];
     }
 
     /**
@@ -417,6 +443,9 @@ class SC_Helper_TaxRule
             $where = 'tax_rule_id = ?';
             $objQuery->update($table, $arrValues, $where, [$tax_rule_id]);
         }
+
+        // 更新後の設定を getTaxRule() が返すようにキャッシュをクリアする
+        self::clearTaxRuleCache();
     }
 
     /**
@@ -491,6 +520,9 @@ class SC_Helper_TaxRule
         $sqlval['update_date'] = 'CURRENT_TIMESTAMP';
         $where = 'tax_rule_id = ?';
         $objQuery->update('dtb_tax_rule', $sqlval, $where, [$tax_rule_id]);
+
+        // 削除後の設定を getTaxRule() が返すようにキャッシュをクリアする
+        self::clearTaxRuleCache();
     }
 
     /**

--- a/data/class/helper/SC_Helper_TaxRule.php
+++ b/data/class/helper/SC_Helper_TaxRule.php
@@ -65,65 +65,75 @@ class SC_Helper_TaxRule
     }
 
     /**
-     * 消費税の内訳を返す.
+     * 税率ごとの消費税の内訳を返す.
      *
      * 税率ごとに以下のような連想配列を返す.
-     * - discount: 税率毎の値引額
+     * - discount: 税率ごとの値引額
      * - total: 値引後の税込み合計金額
      * - tax: 値引後の税額
      * 値引額合計は税率ごとに按分する.
      * 課税規則は標準税率の設定を使用する.
      *
-     * @param array{8?:int, 10?:int} $arrTaxableTotal 税率ごとのお支払い合計金額
+     * @param array{8?:int, 10?:int} $arrTaxInclusiveTotalByRate 税率ごとの税込み合計金額
      * @param int $discount_total 値引額合計
      *
      * @return array{8?:array{discount;int,total:int,tax:int}, 10?:array{discount;int,total:int,tax:int}}
      */
-    public static function getTaxPerTaxRate($arrTaxableTotal, $discount_total = 0)
+    public static function getTaxPerTaxRate(array $arrTaxInclusiveTotalByRate, $discount_total = 0)
     {
-        $arrDefaultTaxRule = static::getTaxRule();
+        /**
+         * @var array このメソッドの戻り値
+         */
+        $arrReturn = [];
 
-        ksort($arrTaxableTotal);
-        $cf_discount = 0;
-        $taxable_total = array_sum($arrTaxableTotal);
-        $divide = [];
-        $result = [];
+        if (empty($arrTaxInclusiveTotalByRate)) {
+            goto do_return;
+        }
 
         // 端数処理方法(calc_rule)と既定の税率(tax_rate)は用途が異なるため別変数に分ける
-        $defaultCalcRule = $arrDefaultTaxRule['calc_rule'];
-        $defaultTaxRate = $arrDefaultTaxRule['tax_rate'];
+        [
+            'calc_rule' => $default_calc_rule,
+            'tax_rate'  => $default_tax_rate,
+        ] = static::getTaxRule();
+
+        ksort($arrTaxInclusiveTotalByRate, SORT_NUMERIC);
+
+        /**
+         * @var array 税率ごとに按分された値引額
+         */
+        $arrDividedDiscount = [];
 
         // 按分後の値引額の合計（8%対象商品の按分後の値引額 ＋ 10%対象商品の按分後の値引額）が実際の値引額より＋－1円となる事への対処
         // ①按分した値引き額を四捨五入で丸める
-        foreach ($arrTaxableTotal as $rate => $total) {
-            $discount[$rate] = $taxable_total !== 0 ? round($discount_total * $total / $taxable_total, 0) : 0;
-            $divide[$rate] = [
-                'discount' => (int) $discount[$rate],
-            ];
-            $cf_discount += $divide[$rate]['discount'];
+        $total = array_sum($arrTaxInclusiveTotalByRate);
+        foreach ($arrTaxInclusiveTotalByRate as $rate => $total_by_rate) {
+            $arrDividedDiscount[$rate] = ($total == 0) ? 0 : round($discount_total * $total_by_rate / $total, 0);
         }
-        // ②四捨五入したとしても、四捨五入前の値引額がそれぞれ 16.5 + 75.5 の場合 →(四捨五入端数処理)→ 17 + 76 両方繰り上がる。事への対処
-        // 丸めで生じた誤差を既定税率のバケットへ寄せ、按分後の値引額の合計を実際の値引額に一致させる
-        $diff = $discount_total - $cf_discount;
-        if ($diff !== 0 && !empty($divide)) {
+        // ②四捨五入したとしても、四捨五入前の値引額がそれぞれ 16.5 + 75.5 の場合 →(四捨五入端数処理)→ 17 + 76 両方繰り上がる事への対処
+        $diff = $discount_total - array_sum($arrDividedDiscount);
+        if ($diff !== 0) {
+            // 丸めで生じた誤差を既定税率のバケットへ寄せ、按分後の値引額の合計を実際の値引額に一致させる
             // 既定税率の商品が無い受注では、金額が最大のバケットへ寄せる
-            $adjustRate = isset($divide[$defaultTaxRate])
-                ? $defaultTaxRate
-                : array_keys($arrTaxableTotal, max($arrTaxableTotal))[0];
-            $divide[$adjustRate]['discount'] += $diff;
+            $adjust_rate = isset($arrDividedDiscount[$default_tax_rate])
+                ? $default_tax_rate
+                : array_keys($arrTaxInclusiveTotalByRate, max($arrTaxInclusiveTotalByRate))[0];
+            $arrDividedDiscount[$adjust_rate] += $diff;
         }
 
-        foreach ($arrTaxableTotal as $rate => $total) {
-            $reduced_total = $total - $divide[$rate]['discount'];
-            $tax = $reduced_total * ($rate / (100 + $rate));
-            $result[$rate] = [
-                'discount' => (int) $divide[$rate]['discount'],
-                'total' => (int) $reduced_total,
-                'tax' => (int) static::roundByCalcRule($tax, $defaultCalcRule),
+        // 戻り値をセットする。
+        foreach ($arrTaxInclusiveTotalByRate as $rate => $total_by_rate) {
+            $discounted_total_by_rate = $total_by_rate - $arrDividedDiscount[$rate];
+            $tax = $discounted_total_by_rate * ($rate / (100 + $rate));
+            $arrReturn[$rate] = [
+                'discount' => (int) $arrDividedDiscount[$rate],
+                'total' => (int) $discounted_total_by_rate,
+                'tax' => (int) static::roundByCalcRule($tax, $default_calc_rule),
             ];
         }
 
-        return $result;
+        do_return:
+
+        return $arrReturn;
     }
 
     /**
@@ -136,7 +146,7 @@ class SC_Helper_TaxRule
      *
      * @return string (<税率>%対象: <値引後税込合計>円 内消費税: <値引後税額>円)
      */
-    public static function getTaxDetail($arrTaxableTotal, $discount_total = 0)
+    public static function getTaxDetail(array $arrTaxableTotal, $discount_total = 0)
     {
         $arrTaxPerTaxRate = static::getTaxPerTaxRate($arrTaxableTotal, $discount_total);
         $result = '';

--- a/data/class/helper/SC_Helper_TaxRule.php
+++ b/data/class/helper/SC_Helper_TaxRule.php
@@ -89,6 +89,10 @@ class SC_Helper_TaxRule
         $divide = [];
         $result = [];
 
+        // 端数処理方法(calc_rule)と既定の税率(tax_rate)は用途が異なるため別変数に分ける
+        $defaultCalcRule = $arrDefaultTaxRule['calc_rule'];
+        $defaultTaxRate = $arrDefaultTaxRule['tax_rate'];
+
         // 按分後の値引額の合計（8%対象商品の按分後の値引額 ＋ 10%対象商品の按分後の値引額）が実際の値引額より＋－1円となる事への対処
         // ①按分した値引き額を四捨五入で丸める
         foreach ($arrTaxableTotal as $rate => $total) {
@@ -99,26 +103,23 @@ class SC_Helper_TaxRule
             $cf_discount += $divide[$rate]['discount'];
         }
         // ②四捨五入したとしても、四捨五入前の値引額がそれぞれ 16.5 + 75.5 の場合 →(四捨五入端数処理)→ 17 + 76 両方繰り上がる。事への対処
-        $defaultTaxRule = $arrDefaultTaxRule['calc_rule'];
+        // 丸めで生じた誤差を既定税率のバケットへ寄せ、按分後の値引額の合計を実際の値引額に一致させる
         $diff = $discount_total - $cf_discount;
-        if ($diff > 0) {
-            $divide[$defaultTaxRule]['discount'] += $diff;
-        } elseif ($diff < 0) {
-            $divide[$defaultTaxRule]['discount'] -= $diff;
+        if ($diff !== 0 && !empty($divide)) {
+            // 既定税率の商品が無い受注では、金額が最大のバケットへ寄せる
+            $adjustRate = isset($divide[$defaultTaxRate])
+                ? $defaultTaxRate
+                : array_keys($arrTaxableTotal, max($arrTaxableTotal))[0];
+            $divide[$adjustRate]['discount'] += $diff;
         }
 
         foreach ($arrTaxableTotal as $rate => $total) {
-            if ($rate == $defaultTaxRule) {
-                $discount[$rate] = $divide[$defaultTaxRule]['discount'];
-            } else {
-                $discount[$rate] = $taxable_total !== 0 ? round($discount_total * $total / $taxable_total, 0) : 0;
-            }
-            $reduced_total = $total - $discount[$rate];
+            $reduced_total = $total - $divide[$rate]['discount'];
             $tax = $reduced_total * ($rate / (100 + $rate));
             $result[$rate] = [
-                'discount' => (int) $discount[$rate],
+                'discount' => (int) $divide[$rate]['discount'],
                 'total' => (int) $reduced_total,
-                'tax' => (int) static::roundByCalcRule($tax, $defaultTaxRule),
+                'tax' => (int) static::roundByCalcRule($tax, $defaultCalcRule),
             ];
         }
 

--- a/data/class/helper/SC_Helper_TaxRule.php
+++ b/data/class/helper/SC_Helper_TaxRule.php
@@ -36,12 +36,16 @@ class SC_Helper_TaxRule
      * getTaxRule() は複数回呼び出されるためキャッシュする.
      * dtb_tax_rule を更新するメソッドから clearTaxRuleCache() でクリアする.
      *
+     * _Ex クラスで clearTaxRuleCache() をオーバーライドした場合にも操作できるよう
+     * protected とする (private だとオーバーライド側からクリアできず、キャッシュが
+     * 無効化されないまま残る).
+     *
      * @var array
      *
      * @see SC_Helper_TaxRule::getTaxRule()
      * @see SC_Helper_TaxRule::clearTaxRuleCache()
      */
-    private static $arrTaxRuleCache = [];
+    protected static $arrTaxRuleCache = [];
 
     /**
      * 設定情報に基づいて税金付与した金額を返す
@@ -445,7 +449,7 @@ class SC_Helper_TaxRule
         }
 
         // 更新後の設定を getTaxRule() が返すようにキャッシュをクリアする
-        self::clearTaxRuleCache();
+        static::clearTaxRuleCache();
     }
 
     /**
@@ -522,7 +526,7 @@ class SC_Helper_TaxRule
         $objQuery->update('dtb_tax_rule', $sqlval, $where, [$tax_rule_id]);
 
         // 削除後の設定を getTaxRule() が返すようにキャッシュをクリアする
-        self::clearTaxRuleCache();
+        static::clearTaxRuleCache();
     }
 
     /**

--- a/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxDetailTest.php
+++ b/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxDetailTest.php
@@ -2,7 +2,7 @@
 
 require __DIR__.'/SC_Helper_TaxRule_TestBase.php';
 
-class SC_Helper_TaxRule_getDetailTest extends SC_Helper_TaxRule_TestBase
+class SC_Helper_TaxRule_getTaxDetailTest extends SC_Helper_TaxRule_TestBase
 {
     private $taxs = [];
 

--- a/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxDetailTest.php
+++ b/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxDetailTest.php
@@ -558,11 +558,261 @@ class SC_Helper_TaxRule_getTaxDetailTest extends SC_Helper_TaxRule_TestBase
         self::assertSame(array_sum($arrTaxableTotal) - $discount_total, $actual[8]['total'] + $actual[10]['total']);
     }
 
+    /**
+     * 空の税込み合計金額を渡した場合は空配列を返す.
+     */
+    public function testGetTaxPerTaxRateWithEmptyArray()
+    {
+        $this->setUpDefaultTaxRule();
+
+        self::assertSame([], SC_Helper_TaxRule_Ex::getTaxPerTaxRate([], 100));
+        self::assertSame('', SC_Helper_TaxRule_Ex::getTaxDetail([], 100));
+    }
+
+    /**
+     * 既定税率(10%)の商品が無い受注では、誤差を金額が最大のバケットへ寄せる.
+     *
+     * 8%対象 1,000円 / 5%対象 3,000円 / 値引 2円 のとき、按分前の値引額は
+     * 5%: 1.5円, 8%: 0.5円 となり、四捨五入で両方繰り上がって 2 + 1 = 3円。
+     * 既定税率(10%)のバケットが存在しないため、誤差(-1円)は金額が最大の
+     * 5%(3,000円)側へ寄せられ、5%の値引額は 2 - 1 = 1円 となる。
+     */
+    public function testGetTaxPerTaxRateWithoutDefaultTaxRate()
+    {
+        $this->setUpDefaultTaxRule();
+
+        $arrTaxInclusiveTotalByRate = [
+            8 => 1000,
+            5 => 3000,
+        ];
+        $discount_total = 2;
+
+        $actual = SC_Helper_TaxRule_Ex::getTaxPerTaxRate($arrTaxInclusiveTotalByRate, $discount_total);
+
+        self::assertSame(
+            [
+                5 => [
+                    'discount' => 1,
+                    'total' => 2999,
+                    'tax' => 143,
+                ],
+                8 => [
+                    'discount' => 1,
+                    'total' => 999,
+                    'tax' => 74,
+                ],
+            ],
+            $actual
+        );
+
+        self::assertSame(
+            $discount_total,
+            array_sum(array_column($actual, 'discount')),
+            '按分後の値引額の合計が実際の値引額と一致していません'
+        );
+        self::assertSame(
+            array_sum($arrTaxInclusiveTotalByRate) - $discount_total,
+            array_sum(array_column($actual, 'total')),
+            '値引後合計の総和が支払額と一致していません'
+        );
+    }
+
+    /**
+     * 丸め誤差が正方向(+1円)に出る場合の補正.
+     *
+     * 8%対象 3,000円 / 10%対象 3,000円 / 5%対象 3,000円 に 1円値引すると、
+     * 按分前の値引額は各 0.333円 で、四捨五入すると全て 0円 に落ち、
+     * 合計 0円 が実際の値引額(1円)より 1円 少なくなる。
+     * 誤差(+1円)を既定税率(10%)側へ寄せて合計を一致させる。
+     *
+     * 3 税率が同一受注に現れることは実運用では無い。2 税率では按分前の端数の和が
+     * 必ず整数になるため丸め誤差は 0 か -1円 にしかならず、正方向の補正を通せない。
+     * ここでは getTaxPerTaxRate() が税率数に依存しない実装であることを利用して、
+     * 3 税率を入力することで正方向の補正のみを検証する。
+     */
+    public function testGetTaxPerTaxRateWithPositiveDiff()
+    {
+        $this->setUpDefaultTaxRule();
+
+        $arrTaxInclusiveTotalByRate = [
+            8 => 3000,
+            10 => 3000,
+            5 => 3000,
+        ];
+        $discount_total = 1;
+
+        $actual = SC_Helper_TaxRule_Ex::getTaxPerTaxRate($arrTaxInclusiveTotalByRate, $discount_total);
+
+        self::assertSame(
+            [
+                5 => [
+                    'discount' => 0,
+                    'total' => 3000,
+                    'tax' => 143,
+                ],
+                8 => [
+                    'discount' => 0,
+                    'total' => 3000,
+                    'tax' => 222,
+                ],
+                10 => [
+                    'discount' => 1,
+                    'total' => 2999,
+                    'tax' => 273,
+                ],
+            ],
+            $actual
+        );
+
+        self::assertSame(
+            $discount_total,
+            array_sum(array_column($actual, 'discount')),
+            '按分後の値引額の合計が実際の値引額と一致していません'
+        );
+        self::assertSame(
+            array_sum($arrTaxInclusiveTotalByRate) - $discount_total,
+            array_sum(array_column($actual, 'total')),
+            '値引後合計の総和が支払額と一致していません'
+        );
+    }
+
+    /**
+     * 単一税率の受注では、値引額がそのまま単一のバケットに割り当てられる.
+     */
+    public function testGetTaxPerTaxRateWithSingleTaxRate()
+    {
+        $this->setUpDefaultTaxRule();
+
+        $arrTaxInclusiveTotalByRate = [
+            8 => 1000,
+        ];
+        $discount_total = 3;
+
+        $actual = SC_Helper_TaxRule_Ex::getTaxPerTaxRate($arrTaxInclusiveTotalByRate, $discount_total);
+
+        self::assertSame(
+            [
+                8 => [
+                    'discount' => 3,
+                    'total' => 997,
+                    'tax' => 74,
+                ],
+            ],
+            $actual
+        );
+
+        self::assertSame(
+            '(8%対象: 997円 内消費税: 74円)'.PHP_EOL,
+            SC_Helper_TaxRule_Ex::getTaxDetail($arrTaxInclusiveTotalByRate, $discount_total)
+        );
+    }
+
+    /**
+     * 値引が無い受注では、値引額は 0円 で税込み合計金額がそのまま残る.
+     */
+    public function testGetTaxPerTaxRateWithoutDiscount()
+    {
+        $this->setUpDefaultTaxRule();
+
+        $arrTaxInclusiveTotalByRate = [
+            10 => 5000,
+            8 => 5000,
+        ];
+
+        // $discount_total は既定値(0)を使用する
+        $actual = SC_Helper_TaxRule_Ex::getTaxPerTaxRate($arrTaxInclusiveTotalByRate);
+
+        self::assertSame(
+            [
+                8 => [
+                    'discount' => 0,
+                    'total' => 5000,
+                    'tax' => 370,
+                ],
+                10 => [
+                    'discount' => 0,
+                    'total' => 5000,
+                    'tax' => 455,
+                ],
+            ],
+            $actual
+        );
+    }
+
+    /**
+     * 誤差の寄せ先が複数該当する場合は、税率が最も小さいバケットへ寄せる.
+     *
+     * 5%対象 5,000円 / 10%対象以外の 8%対象 5,000円 に 1円値引すると、
+     * 按分前の値引額は両税率とも 0.5円 で、四捨五入すると 1 + 1 = 2円 となり
+     * 誤差(-1円)が生じる。既定税率(10%)のバケットが無く、かつ金額が同額のため
+     * 寄せ先の候補が 2 つになるが、ksort 後の先頭(=最も小さい税率)に寄せる.
+     */
+    public function testGetTaxPerTaxRateWithSameTotals()
+    {
+        $this->setUpDefaultTaxRule();
+
+        $arrTaxInclusiveTotalByRate = [
+            8 => 5000,
+            5 => 5000,
+        ];
+        $discount_total = 1;
+
+        $actual = SC_Helper_TaxRule_Ex::getTaxPerTaxRate($arrTaxInclusiveTotalByRate, $discount_total);
+
+        self::assertSame(
+            [
+                5 => [
+                    'discount' => 0,
+                    'total' => 5000,
+                    'tax' => 238,
+                ],
+                8 => [
+                    'discount' => 1,
+                    'total' => 4999,
+                    'tax' => 370,
+                ],
+            ],
+            $actual
+        );
+
+        self::assertSame(
+            $discount_total,
+            array_sum(array_column($actual, 'discount')),
+            '按分後の値引額の合計が実際の値引額と一致していません'
+        );
+        self::assertSame(
+            array_sum($arrTaxInclusiveTotalByRate) - $discount_total,
+            array_sum(array_column($actual, 'total')),
+            '値引後合計の総和が支払額と一致していません'
+        );
+    }
+
     protected function setUpTaxRule(array $taxs = [])
     {
         $this->objQuery->delete('dtb_tax_rule');
         foreach ($taxs as $key => $item) {
             $this->objQuery->insert('dtb_tax_rule', $item);
         }
+    }
+
+    /**
+     * 既定の税率設定(10% / 四捨五入)を登録する.
+     */
+    protected function setUpDefaultTaxRule()
+    {
+        $this->setUpTaxRule([
+            [
+                'tax_rule_id' => 1004,
+                'apply_date' => '2019-10-01 00:00:00',
+                'tax_rate' => '10',
+                'calc_rule' => '1',
+                'product_id' => '0',
+                'product_class_id' => '0',
+                'del_flg' => '0',
+                'member_id' => 1,
+                'create_date' => '2000-01-01 00:00:00',
+                'update_date' => '2000-01-01 00:00:00',
+            ],
+        ]);
     }
 }

--- a/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxDetailTest.php
+++ b/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxDetailTest.php
@@ -110,15 +110,8 @@ class SC_Helper_TaxRule_getTaxDetailTest extends SC_Helper_TaxRule_TestBase
         );
     }
 
-    /**
-     * @runInSeparateProcess
-     *
-     * @preserveGlobalState disabled
-     */
     public function testGetTaxPerTaxRateWithFloor()
     {
-        self::markTestSkipped('Skip this test because @runInSeparateProcess does not work properly');
-
         $this->setUpTaxRule([
             [
                 'tax_rule_id' => 1004,
@@ -160,15 +153,8 @@ class SC_Helper_TaxRule_getTaxDetailTest extends SC_Helper_TaxRule_TestBase
         self::assertSame(array_sum($arrTaxableTotal) - $discount_total, $actual[8]['total'] + $actual[10]['total']);
     }
 
-    /**
-     * @runInSeparateProcess
-     *
-     * @preserveGlobalState disabled
-     */
     public function testGetTaxPerTaxRateWithCeil()
     {
-        self::markTestSkipped('Skip this test because @runInSeparateProcess does not work properly');
-
         $this->setUpTaxRule([
             [
                 'tax_rule_id' => 1004,
@@ -456,15 +442,9 @@ class SC_Helper_TaxRule_getTaxDetailTest extends SC_Helper_TaxRule_TestBase
 
     /**
      * @see https://github.com/EC-CUBE/ec-cube2/pull/762#issuecomment-1897799676
-     *
-     * @runInSeparateProcess
-     *
-     * @preserveGlobalState disabled
      */
     public function testGetTaxPerTaxRateWithFloor2()
     {
-        self::markTestSkipped('Skip this test because @runInSeparateProcess does not work properly');
-
         $this->setUpTaxRule([
             [
                 'tax_rule_id' => 1004,
@@ -508,15 +488,9 @@ class SC_Helper_TaxRule_getTaxDetailTest extends SC_Helper_TaxRule_TestBase
 
     /**
      * @see https://github.com/EC-CUBE/ec-cube2/pull/762#issuecomment-1897799676
-     *
-     * @runInSeparateProcess
-     *
-     * @preserveGlobalState disabled
      */
     public function testGetTaxPerTaxRateWithCeil2()
     {
-        self::markTestSkipped('Skip this test because @runInSeparateProcess does not work properly');
-
         $this->setUpTaxRule([
             [
                 'tax_rule_id' => 1004,
@@ -793,6 +767,9 @@ class SC_Helper_TaxRule_getTaxDetailTest extends SC_Helper_TaxRule_TestBase
         foreach ($taxs as $key => $item) {
             $this->objQuery->insert('dtb_tax_rule', $item);
         }
+
+        // getTaxRule() のキャッシュが残っていると、直前のテストの税率設定が返るためクリアする
+        SC_Helper_TaxRule_Ex::clearTaxRuleCache();
     }
 
     /**

--- a/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxDetailTest.php
+++ b/tests/class/helper/SC_Helper_TaxRule/SC_Helper_TaxRule_getTaxDetailTest.php
@@ -263,6 +263,198 @@ class SC_Helper_TaxRule_getDetailTest extends SC_Helper_TaxRule_TestBase
     }
 
     /**
+     * 値引きを税率で按分し丸めた合計が、実際の値引額と ±1円 ずれるケース.
+     *
+     * 8%対象 755円 / 10%対象 165円 / 値引 92円 のとき、按分前の値引額は
+     * 8%: 75.5円, 10%: 16.5円 となり、四捨五入で両方繰り上がって 76 + 17 = 93円。
+     * このままでは支払額とインボイス合計に誤差が出るため、誤差(-1円)を既定税率
+     * (10%)側へ寄せて合計を一致させる必要がある。
+     *
+     * @see https://github.com/EC-CUBE/ec-cube2/issues/6335 (ec-cube 本体)
+     * @see https://github.com/EC-CUBE/ec-cube2/pull/762#issuecomment-1897935881
+     */
+    public function testGetTaxPerTaxRateWithRoundingDiff()
+    {
+        $this->setUpTaxRule([
+            [
+                'tax_rule_id' => 1004,
+                'apply_date' => '2019-10-01 00:00:00',
+                'tax_rate' => '10',
+                'calc_rule' => '1',
+                'product_id' => '0',
+                'product_class_id' => '0',
+                'del_flg' => '0',
+                'member_id' => 1,
+                'create_date' => '2000-01-01 00:00:00',
+                'update_date' => '2000-01-01 00:00:00',
+            ],
+        ]);
+
+        $arrTaxableTotal = [
+            10 => 165,
+            8 => 755,
+        ];
+        $discount_total = 92;
+
+        $actual = SC_Helper_TaxRule_Ex::getTaxPerTaxRate($arrTaxableTotal, $discount_total);
+
+        // 按分後の値引額の合計は、必ず実際の値引額と一致しなければならない
+        self::assertSame(
+            $discount_total,
+            $actual[8]['discount'] + $actual[10]['discount'],
+            '按分後の値引額の合計が実際の値引額と一致していません'
+        );
+
+        // 値引後合計の総和は、(税込合計 - 値引額) と一致しなければならない
+        self::assertSame(
+            array_sum($arrTaxableTotal) - $discount_total,
+            $actual[8]['total'] + $actual[10]['total'],
+            '値引後合計の総和が支払額と一致していません'
+        );
+
+        self::assertSame(
+            [
+                8 => [
+                    'discount' => 76,
+                    'total' => 679,
+                    'tax' => 50,
+                ],
+                10 => [
+                    'discount' => 16,
+                    'total' => 149,
+                    'tax' => 14,
+                ],
+            ],
+            $actual
+        );
+    }
+
+    /**
+     * 少額ポイント(1ポイント=1円)利用時の按分.
+     *
+     * 8%対象 5,000円 / 10%対象 5,000円 に 1ポイント利用すると、按分前の値引額は
+     * 両税率とも 0.5円 で、四捨五入すると 1 + 1 = 2円 となり実際の値引額(1円)とずれる。
+     * 誤差(-1円)を既定税率(10%)側へ寄せ、合計を一致させる。
+     *
+     * EC-CUBE2 の値引按分は calc_rule に依存せず常に四捨五入のため、基本税率が
+     * 切り捨て設定でも合計はずれない(ec-cube 本体 4.2 系の事象との差異)。
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6335#issuecomment-2626666163
+     */
+    public function testGetTaxPerTaxRateWithSmallPoint1()
+    {
+        $this->setUpTaxRule([
+            [
+                'tax_rule_id' => 1004,
+                'apply_date' => '2019-10-01 00:00:00',
+                'tax_rate' => '10',
+                'calc_rule' => '1',
+                'product_id' => '0',
+                'product_class_id' => '0',
+                'del_flg' => '0',
+                'member_id' => 1,
+                'create_date' => '2000-01-01 00:00:00',
+                'update_date' => '2000-01-01 00:00:00',
+            ],
+        ]);
+
+        $arrTaxableTotal = [
+            10 => 5000,
+            8 => 5000,
+        ];
+        $discount_total = 1;
+
+        $actual = SC_Helper_TaxRule_Ex::getTaxPerTaxRate($arrTaxableTotal, $discount_total);
+
+        self::assertSame(
+            $discount_total,
+            $actual[8]['discount'] + $actual[10]['discount'],
+            '按分後の値引額の合計が実際の値引額と一致していません'
+        );
+        self::assertSame(
+            array_sum($arrTaxableTotal) - $discount_total,
+            $actual[8]['total'] + $actual[10]['total'],
+            '値引後合計の総和が支払額と一致していません'
+        );
+        self::assertSame(
+            [
+                8 => [
+                    'discount' => 1,
+                    'total' => 4999,
+                    'tax' => 370,
+                ],
+                10 => [
+                    'discount' => 0,
+                    'total' => 5000,
+                    'tax' => 455,
+                ],
+            ],
+            $actual
+        );
+    }
+
+    /**
+     * 少額ポイント(2ポイント=2円)利用時の按分.
+     *
+     * 8%対象 7,500円 / 10%対象 2,500円 に 2ポイント利用すると、按分前の値引額は
+     * 8%: 1.5円, 10%: 0.5円 で、四捨五入すると 2 + 1 = 3円 となり実際の値引額(2円)とずれる。
+     * 誤差(-1円)を既定税率(10%)側へ寄せ、合計を一致させる。
+     *
+     * @see https://github.com/EC-CUBE/ec-cube/issues/6335#issuecomment-2626666163
+     */
+    public function testGetTaxPerTaxRateWithSmallPoint2()
+    {
+        $this->setUpTaxRule([
+            [
+                'tax_rule_id' => 1004,
+                'apply_date' => '2019-10-01 00:00:00',
+                'tax_rate' => '10',
+                'calc_rule' => '1',
+                'product_id' => '0',
+                'product_class_id' => '0',
+                'del_flg' => '0',
+                'member_id' => 1,
+                'create_date' => '2000-01-01 00:00:00',
+                'update_date' => '2000-01-01 00:00:00',
+            ],
+        ]);
+
+        $arrTaxableTotal = [
+            10 => 2500,
+            8 => 7500,
+        ];
+        $discount_total = 2;
+
+        $actual = SC_Helper_TaxRule_Ex::getTaxPerTaxRate($arrTaxableTotal, $discount_total);
+
+        self::assertSame(
+            $discount_total,
+            $actual[8]['discount'] + $actual[10]['discount'],
+            '按分後の値引額の合計が実際の値引額と一致していません'
+        );
+        self::assertSame(
+            array_sum($arrTaxableTotal) - $discount_total,
+            $actual[8]['total'] + $actual[10]['total'],
+            '値引後合計の総和が支払額と一致していません'
+        );
+        self::assertSame(
+            [
+                8 => [
+                    'discount' => 2,
+                    'total' => 7498,
+                    'tax' => 555,
+                ],
+                10 => [
+                    'discount' => 0,
+                    'total' => 2500,
+                    'tax' => 227,
+                ],
+            ],
+            $actual
+        );
+    }
+
+    /**
      * @see https://github.com/EC-CUBE/ec-cube2/pull/762#issuecomment-1897799676
      *
      * @runInSeparateProcess


### PR DESCRIPTION
## Summary

`SC_Helper_TaxRule::getTaxPerTaxRate()` の誤差補正が機能しておらず、税率ごとに按分・丸めした値引額の合計が実際の値引額と **±1円** ずれ、支払額とインボイス合計に誤差が出る場合がありました。

- refs https://github.com/EC-CUBE/ec-cube/issues/6335
- refs https://github.com/EC-CUBE/ec-cube2/pull/762#issuecomment-1897935881

### 原因

端数処理方法 `calc_rule` と既定税率 `tax_rate` を 1 変数 `$defaultTaxRule` で兼用していたことが根因です。

```php
$defaultTaxRule = $arrDefaultTaxRule['calc_rule'];   // calc_rule(1/2/3) が入る
...
$divide[$defaultTaxRule]['discount'] += $diff;        // $divide は税率(8/10)キー → 別物
...
if ($rate == $defaultTaxRule) { ... }                 // 税率(8/10) == calc_rule(1/2/3) → 常に false
```

- 補正値を税率キーではなく `calc_rule`(1/2/3)をキーに書き込んでいたため、存在しないキーへ書かれ読み戻されない
- 2 つ目のループの `$rate == $defaultTaxRule` も常に false で、補正が一切反映されない
- さらに `diff < 0` 分岐の `-= $diff` は符号が反転

既存テストが通っていたのは、非 skip のテストがすべて偶然 `diff = 0` のケースだったためです。

## Changes

- `calc_rule` 用の `$defaultCalcRule` と税率キー用の `$defaultTaxRate` を分離
- 丸め誤差を既定税率のバケットへ符号そのままに加算(既定税率の商品が無い受注では金額最大のバケットへフォールバック)
- 2 つ目のループの冗長な再丸めを廃し、補正済みの値を全税率で参照
- 回帰テストを追加
  - `#6335` シナリオ(8%755 / 10%165 / 値引92 → 76+17=93 のずれ)
  - 少額ポイント(-1 / -2)利用時の按分(refs https://github.com/EC-CUBE/ec-cube/issues/6335#issuecomment-2626666163)

### 補足

EC-CUBE2 の値引按分は `calc_rule` に依存せず常に四捨五入のため、基本税率が切り捨て設定でも合計はずれません(ec-cube 本体 4.2 系の `getTotalByTaxRate()` の事象との差異)。本 PR ではこの差異をテストの docblock に明記しています。

## Test plan

- [x] PHPUnit `--filter getTaxPerTaxRate` 通過(SQLite3、10/10、skip 4 は既存の floor/ceil)
- [x] `tests/class/helper/SC_Helper_TaxRule` 一括通過(20/20)
- [x] `php-cs-fixer` 準拠(修正 0 件)
- [x] CI で MySQL / PostgreSQL のテスト通過を確認

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 税率ごとの値引き按分で発生する端数差（丸め誤差）の調整方法を見直し、計算結果の整合性を改善しました（±1円のケースを含む）。
  * 既定の税率区分が存在しない場合でも、差分が適切に反映されるようにしました。
  * 少額ポイント利用時の税額・値引きの整合性を向上しました。
* **Tests**
  * 値引き按分の端数差分や少額ポイント利用などの期待値を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->