### PR TITLE
CI: sqlite3 リストア後の起動を up -d --wait にして無反応な start に対処する

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -193,12 +193,21 @@ jobs:
             docker compose stop -t 5 ec-cube
             sudo cp data/eccube_snapshot.db data/eccube.db
             sudo rm -f data/eccube.db-wal data/eccube.db-shm
-            docker compose start ec-cube
+            # CI ランナーでは stop 直後の `docker compose start` が何も起動しないまま
+            # 正常終了することがある（コンテナは stopped のまま）。冪等で
+            # ヘルスチェック完了まで待つ `up -d --wait` を使用する
+            if ! docker compose up -d --wait ec-cube; then
+              docker compose ps -a ec-cube
+              docker compose logs --tail 50 ec-cube
+              exit 1
+            fi
             tries=0
             until curl -sf -k --connect-timeout 5 --max-time 10 https://localhost:4430/ -o /dev/null; do
               tries=$((tries+1))
               if [ "$tries" -ge 60 ]; then
                 echo "ec-cube did not come back up" >&2
+                docker compose ps -a ec-cube
+                docker compose logs --tail 50 ec-cube
                 exit 1
               fi
               sleep 1
@@ -240,12 +249,21 @@ jobs:
             docker compose stop -t 5 ec-cube
             sudo cp data/eccube_snapshot.db data/eccube.db
             sudo rm -f data/eccube.db-wal data/eccube.db-shm
-            docker compose start ec-cube
+            # CI ランナーでは stop 直後の `docker compose start` が何も起動しないまま
+            # 正常終了することがある（コンテナは stopped のまま）。冪等で
+            # ヘルスチェック完了まで待つ `up -d --wait` を使用する
+            if ! docker compose up -d --wait ec-cube; then
+              docker compose ps -a ec-cube
+              docker compose logs --tail 50 ec-cube
+              exit 1
+            fi
             tries=0
             until curl -sf -k --connect-timeout 5 --max-time 10 https://localhost:4430/ -o /dev/null; do
               tries=$((tries+1))
               if [ "$tries" -ge 60 ]; then
                 echo "ec-cube did not come back up" >&2
+                docker compose ps -a ec-cube
+                docker compose logs --tail 50 ec-cube
                 exit 1
               fi
               sleep 1


### PR DESCRIPTION
refs #1438 / #1442 のフォローアップ

## 問題

CI ランナーで `docker compose stop` 直後の `docker compose start` が **`Starting` を出力せず何も起動しないまま exit 0** し、後続の起動待ちがタイムアウトする事象が複数 run で発生しています。

- [master の run](https://github.com/EC-CUBE/ec-cube2/actions/runs/33475411113): 2回目のリストアで `Stopping → Stopped →（60秒無応答）→ ec-cube did not come back up`、直後の `docker compose exec` は `service "ec-cube" is not running`
- [PR #1443 の run](https://github.com/EC-CUBE/ec-cube2/actions/runs/33489811206): 1回目のリストアで同一の症状

同一ジョブ内で成功するリストアでは `Stopping → Stopped → Starting → Started` が正しく記録されており、ローカルで stop→cp→start を10回反復しても再現しないため、負荷の高いランナー上の Docker デーモンのレースと考えられます。

## 修正

- `docker compose start` を、冪等でヘルスチェック（#1444 の PID ファイル確認）完了まで待つ **`docker compose up -d --wait ec-cube`** に置き換え
- `up --wait` 失敗時と HTTPS 起動待ちタイムアウト時に `docker compose ps -a` とコンテナログを出力し、再発時に診断できるようにする

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - データ復元後のサービス起動処理を改善し、起動完了とヘルスチェックを確実に待機するようにしました。
  - 起動やヘルスチェックに失敗した場合、診断に必要な情報を自動出力するようになりました。
  - 復元後の環境が安定して利用可能になるまでの信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->