### PR TITLE
fix: 郵便番号CSVのダウンロードURLを新URLへ変更

### DIFF
--- a/data/migrations/Version20260714000001_UpdateZipDownloadUrl.php
+++ b/data/migrations/Version20260714000001_UpdateZipDownloadUrl.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Eccube2\Migration\Migration;
+
+/**
+ * 郵便番号CSV(ken_all.zip)のダウンロードURL変更に伴う ZIP_DOWNLOAD_URL の更新.
+ *
+ * 日本郵便の配布URLが変更され、旧URLが404を返すようになったため、
+ * mtb_constants に登録済みの ZIP_DOWNLOAD_URL を新URLへ更新する。
+ *
+ * 旧URL: https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip
+ * 新URL: https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip
+ *
+ * NOTE: 管理者が管理画面「システム設定 > パラメータ設定」で独自のURLへ
+ *       変更済みの環境を上書きしないよう、値が旧URLの場合のみ更新する。
+ * NOTE: 本マイグレーションは mtb_constants(DB) を更新するのみ。定数キャッシュ
+ *       (data/cache/n.php) には即時反映されないため、反映には管理画面
+ *       「システム設定 > パラメータ設定」での保存操作（キャッシュ再生成）が必要。
+ */
+class Version20260714000001_UpdateZipDownloadUrl extends Migration
+{
+    private const OLD_URL = '"https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip"';
+    private const NEW_URL = '"https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip"';
+
+    public function up(): void
+    {
+        $this->sql(
+            "UPDATE mtb_constants SET name = '".self::NEW_URL."' WHERE id = 'ZIP_DOWNLOAD_URL' AND name = '".self::OLD_URL."'"
+        );
+    }
+
+    public function down(): void
+    {
+        $this->sql(
+            "UPDATE mtb_constants SET name = '".self::OLD_URL."' WHERE id = 'ZIP_DOWNLOAD_URL' AND name = '".self::NEW_URL."'"
+        );
+    }
+}

--- a/data/migrations/Version20260714000001_UpdateZipDownloadUrl.php
+++ b/data/migrations/Version20260714000001_UpdateZipDownloadUrl.php
@@ -27,16 +27,14 @@ class Version20260714000001_UpdateZipDownloadUrl extends Migration
     public function up(): void
     {
         $this->sql(
-            'UPDATE mtb_constants SET name = ? WHERE id = ? AND name = ?',
-            [self::NEW_URL, 'ZIP_DOWNLOAD_URL', self::OLD_URL]
+            "UPDATE mtb_constants SET name = '".self::NEW_URL."' WHERE id = 'ZIP_DOWNLOAD_URL' AND name = '".self::OLD_URL."'"
         );
     }
 
     public function down(): void
     {
         $this->sql(
-            'UPDATE mtb_constants SET name = ? WHERE id = ? AND name = ?',
-            [self::OLD_URL, 'ZIP_DOWNLOAD_URL', self::NEW_URL]
+            "UPDATE mtb_constants SET name = '".self::OLD_URL."' WHERE id = 'ZIP_DOWNLOAD_URL' AND name = '".self::NEW_URL."'"
         );
     }
 }

--- a/data/migrations/Version20260714000001_UpdateZipDownloadUrl.php
+++ b/data/migrations/Version20260714000001_UpdateZipDownloadUrl.php
@@ -27,14 +27,16 @@ class Version20260714000001_UpdateZipDownloadUrl extends Migration
     public function up(): void
     {
         $this->sql(
-            "UPDATE mtb_constants SET name = '".self::NEW_URL."' WHERE id = 'ZIP_DOWNLOAD_URL' AND name = '".self::OLD_URL."'"
+            'UPDATE mtb_constants SET name = ? WHERE id = ? AND name = ?',
+            [self::NEW_URL, 'ZIP_DOWNLOAD_URL', self::OLD_URL]
         );
     }
 
     public function down(): void
     {
         $this->sql(
-            "UPDATE mtb_constants SET name = '".self::OLD_URL."' WHERE id = 'ZIP_DOWNLOAD_URL' AND name = '".self::NEW_URL."'"
+            'UPDATE mtb_constants SET name = ? WHERE id = ? AND name = ?',
+            [self::OLD_URL, 'ZIP_DOWNLOAD_URL', self::NEW_URL]
         );
     }
 }

--- a/data/mtb_constants_init.php
+++ b/data/mtb_constants_init.php
@@ -457,7 +457,7 @@ define('ECCUBE_INFO', true);
 /** 外部サイトHTTP取得タイムアウト時間(秒) */
 define('HTTP_REQUEST_TIMEOUT', "5");
 /** 郵便番号CSVのZIPアーカイブファイルの取得元 */
-define('ZIP_DOWNLOAD_URL', "https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip");
+define('ZIP_DOWNLOAD_URL', "https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip");
 /** フックポイント(プレプロセス) */
 define('HOOK_POINT_PREPROCESS', "LC_Page_preProcess");
 /** フックポイント(プロセス) */

--- a/html/install/sql/insert_data.sql
+++ b/html/install/sql/insert_data.sql
@@ -1272,7 +1272,7 @@ INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('DEVICE_TYPE_PC', '1
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('DEVICE_TYPE_ADMIN', '99', 1103, '端末種別: 管理画面');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('ECCUBE_INFO', 'true', 1218, 'EC-CUBE更新情報取得 (true:取得する false:取得しない)');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('HTTP_REQUEST_TIMEOUT', '"5"', 1219, '外部サイトHTTP取得タイムアウト時間(秒)');
-INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('ZIP_DOWNLOAD_URL', '"https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip"', 1224, '郵便番号CSVのZIPアーカイブファイルの取得元');
+INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('ZIP_DOWNLOAD_URL', '"https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip"', 1224, '郵便番号CSVのZIPアーカイブファイルの取得元');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('HOOK_POINT_PREPROCESS', '"LC_Page_preProcess"', 1301, 'フックポイント(プレプロセス)');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('HOOK_POINT_PROCESS', '"LC_Page_process"', 1302, 'フックポイント(プロセス)');
 INSERT INTO mtb_constants (id, name, rank, remarks) VALUES ('PLUGIN_ACTIVATE_FLAG', 'true', 1303, 'プラグインのロード可否フラグ)');


### PR DESCRIPTION
## Summary

日本郵便の郵便番号CSV(`ken_all.zip`)配布URLが変更され、旧URLが404を返すようになったため、`ZIP_DOWNLOAD_URL` を新URLへ更新します。

| URL | HTTP | Content-Type |
|---|---|---|
| 旧: `https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip` | **404** | text/html |
| 新: `https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip` | **200** | application/zip (約1.69MB) |

旧URLが404となったことで、管理画面「基本情報管理 > 郵便番号DB登録」の自動更新(`update_csv`/`auto`)が動作しなくなっていました。

## 変更点

- `data/mtb_constants_init.php`: `ZIP_DOWNLOAD_URL` 定数のフォールバック値を新URLへ変更
- `html/install/sql/insert_data.sql`: 新規インストール時に `mtb_constants` へ投入される値を新URLへ変更
- `data/migrations/Version20260714000001_UpdateZipDownloadUrl.php`: 既存環境の `mtb_constants` を新URLへ更新するマイグレーションを追加（管理画面で独自URLへ変更済みの環境を上書きしないよう、値が旧URLの場合のみ更新）

## 既存環境への反映についての注意

`ZIP_DOWNLOAD_URL` は定数キャッシュ (`data/cache/n.php`) 経由で参照されます。**マイグレーションで `mtb_constants`(DB) を更新しても、定数キャッシュには即時反映されません。** 反映には管理画面「システム設定 > パラメータ設定」での保存操作（キャッシュ再生成）が必要です。

## Test plan

- [ ] マイグレーション適用後、`mtb_constants` の `ZIP_DOWNLOAD_URL` が新URLへ更新されること
- [ ] 管理画面「システム設定 > パラメータ設定」で保存後、新規インストール／既存環境ともに「郵便番号DB登録」の自動更新が成功すること
- [ ] 新URLから `ken_all.zip` が取得・展開され `mtb_zip` へ登録されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * 郵便番号CSV（ZIPアーカイブ）の取得元URLを新しいURLへ更新しました。
  * 既存環境では、現在のURLが旧URLと一致する場合のみ新URLへ更新されます。
  * 管理者が独自のURLを設定している場合、その設定は維持されます。
  * 初期導入時に登録される取得元URLも新URLへ変更しました。
  * 更新を取り消す場合は、新URLが設定されている場合に限り旧URLへ戻します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->