### PR TITLE
SC_CustomerListTest の部分一致検索テストを Faker の値衝突に耐性を持たせる

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -193,12 +193,21 @@ jobs:
             docker compose stop -t 5 ec-cube
             sudo cp data/eccube_snapshot.db data/eccube.db
             sudo rm -f data/eccube.db-wal data/eccube.db-shm
-            docker compose start ec-cube
+            # CI ランナーでは stop 直後の `docker compose start` が何も起動しないまま
+            # 正常終了することがある（コンテナは stopped のまま）。冪等で
+            # ヘルスチェック完了まで待つ `up -d --wait` を使用する
+            if ! docker compose up -d --wait ec-cube; then
+              docker compose ps -a ec-cube
+              docker compose logs --tail 50 ec-cube
+              exit 1
+            fi
             tries=0
             until curl -sf -k --connect-timeout 5 --max-time 10 https://localhost:4430/ -o /dev/null; do
               tries=$((tries+1))
               if [ "$tries" -ge 60 ]; then
                 echo "ec-cube did not come back up" >&2
+                docker compose ps -a ec-cube
+                docker compose logs --tail 50 ec-cube
                 exit 1
               fi
               sleep 1
@@ -240,12 +249,21 @@ jobs:
             docker compose stop -t 5 ec-cube
             sudo cp data/eccube_snapshot.db data/eccube.db
             sudo rm -f data/eccube.db-wal data/eccube.db-shm
-            docker compose start ec-cube
+            # CI ランナーでは stop 直後の `docker compose start` が何も起動しないまま
+            # 正常終了することがある（コンテナは stopped のまま）。冪等で
+            # ヘルスチェック完了まで待つ `up -d --wait` を使用する
+            if ! docker compose up -d --wait ec-cube; then
+              docker compose ps -a ec-cube
+              docker compose logs --tail 50 ec-cube
+              exit 1
+            fi
             tries=0
             until curl -sf -k --connect-timeout 5 --max-time 10 https://localhost:4430/ -o /dev/null; do
               tries=$((tries+1))
               if [ "$tries" -ge 60 ]; then
                 echo "ec-cube did not come back up" >&2
+                docker compose ps -a ec-cube
+                docker compose logs --tail 50 ec-cube
                 exit 1
               fi
               sleep 1

--- a/tests/class/SC_CustomerListTest.php
+++ b/tests/class/SC_CustomerListTest.php
@@ -42,7 +42,10 @@ class SC_CustomerListTest extends Common_TestCase
         $this->params['search_name'] = $this->expected[0]['name01'];
 
         $this->scenario();
-        $this->assertEquals($this->expected[0]['name01'], $this->actual[0]['name01']);
+        // 部分一致検索のため、他のランダム生成顧客の値に検索語が含まれると
+        // 複数件ヒットし並び順が保証されない。期待する顧客が結果に含まれる
+        // ことを検証する
+        $this->assertContains((string) $this->customer_ids[0], array_map('strval', array_column($this->actual, 'customer_id')));
     }
 
     public function testSearchName02()
@@ -52,7 +55,10 @@ class SC_CustomerListTest extends Common_TestCase
         $this->params['search_name'] = $this->expected[0]['name02'];
 
         $this->scenario();
-        $this->assertEquals($this->expected[0]['name02'], $this->actual[0]['name02']);
+        // 部分一致検索のため、他のランダム生成顧客の値に検索語が含まれると
+        // 複数件ヒットし並び順が保証されない。期待する顧客が結果に含まれる
+        // ことを検証する
+        $this->assertContains((string) $this->customer_ids[0], array_map('strval', array_column($this->actual, 'customer_id')));
     }
 
     public function testSearchKana01()
@@ -62,7 +68,10 @@ class SC_CustomerListTest extends Common_TestCase
         $this->params['search_kana'] = $this->expected[0]['kana01'];
 
         $this->scenario();
-        $this->assertEquals($this->expected[0]['kana01'], $this->actual[0]['kana01']);
+        // 部分一致検索のため、他のランダム生成顧客の値に検索語が含まれると
+        // 複数件ヒットし並び順が保証されない。期待する顧客が結果に含まれる
+        // ことを検証する
+        $this->assertContains((string) $this->customer_ids[0], array_map('strval', array_column($this->actual, 'customer_id')));
     }
 
     public function testSearchKana02()
@@ -72,7 +81,10 @@ class SC_CustomerListTest extends Common_TestCase
         $this->params['search_kana'] = $this->expected[0]['kana02'];
 
         $this->scenario();
-        $this->assertEquals($this->expected[0]['kana02'], $this->actual[0]['kana02']);
+        // 部分一致検索のため、他のランダム生成顧客の値に検索語が含まれると
+        // 複数件ヒットし並び順が保証されない。期待する顧客が結果に含まれる
+        // ことを検証する
+        $this->assertContains((string) $this->customer_ids[0], array_map('strval', array_column($this->actual, 'customer_id')));
     }
 
     public function testSearchPref()


### PR DESCRIPTION
refs #1438

## 概要

`SC_CustomerListTest` の `testSearchName01/02`・`testSearchKana01/02` は、Faker でランダム生成した3人の顧客のうち1人の氏名・カナで**部分一致検索**し、**先頭の結果**がその顧客であることを `assertEquals` で検証しています。

しかし、他のランダム顧客の値に検索語が含まれるケース — 実際に発生した例では「**タナベ**」で検索して「**ワタナベ**」もヒット — では複数件がヒットし、並び順によって偶発的に失敗します。

実際の失敗（PR #1442 の CI、[このジョブ](https://github.com/EC-CUBE/ec-cube2/actions/runs/33067032218)）:

```
1) SC_CustomerListTest::testSearchKana01
Failed asserting that two strings are equal.
--- Expected
+++ Actual
-'タナベ'
+'ワタナベ'
```

## 変更内容

4テストの検証を「期待する顧客（customer_id）が検索結果に含まれること」に変更します。部分一致検索の仕様上、他の顧客が同時にヒットするのは正しい挙動であり、テストの意図（検索語で対象顧客が見つかること）は維持されます。

なお `testSearchPref` / `testSearchSex` など完全一致系の検索は、ヒットした全件が検索値を持つため現状の検証で問題ありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 顧客名・カナ検索の検証を更新しました。
  * 検索結果の先頭要素だけでなく、部分一致した対象顧客が結果に含まれることを確認できるようになりました。
  * 複数の検索パターンに対する検証精度を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->