### PR TITLE
CI: Docker イメージに変更がない場合は再ビルドせず公開イメージを利用する

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,6 +16,12 @@ on:
       owner:
         required: true
         type: string
+      use_prebuilt_image:
+        # true の場合、イメージをビルドせず master で build & push 済みの
+        # ghcr.io 公開イメージを利用する (refs #1438)
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -44,6 +50,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Build docker image
+      if: ${{ !inputs.use_prebuilt_image }}
       uses: ./.github/actions/dockerbuild
       with:
         php-version: ${{ matrix.php }}
@@ -70,13 +77,16 @@ jobs:
         BASE_REF: ${{ inputs.base_ref }}
         EVENT_NAME: ${{ inputs.event_name }}
         OWNER: ${{ inputs.owner }}
+        USE_PREBUILT_IMAGE: ${{ inputs.use_prebuilt_image }}
         DB: ${{ matrix.db }}
         PHP: ${{ matrix.php }}
         PATTERN: ${{ matrix.pattern }}
       run: |
         echo "COMPOSE_FILE=docker-compose.yml:docker-compose.${DB}.yml:docker-compose.dev.yml" >> $GITHUB_ENV
         echo "IMAGE_NAME=${OWNER,,}/ec-cube2-php" >> $GITHUB_ENV
-        if [ $EVENT_NAME = "pull_request" ]; then
+        if [ "$USE_PREBUILT_IMAGE" = "true" ]; then
+          echo "TAG=${PHP}-apache" >> $GITHUB_ENV
+        elif [ $EVENT_NAME = "pull_request" ]; then
           if [ -n $DOCKER_METADATA_OUTPUT_VERSION ]; then
             echo "TAG=${DOCKER_METADATA_OUTPUT_VERSION}" >> $GITHUB_ENV
           else
@@ -267,6 +277,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Build docker image
+      if: ${{ !inputs.use_prebuilt_image }}
       uses: ./.github/actions/dockerbuild
       with:
         php-version: ${{ matrix.php }}
@@ -293,12 +304,15 @@ jobs:
         BASE_REF: ${{ inputs.base_ref }}
         EVENT_NAME: ${{ inputs.event_name }}
         OWNER: ${{ inputs.owner }}
+        USE_PREBUILT_IMAGE: ${{ inputs.use_prebuilt_image }}
         DB: ${{ matrix.db }}
         PHP: ${{ matrix.php }}
       run: |
         echo "COMPOSE_FILE=docker-compose.yml:docker-compose.${DB}.yml:docker-compose.dev.yml" >> $GITHUB_ENV
         echo "IMAGE_NAME=${OWNER,,}/ec-cube2-php" >> $GITHUB_ENV
-        if [ $EVENT_NAME = "pull_request" ]; then
+        if [ "$USE_PREBUILT_IMAGE" = "true" ]; then
+          echo "TAG=${PHP}-apache" >> $GITHUB_ENV
+        elif [ $EVENT_NAME = "pull_request" ]; then
           if [ -n $DOCKER_METADATA_OUTPUT_VERSION ]; then
             echo "TAG=${DOCKER_METADATA_OUTPUT_VERSION}" >> $GITHUB_ENV
           else

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -183,7 +183,13 @@ jobs:
             docker compose exec -T postgres pg_restore --user=eccube_db_user --clean --if-exists -d eccube_db /tmp/eccube_snapshot.dump
             ;;
           sqlite3)
-            docker compose exec -T ec-cube sqlite3 /var/www/app/data/eccube.db ".restore /tmp/eccube_snapshot.db"
+            # 稼働中の Apache (mod_php) が SQLite への接続を保持したまま外部から
+            # DB を書き換えると接続状態が壊れ、以降のシーケンス取得や INSERT が
+            # MDB2 Error となる。コンテナを再起動して全接続を閉じてから
+            # ファイルを差し替え、WAL モードを再設定する
+            docker compose restart -t 5 ec-cube
+            docker compose exec -T ec-cube sh -c 'cp /tmp/eccube_snapshot.db /var/www/app/data/eccube.db && rm -f /var/www/app/data/eccube.db-wal /var/www/app/data/eccube.db-shm && sqlite3 /var/www/app/data/eccube.db "PRAGMA journal_mode=WAL;"'
+            until curl -sf -k https://localhost:4430/ -o /dev/null; do sleep 1; done
             ;;
         esac
         # mailcatcher もグループ開始時点の状態（空）に戻す
@@ -214,7 +220,13 @@ jobs:
             docker compose exec -T postgres pg_restore --user=eccube_db_user --clean --if-exists -d eccube_db /tmp/eccube_snapshot.dump
             ;;
           sqlite3)
-            docker compose exec -T ec-cube sqlite3 /var/www/app/data/eccube.db ".restore /tmp/eccube_snapshot.db"
+            # 稼働中の Apache (mod_php) が SQLite への接続を保持したまま外部から
+            # DB を書き換えると接続状態が壊れ、以降のシーケンス取得や INSERT が
+            # MDB2 Error となる。コンテナを再起動して全接続を閉じてから
+            # ファイルを差し替え、WAL モードを再設定する
+            docker compose restart -t 5 ec-cube
+            docker compose exec -T ec-cube sh -c 'cp /tmp/eccube_snapshot.db /var/www/app/data/eccube.db && rm -f /var/www/app/data/eccube.db-wal /var/www/app/data/eccube.db-shm && sqlite3 /var/www/app/data/eccube.db "PRAGMA journal_mode=WAL;"'
+            until curl -sf -k https://localhost:4430/ -o /dev/null; do sleep 1; done
             ;;
         esac
         # mailcatcher もグループ開始時点の状態（空）に戻す

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -154,8 +154,11 @@ jobs:
             docker compose exec -T postgres pg_dump --user=eccube_db_user -Fc -f /tmp/eccube_snapshot.dump eccube_db
             ;;
           sqlite3)
-            # WAL モードのため cp ではなく SQLite Backup API で一貫したスナップショットを取る
-            docker compose exec -T ec-cube sqlite3 /var/www/app/data/eccube.db ".backup /tmp/eccube_snapshot.db"
+            # WAL モードのため cp ではなく SQLite Backup API で一貫したスナップショットを取る。
+            # リストアはコンテナ停止中にホスト側で行うため、マウントされた data/ 配下に置き、
+            # リストア後も WAL モードになるようスナップショット側に設定しておく
+            docker compose exec -T ec-cube sqlite3 /var/www/app/data/eccube.db ".backup /var/www/app/data/eccube_snapshot.db"
+            docker compose exec -T ec-cube sqlite3 /var/www/app/data/eccube_snapshot.db "PRAGMA journal_mode=WAL;"
             ;;
         esac
 
@@ -185,11 +188,21 @@ jobs:
           sqlite3)
             # 稼働中の Apache (mod_php) が SQLite への接続を保持したまま外部から
             # DB を書き換えると接続状態が壊れ、以降のシーケンス取得や INSERT が
-            # MDB2 Error となる。コンテナを再起動して全接続を閉じてから
-            # ファイルを差し替え、WAL モードを再設定する
-            docker compose restart -t 5 ec-cube
-            docker compose exec -T ec-cube sh -c 'cp /tmp/eccube_snapshot.db /var/www/app/data/eccube.db && rm -f /var/www/app/data/eccube.db-wal /var/www/app/data/eccube.db-shm && sqlite3 /var/www/app/data/eccube.db "PRAGMA journal_mode=WAL;"'
-            until curl -sf -k https://localhost:4430/ -o /dev/null; do sleep 1; done
+            # MDB2 Error となる。healthcheck 等で再接続される余地を残さないよう、
+            # コンテナを停止して全接続を閉じた状態でファイルを差し替えてから起動する
+            docker compose stop -t 5 ec-cube
+            sudo cp data/eccube_snapshot.db data/eccube.db
+            sudo rm -f data/eccube.db-wal data/eccube.db-shm
+            docker compose start ec-cube
+            tries=0
+            until curl -sf -k --connect-timeout 5 --max-time 10 https://localhost:4430/ -o /dev/null; do
+              tries=$((tries+1))
+              if [ "$tries" -ge 60 ]; then
+                echo "ec-cube did not come back up" >&2
+                exit 1
+              fi
+              sleep 1
+            done
             ;;
         esac
         # mailcatcher もグループ開始時点の状態（空）に戻す
@@ -222,11 +235,21 @@ jobs:
           sqlite3)
             # 稼働中の Apache (mod_php) が SQLite への接続を保持したまま外部から
             # DB を書き換えると接続状態が壊れ、以降のシーケンス取得や INSERT が
-            # MDB2 Error となる。コンテナを再起動して全接続を閉じてから
-            # ファイルを差し替え、WAL モードを再設定する
-            docker compose restart -t 5 ec-cube
-            docker compose exec -T ec-cube sh -c 'cp /tmp/eccube_snapshot.db /var/www/app/data/eccube.db && rm -f /var/www/app/data/eccube.db-wal /var/www/app/data/eccube.db-shm && sqlite3 /var/www/app/data/eccube.db "PRAGMA journal_mode=WAL;"'
-            until curl -sf -k https://localhost:4430/ -o /dev/null; do sleep 1; done
+            # MDB2 Error となる。healthcheck 等で再接続される余地を残さないよう、
+            # コンテナを停止して全接続を閉じた状態でファイルを差し替えてから起動する
+            docker compose stop -t 5 ec-cube
+            sudo cp data/eccube_snapshot.db data/eccube.db
+            sudo rm -f data/eccube.db-wal data/eccube.db-shm
+            docker compose start ec-cube
+            tries=0
+            until curl -sf -k --connect-timeout 5 --max-time 10 https://localhost:4430/ -o /dev/null; do
+              tries=$((tries+1))
+              if [ "$tries" -ge 60 ]; then
+                echo "ec-cube did not come back up" >&2
+                exit 1
+              fi
+              sleep 1
+            done
             ;;
         esac
         # mailcatcher もグループ開始時点の状態（空）に戻す

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,50 @@ permissions:
   packages: write
 
 jobs:
+  # Docker イメージの内容に影響するファイルが変更されたかを判定する。
+  # 変更がなければ master で build & push 済みの ghcr.io 公開イメージを
+  # そのまま利用し、各ジョブでの再ビルド（約1分/ジョブ）を省略する (refs #1438)
+  changes:
+    name: Detect docker image related changes
+    runs-on: ubuntu-24.04
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+    - name: Detect docker image related changes
+      id: filter
+      env:
+        GH_TOKEN: ${{ github.token }}
+        EVENT_NAME: ${{ github.event_name }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        BEFORE: ${{ github.event.before }}
+        SHA: ${{ github.sha }}
+      run: |
+        # イメージ内容を左右するファイル群（vendor は composer.json/lock からイメージに焼き込まれる）
+        PATTERN='^(Dockerfile|dockerbuild/|\.github/actions/dockerbuild/|composer\.json$|composer\.lock$)'
+        # 判定できない場合は安全側（再ビルド）に倒す
+        docker=true
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          files=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename') || files=""
+          if [ -n "$files" ] && ! echo "$files" | grep -qE "$PATTERN"; then
+            docker=false
+          fi
+        elif [ -n "$BEFORE" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ]; then
+          compare=$(gh api "repos/${REPO}/compare/${BEFORE}...${SHA}") || compare=""
+          if [ -n "$compare" ]; then
+            count=$(echo "$compare" | jq '.files | length')
+            files=$(echo "$compare" | jq -r '.files[].filename')
+            # compare API のファイル一覧は300件で打ち切られるため、それ以上は再ビルドに倒す
+            if [ "$count" -lt 300 ] && ! echo "$files" | grep -qE "$PATTERN"; then
+              docker=false
+            fi
+          fi
+        fi
+        echo "docker=${docker}" >> $GITHUB_OUTPUT
+        echo "docker image related changes: ${docker}"
   dockerbuild:
+    needs: [ changes ]
+    if: needs.changes.outputs.docker == 'true'
     with:
       event_name: ${{ github.event_name }}
     uses: ./.github/workflows/dockerbuild.yml
@@ -33,7 +76,10 @@ jobs:
       base_ref: ${{ github.base_ref }}
       event_name: ${{ github.event_name }}
       owner: ${{ github.repository_owner }}
-    needs: [ dockerbuild ]
+      use_prebuilt_image: ${{ needs.changes.outputs.docker != 'true' }}
+    needs: [ changes, dockerbuild ]
+    # dockerbuild が changes 判定によりスキップされた場合も実行する
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (needs.dockerbuild.result == 'success' || needs.dockerbuild.result == 'skipped') }}
     uses: ./.github/workflows/php-cs-fixer.yml
   phpstan:
     with:
@@ -41,7 +87,10 @@ jobs:
       base_ref: ${{ github.base_ref }}
       event_name: ${{ github.event_name }}
       owner: ${{ github.repository_owner }}
-    needs: [ dockerbuild ]
+      use_prebuilt_image: ${{ needs.changes.outputs.docker != 'true' }}
+    needs: [ changes, dockerbuild ]
+    # dockerbuild が changes 判定によりスキップされた場合も実行する
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (needs.dockerbuild.result == 'success' || needs.dockerbuild.result == 'skipped') }}
     uses: ./.github/workflows/phpstan.yml
   rector:
     with:
@@ -49,7 +98,10 @@ jobs:
       base_ref: ${{ github.base_ref }}
       event_name: ${{ github.event_name }}
       owner: ${{ github.repository_owner }}
-    needs: [ dockerbuild ]
+      use_prebuilt_image: ${{ needs.changes.outputs.docker != 'true' }}
+    needs: [ changes, dockerbuild ]
+    # dockerbuild が changes 判定によりスキップされた場合も実行する
+    if: ${{ !cancelled() && needs.changes.result == 'success' && (needs.dockerbuild.result == 'success' || needs.dockerbuild.result == 'skipped') }}
     uses: ./.github/workflows/rector.yml
   dependency-review:
     uses: ./.github/workflows/dependency-review.yml
@@ -59,7 +111,8 @@ jobs:
       base_ref: ${{ github.base_ref }}
       event_name: ${{ github.event_name }}
       owner: ${{ github.repository_owner }}
-    needs: [ php-cs-fixer, phpstan, rector ]
+      use_prebuilt_image: ${{ needs.changes.outputs.docker != 'true' }}
+    needs: [ changes, php-cs-fixer, phpstan, rector ]
     uses: ./.github/workflows/unit-tests.yml
   e2e-tests:
     with:
@@ -67,7 +120,8 @@ jobs:
       base_ref: ${{ github.base_ref }}
       event_name: ${{ github.event_name }}
       owner: ${{ github.repository_owner }}
-    needs: [ unit-tests ]
+      use_prebuilt_image: ${{ needs.changes.outputs.docker != 'true' }}
+    needs: [ changes, unit-tests ]
     uses: ./.github/workflows/e2e-tests.yml
   success:
     needs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,9 @@ jobs:
       owner: ${{ github.repository_owner }}
       use_prebuilt_image: ${{ needs.changes.outputs.docker != 'true' }}
     needs: [ changes, php-cs-fixer, phpstan, rector ]
+    # 祖先の dockerbuild がスキップされると暗黙の success() が false になるため、
+    # 直接依存するジョブの結果のみで判定する
+    if: ${{ !cancelled() && needs.changes.result == 'success' && needs.php-cs-fixer.result == 'success' && needs.phpstan.result == 'success' && needs.rector.result == 'success' }}
     uses: ./.github/workflows/unit-tests.yml
   e2e-tests:
     with:
@@ -122,6 +125,9 @@ jobs:
       owner: ${{ github.repository_owner }}
       use_prebuilt_image: ${{ needs.changes.outputs.docker != 'true' }}
     needs: [ changes, unit-tests ]
+    # 祖先の dockerbuild がスキップされると暗黙の success() が false になるため、
+    # 直接依存するジョブの結果のみで判定する
+    if: ${{ !cancelled() && needs.changes.result == 'success' && needs.unit-tests.result == 'success' }}
     uses: ./.github/workflows/e2e-tests.yml
   success:
     needs:
@@ -131,4 +137,7 @@ jobs:
       - dependency-review
       - unit-tests
       - e2e-tests
+    # 祖先の dockerbuild がスキップされると暗黙の success() が false になるため、
+    # 直接依存するジョブの結果のみで判定する
+    if: ${{ !cancelled() && needs.php-cs-fixer.result == 'success' && needs.phpstan.result == 'success' && needs.rector.result == 'success' && needs.dependency-review.result == 'success' && needs.unit-tests.result == 'success' && needs.e2e-tests.result == 'success' }}
     uses: ./.github/workflows/success.yml

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -16,6 +16,12 @@ on:
       owner:
         required: true
         type: string
+      use_prebuilt_image:
+        # true の場合、イメージをビルドせず master で build & push 済みの
+        # ghcr.io 公開イメージを利用する (refs #1438)
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -29,6 +35,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Build docker image
+      if: ${{ !inputs.use_prebuilt_image }}
       uses: ./.github/actions/dockerbuild
       with:
         php-version: '8.4'
@@ -39,10 +46,13 @@ jobs:
         BASE_REF: ${{ inputs.base_ref }}
         EVENT_NAME: ${{ inputs.event_name }}
         OWNER: ${{ inputs.owner }}
+        USE_PREBUILT_IMAGE: ${{ inputs.use_prebuilt_image }}
       run: |
         echo "COMPOSE_FILE=docker-compose.yml:docker-compose.pgsql.yml:docker-compose.dev.yml" >> $GITHUB_ENV
         echo "IMAGE_NAME=${OWNER,,}/ec-cube2-php" >> $GITHUB_ENV
-        if [ $EVENT_NAME = "pull_request" ]; then
+        if [ "$USE_PREBUILT_IMAGE" = "true" ]; then
+          echo "TAG=8.4-apache" >> $GITHUB_ENV
+        elif [ $EVENT_NAME = "pull_request" ]; then
           if [ -n $DOCKER_METADATA_OUTPUT_VERSION ]; then
             echo "TAG=${DOCKER_METADATA_OUTPUT_VERSION}" >> $GITHUB_ENV
           else

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,6 +16,12 @@ on:
       owner:
         required: true
         type: string
+      use_prebuilt_image:
+        # true の場合、イメージをビルドせず master で build & push 済みの
+        # ghcr.io 公開イメージを利用する (refs #1438)
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -29,6 +35,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Build docker image
+      if: ${{ !inputs.use_prebuilt_image }}
       uses: ./.github/actions/dockerbuild
       with:
         php-version: '8.3'
@@ -39,10 +46,13 @@ jobs:
         BASE_REF: ${{ inputs.base_ref }}
         EVENT_NAME: ${{ inputs.event_name }}
         OWNER: ${{ inputs.owner }}
+        USE_PREBUILT_IMAGE: ${{ inputs.use_prebuilt_image }}
       run: |
         echo "COMPOSE_FILE=docker-compose.yml:docker-compose.pgsql.yml:docker-compose.dev.yml" >> $GITHUB_ENV
         echo "IMAGE_NAME=${OWNER,,}/ec-cube2-php" >> $GITHUB_ENV
-        if [ $EVENT_NAME = "pull_request" ]; then
+        if [ "$USE_PREBUILT_IMAGE" = "true" ]; then
+          echo "TAG=8.3-apache" >> $GITHUB_ENV
+        elif [ $EVENT_NAME = "pull_request" ]; then
           if [ -n $DOCKER_METADATA_OUTPUT_VERSION ]; then
             echo "TAG=${DOCKER_METADATA_OUTPUT_VERSION}" >> $GITHUB_ENV
           else

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -16,6 +16,12 @@ on:
       owner:
         required: true
         type: string
+      use_prebuilt_image:
+        # true の場合、イメージをビルドせず master で build & push 済みの
+        # ghcr.io 公開イメージを利用する (refs #1438)
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -29,6 +35,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Build docker image
+      if: ${{ !inputs.use_prebuilt_image }}
       uses: ./.github/actions/dockerbuild
       with:
         php-version: '8.3'
@@ -39,10 +46,13 @@ jobs:
         BASE_REF: ${{ inputs.base_ref }}
         EVENT_NAME: ${{ inputs.event_name }}
         OWNER: ${{ inputs.owner }}
+        USE_PREBUILT_IMAGE: ${{ inputs.use_prebuilt_image }}
       run: |
         echo "COMPOSE_FILE=docker-compose.yml:docker-compose.pgsql.yml:docker-compose.dev.yml" >> $GITHUB_ENV
         echo "IMAGE_NAME=${OWNER,,}/ec-cube2-php" >> $GITHUB_ENV
-        if [ $EVENT_NAME = "pull_request" ]; then
+        if [ "$USE_PREBUILT_IMAGE" = "true" ]; then
+          echo "TAG=8.3-apache" >> $GITHUB_ENV
+        elif [ $EVENT_NAME = "pull_request" ]; then
           if [ -n $DOCKER_METADATA_OUTPUT_VERSION ]; then
             echo "TAG=${DOCKER_METADATA_OUTPUT_VERSION}" >> $GITHUB_ENV
           else

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,6 +16,12 @@ on:
       owner:
         required: true
         type: string
+      use_prebuilt_image:
+        # true の場合、イメージをビルドせず master で build & push 済みの
+        # ghcr.io 公開イメージを利用する (refs #1438)
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -36,6 +42,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Build docker image
+      if: ${{ !inputs.use_prebuilt_image }}
       uses: ./.github/actions/dockerbuild
       with:
         php-version: ${{ matrix.php }}
@@ -51,12 +58,15 @@ jobs:
         BASE_REF: ${{ inputs.base_ref }}
         EVENT_NAME: ${{ inputs.event_name }}
         OWNER: ${{ inputs.owner }}
+        USE_PREBUILT_IMAGE: ${{ inputs.use_prebuilt_image }}
         DB: ${{ matrix.db }}
         PHP: ${{ matrix.php }}
       run: |
         echo "COMPOSE_FILE=docker-compose.yml:docker-compose.${DB}.yml:docker-compose.dev.yml" >> $GITHUB_ENV
         echo "IMAGE_NAME=${OWNER,,}/ec-cube2-php" >> $GITHUB_ENV
-        if [ $EVENT_NAME = "pull_request" ]; then
+        if [ "$USE_PREBUILT_IMAGE" = "true" ]; then
+          echo "TAG=${PHP}-apache" >> $GITHUB_ENV
+        elif [ $EVENT_NAME = "pull_request" ]; then
           if [ -n $DOCKER_METADATA_OUTPUT_VERSION ]; then
             echo "TAG=${DOCKER_METADATA_OUTPUT_VERSION}" >> $GITHUB_ENV
           else


### PR DESCRIPTION
refs #1438
**⚠️ #1441 の上に積んでいます。先に #1441 をマージしてください（マージ後にこの PR の diff が本来の変更のみになります）。**

## 概要

現在、先頭の dockerbuild ステージは GHA キャッシュを温めるだけで、後続の**全ジョブ（約140）が毎回 buildx でイメージを再ビルド**しています（キャッシュヒット時でも約56秒/ジョブ、1 run 合計約2時間の job 時間）。

一方、CI では `docker-compose.dev.yml` がソースをワークディレクトリからマウントするため、イメージの実体は **PHP ランタイム + vendor（composer.json/lock から焼き込み）のみ**です。つまり Dockerfile・dockerbuild/・composer.json/lock を触らない大半の PR では、イメージは master のものと同一内容です。

## 変更内容

- `main.yml` に `changes` ジョブを追加し、イメージ内容に影響するファイルの変更有無を判定
- **変更がない場合**（大半の PR）:
  - dockerbuild ステージをスキップ → クリティカルパス先頭の約5分を削減
  - 各ジョブは Build ステップをスキップし、master で build & push 済みの ghcr.io 公開イメージ（`<php>-apache` タグ、`dockerbuild-and-push.yml` が push 済み）を compose が pull して利用（約15〜20秒）
- **変更がある場合**: 従来どおり dockerbuild でキャッシュを温め、各ジョブでビルド（挙動不変）
- **判定できない場合**（API エラー・compare 300ファイル超・force push 等）は安全側（再ビルド）に倒します

## 効果（実測ベースの見積り）

- 典型 PR: クリティカルパス −約5分（dockerbuild ステージ省略）+ 各ジョブ −約40秒
- 1 run あたり約90〜130 job-分の削減 → 同時実行上限下でのキュー回転が改善
- buildx + GHA キャッシュ起因の偶発エラー（api.github.com 504 など）の発生機会も減少

## 備考

- pull されるのは公開パッケージのため認証不要です。フォーク側リポジトリで直接 CI を回す場合は `<owner>/ec-cube2-php:<php>-apache` が存在せず pull に失敗しますが、upstream への PR では常に `ec-cube/ec-cube2-php` が使われるため影響ありません
- linter 系（php-cs-fixer / phpstan / rector）の `if` 条件は「dockerbuild がスキップされた場合も実行」するよう調整しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 各種テスト・静的解析で、事前ビルド済みDockerイメージを選択できるようになりました。
  - Docker関連の変更がない場合は既存イメージを利用し、変更がある場合のみイメージをビルドします。
  - ワークフローの実行条件を整理し、不要な重複実行を抑制しました。
  - SQLiteのスナップショット取得・復元処理を改善し、テスト環境の起動とデータ復元の安定性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->