### PR TITLE
fix: ec-cube コンテナに healthcheck を追加する

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,23 @@ services:
       LOGIN_RATE_LIMIT_IP_THRESHOLD: ${LOGIN_RATE_LIMIT_IP_THRESHOLD:-}
     networks:
       - backend
+    # entrypoint (dockerbuild/wait-for-*.sh) は eccube_install.sh が完了してから
+    # Apache を起動するため、Apache の起動をもって初期化完了を判定できる。
+    # healthcheck が無いと `docker compose up --wait` が初期化完了を待たずに返り、
+    # data/config/config.php が未生成のまま後続処理が走って偶発的に失敗する。
+    #
+    # HTTP リクエストを送るとアプリケーションが動作して data/cache 配下などに
+    # コンテナ側ユーザー所有のファイルが生成され、ホスト側の chmod が失敗する
+    # (インストーラの E2E テスト) ため、PID ファイルの有無のみを確認する。
+    # パスは Dockerfile の APACHE_RUN_DIR に対応する。
+    healthcheck:
+      test: test -f /var/run/apache2/apache2.pid
+      interval: 3s
+      timeout: 10s
+      retries: 20
+      # 初回起動時の eccube_install.sh は CI ランナーの負荷によっては数分かかるため、
+      # その間はヘルスチェックの失敗をカウントしない
+      start_period: 300s
 
   ### Mailcatcher ##################################
   mailcatcher:


### PR DESCRIPTION
refs #1438

## 概要

`ec-cube` サービスに healthcheck を追加し、`docker compose up -d --wait` が初期化完了まで待つようにします。

## 背景

`ec-cube` サービスには healthcheck が定義されておらず、`--wait` はコンテナが running になった時点 (約 0.5 秒) で完了していました。

一方 entrypoint (`dockerbuild/wait-for-{pgsql,mysql,sqlite3}.sh`) は `data/config/config.php` が無い場合に `eccube_install.sh` を実行し、`config.php` の生成は**その最終盤** (DB 構築・データ投入・画像コピーの後、`eccube_install.sh:326`) で行われます。

このため `config.php` が未生成のまま後続ステップが走ることがあります。

### 実際に発生した例 (PHPStan)

同一コミット `64e89e94` に対する 2 つの run で結果が割れています。

| event | run | PHPStan |
|---|---|---|
| pull_request | [33340662923](https://github.com/EC-CUBE/ec-cube2/actions/runs/33340662923) | **失敗** (26件) |
| push | [33340661875](https://github.com/EC-CUBE/ec-cube2/actions/runs/33340661875) | 成功 |

失敗時のエラーはすべて `Constant XXX not found.` で、PR の変更と無関係なファイル (`SC_Query.php`, `SC_Cookie.php`, `LC_Page_Admin.php`, `SC_Utils.php` 等) で発生していました。

`config.php` が無いと `SC_Initial::requireInitialConfig()` はフォールバック分岐に落ちますが、その中身は `if (!defined('HTTP_URL'))` でガードされています。PHPStan の bootstrap である `tests/require.php` が先に `HTTP_URL` / `HTTPS_URL` / `ROOT_URLPATH` / `ADMIN_DIR` を定義済みのため、**フォールバックブロック全体がスキップ**され、残りの `DB_TYPE` / `AUTH_MAGIC` / `MAIL_BACKEND` / `SMTP_HOST` などが未定義になります。エラーになった定数の集合は、まさにこのブロックから上記 4 つを除いたものと一致します。

なお `unit-tests.yml` / `e2e-tests.yml` には `config.php` の生成を待つループが既にありますが、`phpstan.yml` には無いため今回顕在化しました。healthcheck を入れることで `--wait` 自体が正しく待つようになり、他ジョブの偶発的失敗の軽減も期待できます。

## 実装

`wait-for-*.sh` はいずれも `eccube_install.sh` の完了後に `exec docker-php-entrypoint apache2-foreground` するため、**Apache の PID ファイルの有無**で初期化完了を判定できます。

HTTP リクエストを送る方式も検討しましたが、アプリケーションが動作して `data/cache/mtb_constants.php` などがコンテナ側ユーザー (www-data) 所有で生成され、インストーラ E2E テストの `chmod -R o+w data/cache` が失敗するため採用していません (ローカルで実際に発生を確認)。

## 動作確認

すべてローカル (WSL2 / `ghcr.io/ec-cube/ec-cube2-php:8.5-apache`) で実施。

| 検証 | 結果 |
|---|---|
| pgsql `up --wait` | 16秒で healthy、直後に `config.php` 存在 |
| pgsql `up --wait` (**変更前**) | 10.9秒で復帰、`config.php` 未生成 = レースの窓を確認 |
| mysql `up --wait` → PHPStan | `[OK] No errors` |
| sqlite3 `up --wait` | healthy 後に `config.php` 存在 |
| healthcheck による bind mount への副作用 | `data/cache` は `.gitkeep` のみ = 無し |
| インストーラ E2E 相当の `chmod -R o+w` チェーン | 成功 |
| `npm run test:e2e -- e2e-tests/test/installer/installer.test.ts` (pgsql) | **11 passed** |
| `phpunit --exclude-group classloader,mysql_prepare` (mysql) | **1787 tests / 0 failures** |
| PHPStan (コンテナ内・CI と同一コマンド) | `[OK] No errors` |

未実施: `test/admin` / `test/front_guest` / `test/front_login` の E2E (compose の healthcheck 追加のみでアプリの挙動は変わらないため、CI に委ねます)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Docker 環境でサービスの初期化状態を自動的に確認できるようになりました。
  * `docker compose up --wait` を使用すると、サービスが利用可能になるまで待機できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->