### PR TITLE
CI の偶発的なテスト失敗を軽減する

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,6 +24,12 @@ jobs:
   run-on-linux:
     name: Run on Linux
     runs-on: ubuntu-24.04
+    env:
+      # E2E テストはすべて同一 IP からログイン試行を行うため、Playwright のリトライも
+      # 含めると IP ベースのレート制限に達し、無関係なテストが偶発的に失敗する。
+      # メールアドレスベースのしきい値（デフォルト 5 回）は変更しないため、
+      # レート制限自体の E2E テストはメールアドレスベースで引き続き検証される。
+      LOGIN_RATE_LIMIT_IP_THRESHOLD: 1000
     strategy:
       fail-fast: false
       matrix:

--- a/data/class/helper/SC_Helper_LoginRateLimit.php
+++ b/data/class/helper/SC_Helper_LoginRateLimit.php
@@ -75,7 +75,7 @@ class SC_Helper_LoginRateLimit
      */
     protected static function getThreshold($name, $default)
     {
-        if (defined($name)) {
+        if (defined($name) && is_numeric(constant($name))) {
             return (int) constant($name);
         }
 

--- a/data/class/helper/SC_Helper_LoginRateLimit.php
+++ b/data/class/helper/SC_Helper_LoginRateLimit.php
@@ -33,15 +33,70 @@
  */
 class SC_Helper_LoginRateLimit
 {
+    /** 同一メールアドレスの失敗回数しきい値のデフォルト値 */
+    public const DEFAULT_EMAIL_THRESHOLD = 5;
+
+    /** 同一IPアドレスの失敗回数しきい値のデフォルト値 */
+    public const DEFAULT_IP_THRESHOLD = 10;
+
+    /**
+     * メールアドレスベースのレート制限しきい値を取得する
+     *
+     * 定数 LOGIN_RATE_LIMIT_EMAIL_THRESHOLD または同名の環境変数で上書きできます。
+     *
+     * @return int
+     */
+    public static function getEmailThreshold()
+    {
+        return self::getThreshold('LOGIN_RATE_LIMIT_EMAIL_THRESHOLD', self::DEFAULT_EMAIL_THRESHOLD);
+    }
+
+    /**
+     * IPアドレスベースのレート制限しきい値を取得する
+     *
+     * 定数 LOGIN_RATE_LIMIT_IP_THRESHOLD または同名の環境変数で上書きできます。
+     * E2E テストのように同一 IP から大量にログイン試行が発生する環境では
+     * この値を引き上げることで IP ベースの制限を緩和できます。
+     *
+     * @return int
+     */
+    public static function getIPThreshold()
+    {
+        return self::getThreshold('LOGIN_RATE_LIMIT_IP_THRESHOLD', self::DEFAULT_IP_THRESHOLD);
+    }
+
+    /**
+     * しきい値を 定数 > 環境変数 > デフォルト値 の優先順で解決する
+     *
+     * @param string $name しきい値の名称（定数名・環境変数名）
+     * @param int    $default デフォルト値
+     *
+     * @return int
+     */
+    protected static function getThreshold($name, $default)
+    {
+        if (defined($name)) {
+            return (int) constant($name);
+        }
+
+        $env = getenv($name);
+        if ($env !== false && is_numeric($env)) {
+            return (int) $env;
+        }
+
+        return $default;
+    }
+
     /**
      * レート制限をチェックする
      *
      * 同一メールアドレスまたは同一IPアドレスからの
      * ログイン試行失敗が制限を超えていないか確認します。
      *
-     * レート制限ルール:
+     * レート制限ルール（デフォルト）:
      * - 同一メールアドレス: 1時間に4回まで失敗を許可（5回目の失敗でレート制限メッセージ表示）
      * - 同一IPアドレス: 1時間に9回まで失敗を許可（10回目の失敗でレート制限メッセージ表示）
+     * しきい値は getEmailThreshold() / getIPThreshold() を参照。
      *
      * セキュリティ考慮事項:
      * - アカウント列挙攻撃対策: 存在しないメールアドレスも同様にレート制限
@@ -68,7 +123,7 @@ class SC_Helper_LoginRateLimit
             [$login_id]
         );
 
-        if ($email_count >= 5) {
+        if ($email_count >= self::getEmailThreshold()) {
             return [
                 'allowed' => false,
                 'reason' => 'email',
@@ -84,7 +139,7 @@ class SC_Helper_LoginRateLimit
             [$ip_address]
         );
 
-        if ($ip_count >= 10) {
+        if ($ip_count >= self::getIPThreshold()) {
             return [
                 'allowed' => false,
                 'reason' => 'ip',

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -51,4 +51,7 @@ services:
       test: mysqladmin ping
       interval: 3s
       timeout: 3s
-      retries: 3
+      retries: 10
+      # 初回起動時のデータディレクトリ初期化は CI ランナーの負荷によっては
+      # 数十秒かかるため、その間はヘルスチェックの失敗をカウントしない
+      start_period: 60s

--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -56,4 +56,7 @@ services:
       test: pg_isready -U eccube_db_user
       interval: 3s
       timeout: 3s
-      retries: 3
+      retries: 10
+      # 初回起動時のデータディレクトリ初期化は CI ランナーの負荷によっては
+      # 数十秒かかるため、その間はヘルスチェックの失敗をカウントしない
+      start_period: 60s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,9 @@ services:
       SMTP_USER: ~
       SMTP_PASSWORD: ~
       TEST_MAILCATCHER_URL: "http://mailcatcher:1080"
+      # ログイン試行レート制限のしきい値上書き用（未指定時はアプリ側のデフォルト値）
+      LOGIN_RATE_LIMIT_EMAIL_THRESHOLD: ${LOGIN_RATE_LIMIT_EMAIL_THRESHOLD:-}
+      LOGIN_RATE_LIMIT_IP_THRESHOLD: ${LOGIN_RATE_LIMIT_IP_THRESHOLD:-}
     networks:
       - backend
 

--- a/e2e-tests/test/installer/installer.test.ts
+++ b/e2e-tests/test/installer/installer.test.ts
@@ -75,8 +75,10 @@ test.describe.serial('インストーラのテストをします', () => {
     await expect(page.locator('h2').first()).toHaveText('データベースの初期化');
     await page.click('text=次へ進む');
 
-    await expect(page.locator('.contents').first()).toHaveText(/○：テーブルの作成に成功しました。/);
-    await expect(page.locator('.contents').first()).toHaveText(/○：シーケンスの作成に成功しました。/);
+    // テーブル・シーケンスの一括作成は負荷の高い CI ランナーでは
+    // デフォルトの 5 秒を超えることがあるためタイムアウトを延長する
+    await expect(page.locator('.contents').first()).toHaveText(/○：テーブルの作成に成功しました。/, { timeout: 60000 });
+    await expect(page.locator('.contents').first()).toHaveText(/○：シーケンスの作成に成功しました。/, { timeout: 60000 });
     await page.click('text=次へ進む');
   });
 

--- a/tests/class/helper/SC_Helper_LoginRateLimit/SC_Helper_LoginRateLimitTest.php
+++ b/tests/class/helper/SC_Helper_LoginRateLimit/SC_Helper_LoginRateLimitTest.php
@@ -347,4 +347,73 @@ class SC_Helper_LoginRateLimitTest extends Common_TestCase
         $this->assertEquals(5, $stats['failed']);
         $this->assertEquals(3, $stats['success']);
     }
+
+    /**
+     * Test threshold defaults
+     *
+     * しきい値のデフォルト値が取得される
+     */
+    public function testGetThresholdReturnsDefaults()
+    {
+        $this->assertEquals(5, SC_Helper_LoginRateLimit_Ex::getEmailThreshold());
+        $this->assertEquals(10, SC_Helper_LoginRateLimit_Ex::getIPThreshold());
+    }
+
+    /**
+     * Test threshold override by environment variable
+     *
+     * 環境変数でしきい値を上書きできる
+     */
+    public function testGetThresholdIsOverridableByEnvironmentVariable()
+    {
+        putenv('LOGIN_RATE_LIMIT_EMAIL_THRESHOLD=7');
+        putenv('LOGIN_RATE_LIMIT_IP_THRESHOLD=1000');
+        try {
+            $this->assertEquals(7, SC_Helper_LoginRateLimit_Ex::getEmailThreshold());
+            $this->assertEquals(1000, SC_Helper_LoginRateLimit_Ex::getIPThreshold());
+        } finally {
+            putenv('LOGIN_RATE_LIMIT_EMAIL_THRESHOLD');
+            putenv('LOGIN_RATE_LIMIT_IP_THRESHOLD');
+        }
+    }
+
+    /**
+     * Test non-numeric environment variable is ignored
+     *
+     * 数値でない環境変数は無視されデフォルト値が使用される
+     */
+    public function testGetThresholdIgnoresNonNumericEnvironmentVariable()
+    {
+        putenv('LOGIN_RATE_LIMIT_IP_THRESHOLD=invalid');
+        try {
+            $this->assertEquals(10, SC_Helper_LoginRateLimit_Ex::getIPThreshold());
+        } finally {
+            putenv('LOGIN_RATE_LIMIT_IP_THRESHOLD');
+        }
+    }
+
+    /**
+     * Test checkRateLimit respects overridden IP threshold
+     *
+     * 上書きされたIPしきい値がレート制限判定に反映される
+     */
+    public function testCheckRateLimitRespectsOverriddenIPThreshold()
+    {
+        putenv('LOGIN_RATE_LIMIT_IP_THRESHOLD=15');
+        try {
+            $ip = '192.168.1.1';
+
+            // デフォルトのしきい値（10回）を超える失敗を記録
+            for ($i = 0; $i < 12; $i++) {
+                SC_Helper_LoginRateLimit_Ex::recordLoginAttempt("test{$i}@example.com", $ip, 'TestAgent', 0);
+            }
+
+            $result = SC_Helper_LoginRateLimit_Ex::checkRateLimit('new@example.com', $ip);
+
+            $this->assertTrue($result['allowed']);
+            $this->assertEquals(12, $result['ip_count']);
+        } finally {
+            putenv('LOGIN_RATE_LIMIT_IP_THRESHOLD');
+        }
+    }
 }

--- a/tests/class/helper/SC_Helper_LoginRateLimit/SC_Helper_LoginRateLimitTest.php
+++ b/tests/class/helper/SC_Helper_LoginRateLimit/SC_Helper_LoginRateLimitTest.php
@@ -393,6 +393,35 @@ class SC_Helper_LoginRateLimitTest extends Common_TestCase
     }
 
     /**
+     * Test numeric constant overrides threshold
+     *
+     * 数値の定数はしきい値として使用される
+     */
+    public function testGetThresholdUsesNumericConstant()
+    {
+        if (!defined('TEST_LOGIN_RATE_LIMIT_NUMERIC')) {
+            define('TEST_LOGIN_RATE_LIMIT_NUMERIC', '42');
+        }
+
+        $this->assertEquals(42, SC_Helper_LoginRateLimit_ThresholdStub::callGetThreshold('TEST_LOGIN_RATE_LIMIT_NUMERIC', 10));
+    }
+
+    /**
+     * Test non-numeric constant is ignored
+     *
+     * 数値でない定数は無視されデフォルト値が使用される
+     * （(int) 変換で 0 になり即ブロックとなる事故を防ぐ）
+     */
+    public function testGetThresholdIgnoresNonNumericConstant()
+    {
+        if (!defined('TEST_LOGIN_RATE_LIMIT_NON_NUMERIC')) {
+            define('TEST_LOGIN_RATE_LIMIT_NON_NUMERIC', 'invalid');
+        }
+
+        $this->assertEquals(10, SC_Helper_LoginRateLimit_ThresholdStub::callGetThreshold('TEST_LOGIN_RATE_LIMIT_NON_NUMERIC', 10));
+    }
+
+    /**
      * Test checkRateLimit respects overridden IP threshold
      *
      * 上書きされたIPしきい値がレート制限判定に反映される
@@ -415,5 +444,16 @@ class SC_Helper_LoginRateLimitTest extends Common_TestCase
         } finally {
             putenv('LOGIN_RATE_LIMIT_IP_THRESHOLD');
         }
+    }
+}
+
+/**
+ * getThreshold() をテストから呼び出すためのスタブ
+ */
+class SC_Helper_LoginRateLimit_ThresholdStub extends SC_Helper_LoginRateLimit
+{
+    public static function callGetThreshold($name, $default)
+    {
+        return self::getThreshold($name, $default);
     }
 }


### PR DESCRIPTION
refs #1438

## 概要

直近の CI 失敗（master への push / PR）のログを調査したところ、偶発的な失敗の原因はほぼ以下の2つに集約されていました。この PR はその両方に対応します。

## 原因1: DB コンテナのヘルスチェック設定（直近の e2e 失敗6件中5件）

`container ec-cube2-mysql-1 is unhealthy` で `docker compose up -d --wait` がテスト開始前に失敗するパターンです（例: [このジョブ](https://github.com/EC-CUBE/ec-cube2/actions/runs/32553288253)）。

現在のヘルスチェックは `interval: 3s / timeout: 3s / retries: 3` で `start_period` がないため、初回起動（データディレクトリ初期化）が CI ランナーの負荷で長引くと **約9〜12秒で unhealthy が確定**します。MySQL 8.4 の初回初期化は混雑したランナーでは数十秒かかることがあります。

### 対応
- `docker-compose.mysql.yml` / `docker-compose.pgsql.yml` のヘルスチェックに `start_period: 60s` を追加し、`retries` を 10 に増加
- `start_period` 中はヘルスチェックの失敗が unhealthy 判定にカウントされないため、起動が遅いだけのケースで落ちなくなります

## 原因2: ログインレート制限による E2E テスト間の干渉

`login_error.test.ts` で「誤ったパスワード」系のテストが `メールアドレスもしくはパスワードが正しくありません` を期待しているのに `短時間に複数のログイン試行が検出されました` が表示されて失敗するパターン（逆方向もあり）です。

`SC_Helper_LoginRateLimit` の IP ベース制限（1時間に10回）は同一 IP から実行される E2E テスト全体で共有されるため、Playwright の自動リトライも含めて失敗試行が積み増しされると、無関係なテストにレート制限エラーが表示されます。テストファイル内の `FIXME` / `test.skip` でも既知の問題として言及されています。

### 対応
- しきい値を「定数 > 環境変数 > デフォルト値」の優先順で解決するように変更（`LOGIN_RATE_LIMIT_EMAIL_THRESHOLD` / `LOGIN_RATE_LIMIT_IP_THRESHOLD`）。デフォルト値（5回 / 10回)は従来どおりで、**本番挙動は変わりません**
- `docker-compose.yml` の ec-cube サービスに環境変数のパススルーを追加
- E2E ワークフローでは `LOGIN_RATE_LIMIT_IP_THRESHOLD: 1000` を設定して IP ベースの干渉を排除。**メールアドレスベースのしきい値（5回）は変更しない**ため、`マイページログインのレート制限が動作します` のテストは引き続きレート制限を検証します
- しきい値の解決ロジックにユニットテストを追加

## 備考

- これにより、現在 `test.skip` されている `ショッピングカートログインのレート制限が動作します`（IP 干渉が理由でスキップ）も再有効化できる見込みですが、この PR ではスコープ外としています
- 8/25 の phpstan / php-cs-fixer の失敗は実際のコードスタイル違反（次の push で修正済み）で、フレークではありませんでした

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ログイン試行のレート制限を、メールアドレス別・IPアドレス別に設定できるようになりました。
  - 環境設定で標準の制限値を変更できます。不正な設定値は無視され、既定値が使用されます。

- **改善**
  - 初回起動時のデータベース初期化に時間がかかる場合でも、サービスが安定して起動しやすくなりました。
  - 高負荷な環境での初期設定処理が完了するまでの待機が改善されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->