### PR TITLE
SC_SendMail 文字コードとヘッダー処理を拡張

### DIFF
--- a/data/class/SC_SendMail.php
+++ b/data/class/SC_SendMail.php
@@ -21,31 +21,49 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-// テキスト/HTML　メール送信
+/**
+ * テキスト/HTML　メール送信
+ */
 class SC_SendMail
 {
-    public $to;            // 送信先
-    public $subject;       // 題名
-    public $body;          // 本文
-    public $cc;            // CC
-    public $bcc;           // BCC
-    public $replay_to;     // replay_to
-    public $return_path;   // return_path
+    /** 送信先のメールアドレス */
+    public string $to = '';
+    public string $to_name = '';
+    /** 題名 */
+    public string $subject = '';
+    /** 本文 */
+    public string $body = '';
+    public string $cc = '';
+    public string $cc_name = '';
+    public string $bcc = '';
+    public string $bcc_name = '';
+    public string $replay_to = '';
+    public string $return_path = '';
+    /** @var \Mail|\PEAR_Error */
     public $objMail;
-    /** @var array */
-    public $arrRecip;
-    /** @var string */
-    public $backend;
-    /** @var string */
-    public $host;
-    /** @var int */
-    public $port;
-    /** @var string */
-    public $from;
-    /** @var string */
-    public $reply_to;
-    /** @var array */
-    protected $customHeaders;
+    public array $arrRecip = [];
+    public string $backend = MAIL_BACKEND;
+    public string $host = SMTP_HOST;
+    /**
+     * ポート番号
+     *
+     * 本質的には数値だが、処理を簡素にするため文字列も可能とする。
+     *
+     * @var int|string
+     */
+    public $port = SMTP_PORT;
+    public string $from = '';
+    public string $from_name = '';
+    public string $reply_to = '';
+    protected array $customHeaders = [];
+    protected string $charset = 'ISO-2022-JP';
+
+    /**
+     * 本文に Base64 エンコードを使用するか。
+     *
+     * null は自動判定。
+     */
+    protected ?bool $useBase64ForBody = null;
 
     /**
      * コンストラクタ
@@ -54,33 +72,20 @@ class SC_SendMail
      */
     public function __construct()
     {
-        $this->arrRecip = [];
-        $this->to = '';
-        $this->subject = '';
-        $this->body = '';
-        $this->cc = '';
-        $this->bcc = '';
-        $this->reply_to = '';
-        $this->return_path = '';
-        $this->customHeaders = [];
-        $this->backend = MAIL_BACKEND;
-        $this->host = SMTP_HOST;
-        $this->port = SMTP_PORT;
-
         // PEAR::Mailを使ってメール送信オブジェクト作成
-        $this->objMail = &Mail::factory(
+        $this->objMail = \Mail::factory(
             $this->backend,
             $this->getBackendParams($this->backend)
         );
-        if (PEAR::isError($this->objMail)) {
+        if (\PEAR::isError($this->objMail)) {
             // XXX 環境によっては文字エンコードに差異がないか些か心配
             trigger_error($this->objMail->getMessage(), E_USER_ERROR);
         }
     }
 
-    // 送信先の設定
-
     /**
+     * 送信先の設定
+     *
      * @param string $key
      */
     public function setRecip($key, $recipient)
@@ -88,50 +93,78 @@ class SC_SendMail
         $this->arrRecip[$key] = $recipient;
     }
 
-    // 宛先の設定
+    /**
+     * 宛先の設定
+     */
     public function setTo($to, $to_name = '')
     {
         if ($to != '') {
-            $this->to = $this->getNameAddress($to_name, $to);
+            $this->to = $to;
+            $this->to_name = $to_name;
             $this->setRecip('To', $to);
         }
     }
 
-    // 送信元の設定
-    public function setFrom($from, $from_name = '')
+    public function getToWithEncodedName()
     {
-        $this->from = $this->getNameAddress($from_name, $from);
+        return $this->getNameAddress($this->to_name, $this->to);
     }
 
-    // CCの設定
+    /**
+     * 送信元の設定
+     */
+    public function setFrom($from, $from_name = '')
+    {
+        $this->from = $from;
+        $this->from_name = $from_name;
+    }
+
+    public function getFromWithEncodedName()
+    {
+        return $this->getNameAddress($this->from_name, $this->from);
+    }
 
     /**
+     * CCの設定
+     *
      * @param string $cc
      */
     public function setCc($cc, $cc_name = '')
     {
         if ($cc != '') {
-            $this->cc = $this->getNameAddress($cc_name, $cc);
+            $this->cc = $cc;
+            $this->cc_name = $cc_name;
             $this->setRecip('Cc', $cc);
         }
     }
 
-    // BCCの設定
+    public function getCcWithEncodedName()
+    {
+        return $this->getNameAddress($this->cc_name, $this->cc);
+    }
 
     /**
+     * BCCの設定
+     *
      * @param string $bcc
      */
-    public function setBcc($bcc)
+    public function setBcc($bcc, $bcc_name = '')
     {
         if ($bcc != '') {
             $this->bcc = $bcc;
+            $this->bcc_name = $bcc_name;
             $this->setRecip('Bcc', $bcc);
         }
     }
 
-    // Reply-Toの設定
+    public function getBccWithEncodedName()
+    {
+        return $this->getNameAddress($this->bcc_name, $this->bcc);
+    }
 
     /**
+     * Reply-Toの設定
+     *
      * @param string $reply_to
      */
     public function setReplyTo($reply_to)
@@ -141,7 +174,9 @@ class SC_SendMail
         }
     }
 
-    // Return-Pathの設定
+    /**
+     * Return-Pathの設定
+     */
     public function setReturnPath($return_path)
     {
         $this->return_path = $return_path;
@@ -188,19 +223,47 @@ class SC_SendMail
         $this->customHeaders = [];
     }
 
-    // 件名の設定
+    /**
+     * 件名の設定
+     */
     public function setSubject($subject)
     {
         $subject = str_replace(["\r\n", "\r", "\n"], ' ', $subject);
-        $this->subject = mb_encode_mimeheader($subject, 'ISO-2022-JP-MS', 'B', "\n");
+        $this->subject = $subject;
     }
 
-    // 本文の設定
+    public function getEncodedSubject()
+    {
+        $subject = $this->subject;
+
+        $subject = mb_encode_mimeheader($subject, $this->getCharsetForEncodeProcess(), 'B', "\n");
+
+        return $subject;
+    }
+
+    /**
+     * 本文の設定
+     */
     public function setBody($body)
     {
-        // iso-2022-jpだと特殊文字が？で送信されるのでISO-2022-JP-MSを使用する
-        $this->body = mb_convert_encoding($body, 'ISO-2022-JP-MS', CHAR_CODE);
-        $this->body = str_replace(["\r\n", "\r"], "\n", $this->body);
+        $this->body = $body;
+    }
+
+    public function getEncodedBody()
+    {
+        $body = $this->body;
+
+        if ($this->useBase64ForBody) {
+            $body = mb_convert_encoding($this->body, $this->getCharsetForEncodeProcess());
+
+            // Base64 エンコード（RFC2045 に準拠し chunk_split で76文字ごとに改行）
+            $body = chunk_split(base64_encode($body));
+        }
+
+        $body = mb_convert_encoding($body, $this->getCharsetForEncodeProcess(), CHAR_CODE);
+        $body = str_replace(["\r\n", "\r"], "\n", $body);
+
+        return $body;
     }
 
     /**
@@ -217,7 +280,7 @@ class SC_SendMail
             'port' => $this->port,
         ];
         // PEAR::Mailを使ってメール送信オブジェクト作成
-        $this->objMail = &Mail::factory('smtp', $arrHost);
+        $this->objMail = \Mail::factory('smtp', $arrHost);
     }
 
     /**
@@ -234,25 +297,34 @@ class SC_SendMail
             'port' => $this->port,
         ];
         // PEAR::Mailを使ってメール送信オブジェクト作成
-        $this->objMail = &Mail::factory('smtp', $arrHost);
+        $this->objMail = \Mail::factory('smtp', $arrHost);
     }
 
-    // 名前<メールアドレス>の形式を生成
-
     /**
-     * @param string $name
+     * `名前 <メールアドレス>` の形式を生成
      */
-    public function getNameAddress($name, $mail_address)
+    public function getNameAddress(?string $name, ?string $mail_address)
     {
-        if ($name != '') {
-            // 制御文字を変換する。
-            $_name = $name;
-            $_name = mb_encode_mimeheader($_name, 'ISO-2022-JP-MS', 'B', "\n");
-            $_name = str_replace('"', '\"', $_name);
-            $name_address = sprintf('"%s" <%s>', $_name, $mail_address);
-        } else {
-            $name_address = $mail_address;
-        }
+        $name = (string) $name;
+        $mail_address = (string) $mail_address;
+
+        $name_address = (function () use ($name) {
+            switch (true) {
+                // 空文字の場合
+                case $name === '':
+                    return '';
+                    // ダブルクォーテーションを含む場合
+                case str_contains($name, '"'):
+                    // nop: `"` のエスケープ `\"` を正しく解釈しない MUA があるため、`"` を含む場合はこのルートを通さずエンコードに回す。
+                    break;
+                    // ASCII のみの場合
+                case preg_match('/^[\x20-\x7E]*$/', $name):
+                    return '"'.$name.'" ';
+            }
+
+            return mb_encode_mimeheader($name, $this->getCharsetForEncodeProcess(), 'B', "\n").' ';
+        })();
+        $name_address .= "<{$mail_address}>";
 
         return $name_address;
     }
@@ -306,27 +378,49 @@ class SC_SendMail
         }
     }
 
-    // ヘッダーを返す
+    /**
+     * ヘッダーを返す (後方互換)
+     *
+     * @deprecated getHeader() を使用すること。
+     */
     public function getBaseHeader()
+    {
+        $arrHeader = $this->getHeader();
+        unset($arrHeader['Content-Type']);
+
+        return $arrHeader;
+    }
+
+    /**
+     * ヘッダーを返す
+     *
+     * @param bool $use_html HTMLメールか
+     */
+    public function getHeader(bool $use_html = false): array
     {
         // 送信するメールの内容と送信先
         $arrHeader = [];
         $arrHeader['MIME-Version'] = '1.0';
-        $arrHeader['To'] = $this->to;
-        $arrHeader['Subject'] = $this->subject;
-        $arrHeader['From'] = $this->from;
+        $arrHeader['To'] = $this->getToWithEncodedName();
+        $arrHeader['Subject'] = $this->getEncodedSubject();
+        $arrHeader['From'] = $this->getFromWithEncodedName();
         $arrHeader['Return-Path'] = $this->return_path;
         if ($this->reply_to != '') {
             $arrHeader['Reply-To'] = $this->reply_to;
         }
         if ($this->cc != '') {
-            $arrHeader['Cc'] = $this->cc;
+            $arrHeader['Cc'] = $this->getCcWithEncodedName();
         }
         if ($this->bcc != '') {
-            $arrHeader['Bcc'] = $this->bcc;
+            $arrHeader['Bcc'] = $this->getBccWithEncodedName();
         }
         $arrHeader['Date'] = date('D, j M Y H:i:s O');
-        $arrHeader['Content-Transfer-Encoding'] = '7bit';
+        $arrHeader['Content-Transfer-Encoding'] = $this->getContentTransferEncoding();
+
+        $arrHeader['Content-Type'] = $use_html
+            ? 'text/html; charset="'.$this->getCharsetForHeader().'"'
+            : 'text/plain; charset="'.$this->getCharsetForHeader().'"'
+        ;
 
         // カスタムヘッダーをマージ
         foreach ($this->customHeaders as $name => $value) {
@@ -336,22 +430,24 @@ class SC_SendMail
         return $arrHeader;
     }
 
-    // ヘッダーを返す
+    /**
+     * ヘッダーを返す (後方互換)
+     *
+     * @deprecated getHeader() を使用すること。
+     */
     public function getTEXTHeader()
     {
-        $arrHeader = $this->getBaseHeader();
-        $arrHeader['Content-Type'] = 'text/plain; charset="ISO-2022-JP"';
-
-        return $arrHeader;
+        return $this->getHeader();
     }
 
-    // ヘッダーを返す
+    /**
+     * ヘッダーを返す (後方互換)
+     *
+     * @deprecated getHeader() を使用すること。
+     */
     public function getHTMLHeader()
     {
-        $arrHeader = $this->getBaseHeader();
-        $arrHeader['Content-Type'] = 'text/html; charset="ISO-2022-JP"';
-
-        return $arrHeader;
+        return $this->getHeader(true);
     }
 
     /**
@@ -382,11 +478,12 @@ class SC_SendMail
      */
     public function sendMail($isHtml = false)
     {
-        $header = $isHtml ? $this->getHTMLHeader() : $this->getTEXTHeader();
+        $header = $this->getHeader($isHtml);
         $recip = $this->getRecip();
+
         // メール送信
-        $result = $this->objMail->send($recip, $header, $this->body);
-        if (PEAR::isError($result)) {
+        $result = $this->objMail->send($recip, $header, $this->getEncodedBody());
+        if (\PEAR::isError($result)) {
             // XXX Windows 環境では SJIS でメッセージを受け取るようなので変換する。
             $msg = mb_convert_encoding($result->getMessage(), CHAR_CODE, 'auto');
             $msg = 'メール送信に失敗しました。['.$msg.']';
@@ -457,5 +554,58 @@ class SC_SendMail
         }
 
         return $arrParams;
+    }
+
+    /**
+     * エンコード処理で用いる文字コードを設定する。
+     *
+     * @param string $charset 文字コード。
+     */
+    public function setCharset(string $charset)
+    {
+        $this->charset = $charset;
+    }
+
+    /**
+     * エンコード処理で用いる文字コードを返す。
+     */
+    public function getCharsetForEncodeProcess(): string
+    {
+        if ($this->charset === 'ISO-2022-JP') {
+            return 'ISO-2022-JP-MS';
+        }
+
+        return $this->charset;
+    }
+
+    /**
+     * ヘッダーに記すための文字コードを取得する。
+     */
+    public function getCharsetForHeader(): string
+    {
+        return $this->charset;
+    }
+
+    /**
+     * ヘッダーに記すための Content-Transfer-Encoding を取得する。
+     */
+    public function getContentTransferEncoding(): string
+    {
+        $charset = $this->getCharsetForHeader();
+
+        if ($this->useBase64ForBody === true) {
+            return 'base64';
+        }
+
+        if ($charset === 'ISO-2022-JP') {
+            return '7bit';
+        }
+
+        return '8bit';
+    }
+
+    public function setUseBase64ForBody(?bool $useBase64ForBody): void
+    {
+        $this->useBase64ForBody = $useBase64ForBody;
     }
 }

--- a/data/class/SC_SendMail.php
+++ b/data/class/SC_SendMail.php
@@ -313,11 +313,13 @@ class SC_SendMail
                 // 空文字の場合
                 case $name === '':
                     return '';
-                    // ダブルクォーテーションを含む場合
-                case str_contains($name, '"'):
-                    // nop: `"` のエスケープ `\"` を正しく解釈しない MUA があるため、`"` を含む場合はこのルートを通さずエンコードに回す。
+                    // ダブルクォーテーションまたはバックスラッシュを含む場合
+                    // - バックスラッシュを正しく解釈しない MUA があるため、ASCII として処理せずエンコードに回す。
+                    // - `"` も原則通りエスケープすると `\"` となるため同様。
+                case strcspn($name, '"\\') < strlen($name):
+                    // nop
                     break;
-                    // ASCII のみの場合
+                    // 印字可能 ASCII（制御文字除く）のみの場合
                 case preg_match('/^[\x20-\x7E]*$/', $name):
                     return '"'.$name.'" ';
             }

--- a/data/class/SC_SendMail.php
+++ b/data/class/SC_SendMail.php
@@ -121,7 +121,7 @@ class SC_SendMail
     /**
      * @param string $bcc
      */
-    public function setBCc($bcc)
+    public function setBcc($bcc)
     {
         if ($bcc != '') {
             $this->bcc = $bcc;

--- a/tests/class/SC_SendMailTest.php
+++ b/tests/class/SC_SendMailTest.php
@@ -138,6 +138,17 @@ class SC_SendMailTest extends Common_TestCase
         );
     }
 
+    public function testGetNameAddressUsesEncodedWordWhenAsciiDisplayNameContainsBackslash()
+    {
+        $name = 'Sender\\Name';
+        $expectedName = mb_encode_mimeheader($name, 'ISO-2022-JP-MS', 'B', "\n");
+
+        $this->assertSame(
+            $expectedName.' <user@example.com>',
+            $this->objSendMail->getNameAddress($name, 'user@example.com')
+        );
+    }
+
     public static function base64BodyEncodingProvider(): array
     {
         return [

--- a/tests/class/SC_SendMailTest.php
+++ b/tests/class/SC_SendMailTest.php
@@ -19,6 +19,133 @@ class SC_SendMailTest extends Common_TestCase
         $this->assertInstanceOf('SC_SendMail', $this->objSendMail);
     }
 
+    public function testGetHeaderWithRecipientNames()
+    {
+        $this->objSendMail->setTo('to@example.com', '宛先');
+        $this->objSendMail->setFrom('from@example.com', '差出人');
+        $this->objSendMail->setCc('cc@example.com', 'CC');
+        $this->objSendMail->setBcc('bcc@example.com', 'BCC');
+        $this->objSendMail->setSubject("件名\n改行");
+        $this->objSendMail->setReturnPath('return-path@example.com');
+
+        $header = $this->objSendMail->getHeader();
+
+        $this->assertStringContainsString('to@example.com', $header['To']);
+        $this->assertStringContainsString('from@example.com', $header['From']);
+        $this->assertStringContainsString('cc@example.com', $header['Cc']);
+        $this->assertStringContainsString('bcc@example.com', $header['Bcc']);
+        $this->assertStringNotContainsString("\n改行", $this->objSendMail->subject);
+        $this->assertSame('text/plain; charset="ISO-2022-JP"', $header['Content-Type']);
+        $this->assertSame('7bit', $header['Content-Transfer-Encoding']);
+    }
+
+    public function testGetHtmlHeaderAndBackwardCompatibleHeaders()
+    {
+        $this->objSendMail->setSubject('件名');
+
+        $htmlHeader = $this->objSendMail->getHeader(true);
+        $this->assertSame('text/html; charset="ISO-2022-JP"', $htmlHeader['Content-Type']);
+
+        $textHeader = $this->objSendMail->getTEXTHeader();
+        $header = $this->objSendMail->getHeader();
+        unset($textHeader['Date'], $header['Date']);
+        $this->assertSame($header, $textHeader);
+
+        $baseHeader = $this->objSendMail->getBaseHeader();
+        $this->assertArrayNotHasKey('Content-Type', $baseHeader);
+        $header = $this->objSendMail->getHeader();
+        unset($baseHeader['Date'], $header['Date']);
+        $this->assertSame($header, array_merge($baseHeader, [
+            'Content-Type' => 'text/plain; charset="ISO-2022-JP"',
+        ]));
+    }
+
+    public function testSetCharset()
+    {
+        $this->objSendMail->setCharset('UTF-8');
+
+        $this->assertSame('UTF-8', $this->objSendMail->getCharsetForHeader());
+        $this->assertSame('UTF-8', $this->objSendMail->getCharsetForEncodeProcess());
+        $this->assertSame('8bit', $this->objSendMail->getContentTransferEncoding());
+        $this->assertSame('text/plain; charset="UTF-8"', $this->objSendMail->getHeader()['Content-Type']);
+    }
+
+    public function testChangingCharsetAfterSettingBody()
+    {
+        $body = '髙';
+
+        $this->objSendMail->setCharset('UTF-8');
+        $this->objSendMail->setBody($body);
+        $this->objSendMail->setCharset('ISO-2022-JP');
+
+        $expectedBody = mb_convert_encoding($body, 'ISO-2022-JP-MS');
+
+        $this->assertSame('ISO-2022-JP', $this->objSendMail->getCharsetForHeader());
+        $this->assertSame($expectedBody, $this->objSendMail->getEncodedBody());
+        $this->assertNotSame(mb_convert_encoding($body, 'ISO-2022-JP'), $this->objSendMail->getEncodedBody());
+        $this->assertSame('text/plain; charset="ISO-2022-JP"', $this->objSendMail->getHeader()['Content-Type']);
+    }
+
+    /**
+     * @dataProvider base64BodyEncodingProvider
+     */
+    public function testBase64BodyEncoding(string $charset)
+    {
+        $body = '髙';
+
+        $this->objSendMail->setCharset($charset);
+        $this->objSendMail->setBody($body);
+        $this->objSendMail->setUseBase64ForBody(true);
+
+        $this->assertSame('base64', $this->objSendMail->getContentTransferEncoding());
+        $expectedBody = chunk_split(base64_encode(mb_convert_encoding($body, $this->objSendMail->getCharsetForEncodeProcess())));
+        $expectedBody = str_replace(["\r\n", "\r"], "\n", $expectedBody);
+        $this->assertSame($expectedBody, $this->objSendMail->getEncodedBody());
+    }
+
+    public function testGetNameAddressDoesNotQuoteEncodedWord()
+    {
+        $this->assertSame(
+            '=?ISO-2022-JP?B?GyRCOjk9UD9NGyhC?= <user@example.com>',
+            $this->objSendMail->getNameAddress('差出人', 'user@example.com')
+        );
+    }
+
+    public function testGetNameAddressAlwaysQuotesAsciiDisplayName()
+    {
+        $this->assertSame(
+            '"Sender Name" <user@example.com>',
+            $this->objSendMail->getNameAddress('Sender Name', 'user@example.com')
+        );
+    }
+
+    public function testGetNameAddressReturnsAngleBracketsWhenDisplayNameIsEmpty()
+    {
+        $this->assertSame(
+            '<user@example.com>',
+            $this->objSendMail->getNameAddress('', 'user@example.com')
+        );
+    }
+
+    public function testGetNameAddressUsesEncodedWordWhenAsciiDisplayNameContainsDoubleQuote()
+    {
+        $name = 'Sender "Name';
+        $expectedName = mb_encode_mimeheader($name, 'ISO-2022-JP-MS', 'B', "\n");
+
+        $this->assertSame(
+            $expectedName.' <user@example.com>',
+            $this->objSendMail->getNameAddress($name, 'user@example.com')
+        );
+    }
+
+    public static function base64BodyEncodingProvider(): array
+    {
+        return [
+            ['UTF-8'],
+            ['ISO-2022-JP'],
+        ];
+    }
+
     public function testSendMail()
     {
         $this->resetEmails();


### PR DESCRIPTION
- charsetの設定・取得処理を追加
  - 全面的な UTF-8 メール化は、プロパティ書き換え(1箇所)で対応できる。
  - 使い分けが必要な場合、setCharset() で。
- プロパティに型宣言と初期値を追加
- 宛先、差出人、CC、BCCの表示名を保持するよう変更
- 表示名付きメールアドレスをヘッダー生成時にMIMEエンコード
- 件名と本文のエンコード処理を送信時に変更
- 本文のBase64エンコードに対応
- Content-TypeとContent-Transfer-Encodingを動的に設定
- getHeader() を追加しヘッダー生成処理を統合
  - 従来メソッドは後方互換用として維持
- メソッドの大文字・小文字誤りを修正
- テスト追加 (✨️主にAI生成)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新機能
- 宛先、送信元、CC、BCCに表示名を設定できるようになりました。
- 表示名を含むメールヘッダーを適切にエンコードできるようになりました。
- 文字コードを指定して、件名や本文を送信できるようになりました。
- 本文のBase64エンコードに対応しました。
- HTMLメール用ヘッダーの生成に対応しました。

## 改善
- 既存のメール送信APIとの互換性を維持しました。
- ASCII文字を含む表示名のヘッダー処理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->