### PR TITLE
フロントの商品一覧の並び替えで表示件数が無視される問題の修正

### DIFF
--- a/data/class/SC_Product.php
+++ b/data/class/SC_Product.php
@@ -84,6 +84,9 @@ class SC_Product
     {
         $table = 'dtb_products AS alldtl';
 
+        //一旦表示数を退避
+        $limit = $objQuery->limit;
+
         if (is_array($this->arrOrderData) && $objQuery->order == '') {
             $o_col = $this->arrOrderData['col'];
             $o_table = $this->arrOrderData['table'];
@@ -96,6 +99,8 @@ class SC_Product
 
             $objQuery->setOrder("($sub_sql) $o_order, product_id");
         }
+        // 1ページあたりの商品点数を再設定
+        $objQuery->setLimit($limit);
         $arrReturn = $objQuery->getCol('alldtl.product_id', $table, $objQuery->where ? '' : 'alldtl.del_flg = 0', $arrVal);
 
         return $arrReturn;

--- a/data/class/SC_Product.php
+++ b/data/class/SC_Product.php
@@ -84,10 +84,12 @@ class SC_Product
     {
         $table = 'dtb_products AS alldtl';
 
-        //一旦表示数を退避
+        //一旦表示数、オフセットを退避
         $limit = $objQuery->limit;
+        $offset = $objQuery->offset;
 
         if (is_array($this->arrOrderData) && $objQuery->order == '') {
+
             $o_col = $this->arrOrderData['col'];
             $o_table = $this->arrOrderData['table'];
             $o_order = $this->arrOrderData['order'];
@@ -99,8 +101,8 @@ class SC_Product
 
             $objQuery->setOrder("($sub_sql) $o_order, product_id");
         }
-        // 1ページあたりの商品点数を再設定
-        $objQuery->setLimit($limit);
+        // 1ページあたりの商品点数を、オフセットを再設定
+        $objQuery->setLimitOffset($limit,$offset);
         $arrReturn = $objQuery->getCol('alldtl.product_id', $table, $objQuery->where ? '' : 'alldtl.del_flg = 0', $arrVal);
 
         return $arrReturn;

--- a/data/class/SC_Product.php
+++ b/data/class/SC_Product.php
@@ -84,12 +84,11 @@ class SC_Product
     {
         $table = 'dtb_products AS alldtl';
 
-        //一旦表示数、オフセットを退避
+        // 一旦表示数、オフセットを退避
         $limit = $objQuery->limit;
         $offset = $objQuery->offset;
 
         if (is_array($this->arrOrderData) && $objQuery->order == '') {
-
             $o_col = $this->arrOrderData['col'];
             $o_table = $this->arrOrderData['table'];
             $o_order = $this->arrOrderData['order'];
@@ -102,7 +101,7 @@ class SC_Product
             $objQuery->setOrder("($sub_sql) $o_order, product_id");
         }
         // 1ページあたりの商品点数を、オフセットを再設定
-        $objQuery->setLimitOffset($limit,$offset);
+        $objQuery->setLimitOffset($limit, $offset);
         $arrReturn = $objQuery->getCol('alldtl.product_id', $table, $objQuery->where ? '' : 'alldtl.del_flg = 0', $arrVal);
 
         return $arrReturn;

--- a/data/class/pages/products/LC_Page_Products_List.php
+++ b/data/class/pages/products/LC_Page_Products_List.php
@@ -221,8 +221,8 @@ class LC_Page_Products_List extends LC_Page_Ex
 
         $objSession = new SC_Session_Ex();
 
-        //並び順が変更されたかどうかの検知
-        if($_SESSION['currentOrderBy'] != $this->orderby){
+        // 並び順が変更されたかどうかの検知
+        if ($_SESSION['currentOrderBy'] != $this->orderby) {
             $_SESSION['currentOrderBy'] = $this->orderby;
             $startno = 1;
         }

--- a/data/class/pages/products/LC_Page_Products_List.php
+++ b/data/class/pages/products/LC_Page_Products_List.php
@@ -219,6 +219,14 @@ class LC_Page_Products_List extends LC_Page_Ex
 
         $arrOrderVal = [];
 
+        $objSession = new SC_Session_Ex();
+
+        //並び順が変更されたかどうかの検知
+        if($_SESSION['currentOrderBy'] != $this->orderby){
+            $_SESSION['currentOrderBy'] = $this->orderby;
+            $startno = 1;
+        }
+
         // 表示順序
         switch ($this->orderby) {
             // 販売価格が安い順


### PR DESCRIPTION
このプルリクエストは、`SC_Product.php` の `findProductIdsOrder` メソッドに的を絞った修正を加え、クエリの制限 (つまり、1 ページあたりに表示される製品数) が保持され、カスタムの並べ替えロジックが実行された後に正しく再適用されるようにします。

クエリ制限の処理: * クエリの制限の現在の値は、並べ替えロジックが適用される前に保存され、その後、正しいページネーション動作を維持するために明示的にリセットされます。

[[1]](diffhunk://#diff-c7e39d8525b9788a69745a29e9f57655ad8a2a54f0513f421c12b6ce35dd468cR87-R89) 
[[2]](diffhunk://#diff-c7e39d8525b9788a69745a29e9f57655ad8a2a54f0513f421c12b6ce35dd468cR102-R103)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 商品一覧で並び替え条件を指定した場合に、表示件数や取得範囲が意図せず変わる問題を修正しました。
  * 並び替え時に取得開始位置を先頭からに切り替え、並び順が同一の場合は既存の取得範囲を維持するよう改善しました。
  * 並び替え処理の影響で制限条件が残らないよう、表示件数とオフセットを正しく復元するよう調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->