### PR TITLE
URLチェックで許可する記号が足りない問題の修正

### DIFF
--- a/data/class/SC_CheckError.php
+++ b/data/class/SC_CheckError.php
@@ -1076,7 +1076,7 @@ class SC_CheckError
         }
 
         $input_var = $this->arrParam[$keyname];
-        $pattern = "@^https?://+($|[a-zA-Z0-9_~=:&\?\.\/-])+$@i";
+        $pattern = "@^https?://+($|[a-zA-Z0-9_~=:&\?\.\/#%+-])+$@i";
         if (strlen($input_var) > 0 && !preg_match($pattern, $input_var)) {
             $this->arrErr[$keyname] = "※ {$disp_name}を正しく入力してください。<br />";
         }


### PR DESCRIPTION
This pull request updates the URL validation logic in the `SC_CheckError.php` file to allow a broader set of characters in URLs, improving compatibility with more valid URL formats.

Validation improvements:

* Updated the regular expression pattern in the `URL_CHECK` function to allow `#`, `%`, and `+` characters in URLs, making the validation more robust and accurate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * URLバリデーションで、`#`、`%`、`+`、`-`を含むURLが正しく許可されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->