### PR TITLE
test: AUTH_TYPE=PLAIN のテストを分離プロセスで実行し通常の phpunit 実行で通るようにする

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -85,7 +85,7 @@ jobs:
         cat data/config/config.php
         docker compose exec -T ec-cube composer dumpautoload
     - name: Run to PHPUnit
-      run: docker compose exec -T ec-cube php data/vendor/bin/phpunit --exclude-group classloader,mysql_prepare,auth_type_plain
+      run: docker compose exec -T ec-cube php data/vendor/bin/phpunit --exclude-group classloader,mysql_prepare
     - name: Run to PHPUnit classloader
       run: docker compose exec -T ec-cube php data/vendor/bin/phpunit --group classloader
     - name: Run to PHPUnit mysql_prepare
@@ -93,9 +93,6 @@ jobs:
       run: docker compose exec -T ec-cube php data/vendor/bin/phpunit --group mysql_prepare
     - name: Run to PHPUnit SessionFactory
       run: docker compose exec -T ec-cube php data/vendor/bin/phpunit tests/class/SC_SessionFactoryTest.php
-    - name: Run to PHPUnit AUTH_TYPE=PLAIN
-      # AUTH_TYPE は定数のためまとめて実行できない. PLAIN用のbootstrapで個別に実行する
-      run: docker compose exec -T ec-cube php data/vendor/bin/phpunit --no-configuration --bootstrap tests/require_auth_type_plain.php --group auth_type_plain tests/class/util/SC_Utils/
     - name: Run to Email-template compatibility tests
       # 2.17.2-p2 のメールテンプレートで正常にテストが通るかチェックする
       run: |

--- a/tests/class/util/SC_Utils/SC_Utils_AuthTypePlain_TestBase.php
+++ b/tests/class/util/SC_Utils/SC_Utils_AuthTypePlain_TestBase.php
@@ -1,0 +1,70 @@
+<?php
+
+$HOME = realpath(__DIR__).'/../../../..';
+require_once $HOME.'/tests/class/Common_TestCase.php';
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+/**
+ * AUTH_TYPE = PLAIN 前提のテストの基底クラス.
+ *
+ * AUTH_TYPE は定数のため, bootstrap (tests/require.php) で HMAC に定義された後は変更できない.
+ * そのためサブクラスには `@runTestsInSeparateProcesses` と `@preserveGlobalState disabled` を付与し,
+ * テストメソッドごとに子プロセスを起動する (クラスアノテーションは継承されないため各サブクラスに記述が必要).
+ *
+ * 子プロセスは親プロセスの環境変数を引き継ぐため, setUpBeforeClass() で設定した
+ * ECCUBE_TEST_AUTH_TYPE=PLAIN を bootstrap が読み取り, AUTH_TYPE = PLAIN として定義する.
+ * (`@preserveGlobalState disabled` が無いと親プロセスの定数 (AUTH_TYPE = HMAC) が子プロセスに複製される)
+ *
+ * @see tests/require.php
+ */
+abstract class SC_Utils_AuthTypePlain_TestBase extends Common_TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        putenv('ECCUBE_TEST_AUTH_TYPE=PLAIN');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        putenv('ECCUBE_TEST_AUTH_TYPE');
+        parent::tearDownAfterClass();
+    }
+
+    protected function setUp(): void
+    {
+        // DB は使用しないため parent::setUp() は呼ばない.
+        // アノテーション漏れ等で AUTH_TYPE が切り替わっていない場合はここで検出する.
+        $this->assertSame(
+            'PLAIN',
+            AUTH_TYPE,
+            'AUTH_TYPE が PLAIN として定義されていません. '
+            .'テストクラスに @runTestsInSeparateProcesses と @preserveGlobalState disabled が付与されているか確認してください.'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        // parent::setUp() を呼んでいないため parent::tearDown() も呼ばない
+    }
+}

--- a/tests/class/util/SC_Utils/SC_Utils_sfGetHashString_authTypePlainTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfGetHashString_authTypePlainTest.php
@@ -1,9 +1,7 @@
 <?php
 
 $HOME = realpath(__DIR__).'/../../../..';
-// このテスト専用の定数の設定
-defined('AUTH_TYPE') || define('AUTH_TYPE', 'PLAIN');
-require_once $HOME.'/tests/class/Common_TestCase.php';
+require_once $HOME.'/tests/class/util/SC_Utils/SC_Utils_AuthTypePlain_TestBase.php';
 /*
  * This file is part of EC-CUBE
  *
@@ -27,39 +25,27 @@ require_once $HOME.'/tests/class/Common_TestCase.php';
  */
 
 /**
- * SC_Utils::sfGetHashString()のテストクラス.
- * TODO まとめて実行する場合は定数の変更ができないためNG
+ * SC_Utils::sfGetHashString()のテストクラス (AUTH_TYPE = PLAIN).
+ *
+ * @see SC_Utils_AuthTypePlain_TestBase
  *
  * @author Hiroko Tamagawa
  *
- * @version $Id$
+ * @group auth_type_plain
+ *
+ * @runTestsInSeparateProcesses
+ *
+ * @preserveGlobalState disabled
  */
-class SC_Utils_sfGetHashString_authTypePlainTest extends Common_TestCase
+class SC_Utils_sfGetHashString_authTypePlainTest extends SC_Utils_AuthTypePlain_TestBase
 {
-    protected function setUp(): void
+    public function testSfGetHashString暗号化なしの設定になっている場合文字列が変換されない()
     {
-        parent::setUp();
-    }
+        $input = 'hello, world';
 
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-    }
+        $this->expected = $input;
+        $this->actual = SC_Utils::sfGetHashString($input);
 
-    // ///////////////////////////////////////
-    // public function testSfGetHashString_暗号化なしの設定になっている場合_文字列が変換されない()
-    // {
-    //     $input = 'hello, world';
-
-    //     $this->expected = $input;
-    //     $this->actual = SC_Utils::sfGetHashString($input);
-
-    //     $this->verify();
-    // }
-
-    public function testDummyTest()
-    {
-        // Warning が出るため空のテストを作成
-        $this->assertTrue(true);
+        $this->verify();
     }
 }

--- a/tests/class/util/SC_Utils/SC_Utils_sfIsMatchHashPassword_authTypePlainTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfIsMatchHashPassword_authTypePlainTest.php
@@ -1,9 +1,7 @@
 <?php
 
 $HOME = realpath(__DIR__).'/../../../..';
-// このテスト専用の定数の設定
-defined('AUTH_TYPE') || define('AUTH_TYPE', 'PLAIN');
-require_once $HOME.'/tests/class/Common_TestCase.php';
+require_once $HOME.'/tests/class/util/SC_Utils/SC_Utils_AuthTypePlain_TestBase.php';
 /*
  * This file is part of EC-CUBE
  *
@@ -28,23 +26,17 @@ require_once $HOME.'/tests/class/Common_TestCase.php';
 
 /**
  * SC_Utils::sfIsMatchHashPassword()のテストクラス (AUTH_TYPE = PLAIN).
- * AUTH_TYPE は定数のためまとめて実行できない. 個別実行が必要:
- * data/vendor/bin/phpunit tests/class/util/SC_Utils/SC_Utils_sfIsMatchHashPassword_authTypePlainTest.php
+ *
+ * @see SC_Utils_AuthTypePlain_TestBase
  *
  * @group auth_type_plain
+ *
+ * @runTestsInSeparateProcesses
+ *
+ * @preserveGlobalState disabled
  */
-class SC_Utils_sfIsMatchHashPassword_authTypePlainTest extends Common_TestCase
+class SC_Utils_sfIsMatchHashPassword_authTypePlainTest extends SC_Utils_AuthTypePlain_TestBase
 {
-    protected function setUp(): void
-    {
-        // parent::setUp();
-    }
-
-    protected function tearDown(): void
-    {
-        // parent::tearDown();
-    }
-
     public function testSfIsMatchHashPassword文字列が一致する場合Trueが返る()
     {
         $pass = 'ec-cube';

--- a/tests/class/util/SC_Utils/SC_Utils_sfNeedsReHash_authTypePlainTest.php
+++ b/tests/class/util/SC_Utils/SC_Utils_sfNeedsReHash_authTypePlainTest.php
@@ -1,9 +1,7 @@
 <?php
 
 $HOME = realpath(__DIR__).'/../../../..';
-// このテスト専用の定数の設定
-defined('AUTH_TYPE') || define('AUTH_TYPE', 'PLAIN');
-require_once $HOME.'/tests/class/Common_TestCase.php';
+require_once $HOME.'/tests/class/util/SC_Utils/SC_Utils_AuthTypePlain_TestBase.php';
 /*
  * This file is part of EC-CUBE
  *
@@ -28,23 +26,17 @@ require_once $HOME.'/tests/class/Common_TestCase.php';
 
 /**
  * SC_Utils::sfNeedsReHash() のテストクラス (AUTH_TYPE = PLAIN).
- * AUTH_TYPE は定数のためまとめて実行できない. 個別実行が必要:
- * data/vendor/bin/phpunit tests/class/util/SC_Utils/SC_Utils_sfNeedsReHash_authTypePlainTest.php
+ *
+ * @see SC_Utils_AuthTypePlain_TestBase
  *
  * @group auth_type_plain
+ *
+ * @runTestsInSeparateProcesses
+ *
+ * @preserveGlobalState disabled
  */
-class SC_Utils_sfNeedsReHash_authTypePlainTest extends Common_TestCase
+class SC_Utils_sfNeedsReHash_authTypePlainTest extends SC_Utils_AuthTypePlain_TestBase
 {
-    protected function setUp(): void
-    {
-        // parent::setUp();
-    }
-
-    protected function tearDown(): void
-    {
-        // parent::tearDown();
-    }
-
     public function testSfNeedsReHashAuthTypePlainの場合常にFalseが返る()
     {
         $hashpass = 'ec-cube';

--- a/tests/require.php
+++ b/tests/require.php
@@ -1,5 +1,13 @@
 <?php
 
+// AUTH_TYPE は定数のため, 一度定義されるとテスト内で切り替えられない.
+// PLAIN 前提のテスト (@group auth_type_plain) は @runTestsInSeparateProcesses で子プロセスを起動し,
+// 環境変数 ECCUBE_TEST_AUTH_TYPE 経由でこの bootstrap の時点で AUTH_TYPE を定義する.
+// see tests/class/util/SC_Utils/SC_Utils_AuthTypePlain_TestBase.php
+if (!defined('AUTH_TYPE') && getenv('ECCUBE_TEST_AUTH_TYPE') !== false) {
+    define('AUTH_TYPE', getenv('ECCUBE_TEST_AUTH_TYPE'));
+}
+
 $loader = require __DIR__.'/../data/vendor/autoload.php';
 
 /* テスト中 */

--- a/tests/require_auth_type_plain.php
+++ b/tests/require_auth_type_plain.php
@@ -1,6 +1,0 @@
-<?php
-
-// AUTH_TYPE = PLAIN 用のテストブートストラップ
-// 標準の require.php より先に AUTH_TYPE を定義することで、PLAIN モードのテストを実行する
-define('AUTH_TYPE', 'PLAIN');
-require __DIR__.'/require.php';


### PR DESCRIPTION
## Summary

#1451 で報告された「`authTypePlainTest` がローカルの通常実行で失敗する」問題を、skip ではなく **通常の `phpunit` 一発で PLAIN テストも通る** 形で解消します。

### 原因

`AUTH_TYPE` は定数のため、`phpunit.xml.dist` の bootstrap (`tests/require.php` → `SC_Initial` → `mtb_constants_init.php`) で `HMAC` に定義された後はテスト内で切り替えられません。テストファイル冒頭の `defined('AUTH_TYPE') || define('AUTH_TYPE', 'PLAIN')` は bootstrap より後に評価されるため効いておらず、`phpunit tests/class/util/SC_Utils/` のような通常実行では必ず失敗していました。

- `unit-tests.yml` では `--exclude-group auth_type_plain` + 専用 bootstrap での個別実行で回避
- `coverage.yml` では除外されておらず、`continue-on-error: true` に隠れて失敗し続けていました (例: master の [run 33832952678](https://github.com/EC-CUBE/ec-cube2/actions/runs/33832952678) で `Failures: 8` 中 3 件が `authTypePlainTest`)

### 修正方針

このテストスイートで既に使われている `@runInSeparateProcess` + `@preserveGlobalState disabled` のパターン (`SC_FpdfTest`, `SC_Helper_TaxRule_getTaxRuleTest` 等) を流用し、**子プロセスの bootstrap 時点で環境変数から `AUTH_TYPE` を定義**します。

## Changes

- `tests/require.php`: 環境変数 `ECCUBE_TEST_AUTH_TYPE` があれば `AUTH_TYPE` を先に定義
- `tests/class/util/SC_Utils/SC_Utils_AuthTypePlain_TestBase.php` (新規): PLAIN テスト共通の基底クラス
  - `setUpBeforeClass()` で `putenv('ECCUBE_TEST_AUTH_TYPE=PLAIN')`、`tearDownAfterClass()` で解除
  - `setUp()` で `AUTH_TYPE === 'PLAIN'` を前提検査し、アノテーション漏れ時は原因を案内するメッセージで失敗させる
- PLAIN テスト 3 クラス: 基底クラスを継承し `@runTestsInSeparateProcesses` / `@preserveGlobalState disabled` を付与
  - PHPUnit 9 の子プロセスは `{constants}` → bootstrap → テストクラス読込の順のため、`@preserveGlobalState disabled` が無いと親の `AUTH_TYPE=HMAC` が複製されます
  - クラスアノテーションは親クラスから継承されない (トレイトと自クラスのみ) ため、各クラスに記述しています
- `SC_Utils_sfGetHashString_authTypePlainTest`: ダミーテストのみだったため、コメントアウトされていた本来のテストを同じ仕組みで復活
- 不要になった `tests/require_auth_type_plain.php` と `unit-tests.yml` の `AUTH_TYPE=PLAIN` 個別実行ステップを削除し、`--exclude-group` から `auth_type_plain` を外す

## Test plan

ローカル (Docker: `ec-cube2-php:8.1-apache` + PostgreSQL 18) で CI と同じ手順を実行:

- [x] `phpunit --exclude-group classloader,mysql_prepare` (PLAIN テスト込み): OK (1812 tests, 0 failures)
- [x] `phpunit --group auth_type_plain --testdox`: 5 tests が skip ではなく実行され OK
- [x] `phpunit --group classloader`: OK (15 tests)
- [x] `phpunit --group mysql_prepare`: OK (11 tests)
- [x] `phpunit tests/class/SC_SessionFactoryTest.php`: OK
- [x] ネガティブ確認: `@preserveGlobalState disabled` または `@runTestsInSeparateProcesses` を外すと前提検査で失敗する
- [x] `tests/class/util/SC_Utils/` 一括実行で PLAIN の後に走る HMAC テストに影響なし (環境変数リークなし)
- [x] php-cs-fixer / PHPStan (level 1): 指摘なし
- [ ] CI (PHP 7.4〜8.5 × MySQL/PostgreSQL/SQLite3、coverage ジョブの phpdbg 経由)

E2E テストはアプリケーションコードに変更がないため未実施です。

Refs #1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - PLAIN認証モードのテストを、専用の実行手順ではなく標準のテスト実行に統合しました。
  - PLAIN認証モードでのハッシュ処理に関する検証を追加・整理しました。
  - テスト実行時の認証モード設定を、環境に応じて適用できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->