### PR TITLE
CI: 同一コミットに対するパイプラインの二重実行を防ぐ

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,8 +1,10 @@
 name: Coverage
 on:
   push:
+    # ブランチへの push は pull_request イベント側で coverage が取得されるため、
+    # master と tag に限定して同一コミットの二重実行を防ぐ (refs #1438)
     branches:
-      - '*'
+      - master
     tags:
       - '*'
     paths:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,10 @@ name: CI/CD for EC-CUBE
 
 on:
   push:
+    # ブランチへの push は pull_request イベント側で CI が実行されるため、
+    # master と tag に限定して同一コミットの二重実行を防ぐ (refs #1438)
     branches:
-      - '*'
+      - master
     tags:
       - '*'
     paths:


### PR DESCRIPTION
refs #1438

## 概要

リポジトリ内のブランチから PR を作成すると、**push イベントと pull_request イベントの両方で全パイプライン（約170ジョブ）が同一コミットに対して二重実行**されています。実例: commit `921243b`（seasoft-SC_SendMail）は [push run](https://github.com/EC-CUBE/ec-cube2/actions/runs/32950172724) と [pull_request run](https://github.com/EC-CUBE/ec-cube2/actions/runs/32950176746) が同時に走っています。`concurrency` グループは ref が異なる（`refs/heads/...` と `refs/pull/.../merge`）ため相殺されません。

Actions の同時実行数には上限があるため、この二重実行がキュー待ちを倍増させ、CI 全体の所要時間を悪化させています。

## 変更内容

`main.yml` と `coverage.yml` の push トリガーを master と tag に限定します。

- ブランチの CI / coverage は **pull_request イベント側で引き続き実行**されるため、PR を伴う開発フローでの検証内容・coverage 取得は変わりません
- 失われるのは「PR を出していないブランチへの push」の実行のみです
- フォークからの PR は元々 push イベントが発火しないため影響ありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * CI とカバレッジチェックの実行対象を `master` ブランチとタグに限定しました。
  * プルリクエストで実行されるチェックとの重複を減らし、不要な二重実行を防止します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->